### PR TITLE
feat: add pi coding agent as a supported agent provider

### DIFF
--- a/.changeset/add-pi-agent-provider.md
+++ b/.changeset/add-pi-agent-provider.md
@@ -1,0 +1,11 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add pi coding agent as a supported agent provider
+
+- Extended `AgentProvider` interface with `defaultModel`, `buildPrintCommand`, `buildInteractiveArgs`, and `parseStreamLine` methods
+- Added `piProvider` for the [pi coding agent](https://github.com/badlogic/pi-mono)
+- Added `agent` option to `RunOptions` (default: `"claude-code"`)
+- Added `--agent` CLI flag to `init` and `interactive` commands
+- Exported `AgentProvider` type, `getAgentProvider`, `claudeCodeProvider`, and `piProvider` from the public API

--- a/README.md
+++ b/README.md
@@ -93,7 +93,11 @@ const result = await run({
   // Branch the agent commits to inside the sandbox.
   branch: "agent/fix-42",
 
-  // Claude model passed to the agent. Default: "claude-opus-4-6"
+  // Agent provider to use. Default: "claude-code"
+  // Available: "claude-code", "pi"
+  agent: "claude-code",
+
+  // Model passed to the agent. Default depends on agent provider.
   model: "claude-opus-4-6",
 
   // Docker image used for the sandbox. Default: "sandcastle:<repo-dir-name>"
@@ -259,9 +263,10 @@ Select a template during `sandcastle init` when prompted, or re-run init in a fr
 
 Scaffolds the `.sandcastle/` config directory and builds the Docker image. This is the first command you run in a new repo.
 
-| Option         | Required | Default                      | Description       |
-| -------------- | -------- | ---------------------------- | ----------------- |
-| `--image-name` | No       | `sandcastle:<repo-dir-name>` | Docker image name |
+| Option         | Required | Default                      | Description                          |
+| -------------- | -------- | ---------------------------- | ------------------------------------ |
+| `--image-name` | No       | `sandcastle:<repo-dir-name>` | Docker image name                    |
+| `--agent`      | No       | `claude-code`                | Agent provider (`claude-code`, `pi`) |
 
 Creates the following files:
 
@@ -301,7 +306,8 @@ Removes the Docker image.
 | `maxIterations`      | number             | `1`                           | Maximum iterations to run                                                   |
 | `hooks`              | object             | —                             | Lifecycle hooks (`onSandboxReady`)                                          |
 | `branch`             | string             | —                             | Target branch for sandbox work                                              |
-| `model`              | string             | `claude-opus-4-6`             | Model to use for the agent                                                  |
+| `agent`              | string             | `"claude-code"`               | Agent provider (`"claude-code"`, `"pi"`)                                    |
+| `model`              | string             | provider-specific             | Model to use (claude-code: `claude-opus-4-6`, pi: `claude-sonnet-4-6`)      |
 | `imageName`          | string             | `sandcastle:<repo-dir-name>`  | Docker image name for the sandbox                                           |
 | `name`               | string             | —                             | Display name for the run, shown as a prefix in log output                   |
 | `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                        |
@@ -331,20 +337,22 @@ All per-repo sandbox configuration lives in `.sandcastle/`. Run `sandcastle init
 
 ### Custom Dockerfile
 
-The `.sandcastle/Dockerfile` controls the sandbox environment. The default template installs:
+The `.sandcastle/Dockerfile` controls the sandbox environment. The default template depends on the agent provider selected during `sandcastle init --agent`. Each provider installs its own CLI tool.
+
+All templates share:
 
 - **Node.js 22** (base image)
 - **git**, **curl**, **jq** (system dependencies)
 - **GitHub CLI** (`gh`)
-- **Claude Code CLI**
-- A non-root `agent` user (required — Claude runs as this user)
+- The selected agent CLI (Claude Code or pi)
+- A non-root `agent` user (required — the agent runs as this user)
 
 When customizing the Dockerfile, ensure you keep:
 
-- A non-root user (the default `agent` user) for Claude to run as
+- A non-root user (the default `agent` user) for the agent to run as
 - `git` (required for commits and branch operations)
 - `gh` (required for issue fetching)
-- Claude Code CLI installed and on PATH
+- The agent CLI installed and on PATH
 
 Add your project-specific dependencies (e.g., language runtimes, build tools) to the Dockerfile as needed.
 

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -7,7 +7,7 @@
 | **Sandcastle** | The TypeScript CLI tool that orchestrates AI coding agents inside isolated environments                                       | "the tool", "the CLI", "RALPH"                                                          |
 | **Sandbox**    | An isolated environment where an agent executes code — a Docker container with the **worktree** bind-mounted as the workspace | "container" (too specific), "Docker sandbox" (ambiguous with Claude's built-in feature) |
 | **Host**       | The developer's machine where Sandcastle runs and the real git repo lives                                                     | "local" (ambiguous — the sandbox also has a local filesystem)                           |
-| **Agent**      | The AI coding tool invoked inside the sandbox (e.g. Claude Code, Codex)                                                       | "RALPH", "the bot", "Claude" (too specific — agent is swappable)                        |
+| **Agent**      | The AI coding tool invoked inside the sandbox (e.g. Claude Code, pi, Codex)                                                   | "RALPH", "the bot", "Claude" (too specific — agent is swappable)                        |
 
 ## Environment
 
@@ -52,10 +52,11 @@
 
 ## Architecture
 
-| Term                | Definition                                                                                                                                                                      | Aliases to avoid       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| **Sandbox service** | The Effect service interface exposing `exec`, `copyIn`, and `copyOut` operations against a sandbox                                                                              | "adapter", "transport" |
-| **Worktree**        | A git worktree created in `.sandcastle/worktrees/` on the **host**, bind-mounted into the **sandbox** container as the agent's working directory — eliminates the need for sync | "branch copy", "clone" |
+| Term                | Definition                                                                                                                                                                                                                              | Aliases to avoid                |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| **Agent provider**  | A named bundle of agent-specific behavior: Dockerfile template, env manifest, default model, CLI command construction, and stream output parsing. Each provider is registered in the agent registry and selected via the `agent` option | "agent adapter", "agent driver" |
+| **Sandbox service** | The Effect service interface exposing `exec`, `copyIn`, and `copyOut` operations against a sandbox                                                                                                                                      | "adapter", "transport"          |
+| **Worktree**        | A git worktree created in `.sandcastle/worktrees/` on the **host**, bind-mounted into the **sandbox** container as the agent's working directory — eliminates the need for sync                                                         | "branch copy", "clone"          |
 
 ## Relationships
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ai-hero/sandcastle",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ai-hero/sandcastle",
-      "version": "0.1.5",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { claudeCodeProvider, getAgentProvider } from "./AgentProvider.js";
+import {
+  claudeCodeProvider,
+  piProvider,
+  getAgentProvider,
+  parseClaudeStreamLine,
+  parsePiStreamLine,
+} from "./AgentProvider.js";
 
 describe("claudeCodeProvider", () => {
   it("has name 'claude-code'", () => {
@@ -18,6 +24,109 @@ describe("claudeCodeProvider", () => {
     expect(claudeCodeProvider.dockerfileTemplate).toContain("FROM");
     expect(claudeCodeProvider.dockerfileTemplate).toContain("claude");
   });
+
+  it("has a default model", () => {
+    expect(claudeCodeProvider.defaultModel).toBe("claude-opus-4-6");
+  });
+
+  it("builds a print command with claude CLI flags", () => {
+    const cmd = claudeCodeProvider.buildPrintCommand({
+      model: "claude-sonnet-4-6",
+      prompt: "Hello world",
+    });
+    expect(cmd).toContain("claude");
+    expect(cmd).toContain("--print");
+    expect(cmd).toContain("--output-format stream-json");
+    expect(cmd).toContain("claude-sonnet-4-6");
+    expect(cmd).toContain("Hello world");
+  });
+
+  it("shell-escapes model and prompt in print command", () => {
+    const cmd = claudeCodeProvider.buildPrintCommand({
+      model: "my'model",
+      prompt: "Fix the user's code",
+    });
+    expect(cmd).toContain("my'\\''model");
+    expect(cmd).toContain("user'\\''s");
+  });
+
+  it("builds interactive args for claude", () => {
+    const args = claudeCodeProvider.buildInteractiveArgs({
+      model: "claude-sonnet-4-6",
+    });
+    expect(args[0]).toBe("claude");
+    expect(args).toContain("--dangerously-skip-permissions");
+    expect(args).toContain("claude-sonnet-4-6");
+  });
+
+  it("parseStreamLine delegates to parseClaudeStreamLine", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "Hello" }] },
+    });
+    expect(claudeCodeProvider.parseStreamLine(line)).toEqual(
+      parseClaudeStreamLine(line),
+    );
+  });
+});
+
+describe("piProvider", () => {
+  it("has name 'pi'", () => {
+    expect(piProvider.name).toBe("pi");
+  });
+
+  it("envManifest contains ANTHROPIC_API_KEY and GH_TOKEN", () => {
+    expect(piProvider.envManifest).toHaveProperty("ANTHROPIC_API_KEY");
+    expect(piProvider.envManifest).toHaveProperty("GH_TOKEN");
+  });
+
+  it("has a non-empty dockerfileTemplate that installs pi", () => {
+    expect(piProvider.dockerfileTemplate).toContain("FROM");
+    expect(piProvider.dockerfileTemplate).toContain("pi-coding-agent");
+  });
+
+  it("has a default model", () => {
+    expect(piProvider.defaultModel).toBe("claude-sonnet-4-6");
+  });
+
+  it("builds a print command with pi CLI flags", () => {
+    const cmd = piProvider.buildPrintCommand({
+      model: "claude-sonnet-4-6",
+      prompt: "Hello world",
+    });
+    expect(cmd).toContain("pi");
+    expect(cmd).toContain("-p");
+    expect(cmd).toContain("--mode json");
+    expect(cmd).toContain("--no-session");
+    expect(cmd).toContain("'claude-sonnet-4-6'");
+    expect(cmd).toContain("'Hello world'");
+  });
+
+  it("shell-escapes single quotes in prompts and model", () => {
+    const cmd = piProvider.buildPrintCommand({
+      model: "my'model",
+      prompt: "Fix the user's code",
+    });
+    expect(cmd).toContain("my'\\''model");
+    expect(cmd).toContain("user'\\''s");
+  });
+
+  it("builds interactive args for pi", () => {
+    const args = piProvider.buildInteractiveArgs({
+      model: "claude-sonnet-4-6",
+    });
+    expect(args[0]).toBe("pi");
+    expect(args).toContain("--model");
+    expect(args).toContain("claude-sonnet-4-6");
+  });
+
+  it("parseStreamLine delegates to parsePiStreamLine", () => {
+    const line = JSON.stringify({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Hello" },
+    });
+    expect(piProvider.parseStreamLine(line)).toEqual(parsePiStreamLine(line));
+  });
 });
 
 describe("getAgentProvider", () => {
@@ -26,7 +135,410 @@ describe("getAgentProvider", () => {
     expect(provider.name).toBe("claude-code");
   });
 
+  it("returns pi provider for 'pi'", () => {
+    const provider = getAgentProvider("pi");
+    expect(provider.name).toBe("pi");
+  });
+
   it("throws for unknown agent name", () => {
     expect(() => getAgentProvider("unknown-agent")).toThrow(/unknown-agent/);
+  });
+});
+
+describe("parseClaudeStreamLine", () => {
+  it("extracts text from assistant message", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "Hello world" }] },
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([
+      { type: "text", text: "Hello world" },
+    ]);
+  });
+
+  it("extracts result from result message", () => {
+    const line = JSON.stringify({
+      type: "result",
+      result: "Final answer <promise>COMPLETE</promise>",
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([
+      {
+        type: "result",
+        result: "Final answer <promise>COMPLETE</promise>",
+        usage: null,
+      },
+    ]);
+  });
+
+  it("returns empty array for non-JSON lines", () => {
+    expect(parseClaudeStreamLine("not json")).toEqual([]);
+    expect(parseClaudeStreamLine("")).toEqual([]);
+  });
+
+  it("returns empty array for malformed JSON starting with {", () => {
+    expect(parseClaudeStreamLine("{bad json")).toEqual([]);
+    expect(parseClaudeStreamLine('{"type": "assistant", broken')).toEqual([]);
+  });
+
+  it("returns empty array for unrecognized JSON types", () => {
+    const line = JSON.stringify({ type: "system", data: "something" });
+    expect(parseClaudeStreamLine(line)).toEqual([]);
+  });
+
+  it("handles multiple text content blocks", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Hello " },
+          { type: "text", text: "world" },
+        ],
+      },
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([
+      { type: "text", text: "Hello world" },
+    ]);
+  });
+
+  it("skips malformed tool_use blocks (no name/input)", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "tool_use", id: "123" },
+          { type: "text", text: "result" },
+        ],
+      },
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([
+      { type: "text", text: "result" },
+    ]);
+  });
+
+  it("extracts tool_use block from assistant event (Bash → command arg)", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "tool_use", name: "Bash", input: { command: "npm test" } },
+        ],
+      },
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([
+      { type: "tool_call", name: "Bash", args: "npm test" },
+    ]);
+  });
+
+  it("handles mixed text and tool_use content blocks", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Running tests..." },
+          { type: "tool_use", name: "Bash", input: { command: "npm test" } },
+        ],
+      },
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([
+      { type: "text", text: "Running tests..." },
+      { type: "tool_call", name: "Bash", args: "npm test" },
+    ]);
+  });
+
+  it("handles multiple tool_use blocks in one event", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "tool_use", name: "Bash", input: { command: "npm test" } },
+          {
+            type: "tool_use",
+            name: "WebSearch",
+            input: { query: "typescript types" },
+          },
+        ],
+      },
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([
+      { type: "tool_call", name: "Bash", args: "npm test" },
+      { type: "tool_call", name: "WebSearch", args: "typescript types" },
+    ]);
+  });
+
+  it("extracts WebFetch tool_use with url arg", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            name: "WebFetch",
+            input: { url: "https://example.com" },
+          },
+        ],
+      },
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([
+      { type: "tool_call", name: "WebFetch", args: "https://example.com" },
+    ]);
+  });
+
+  it("extracts Agent tool_use with description arg", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            name: "Agent",
+            input: { description: "Run tests and report results" },
+          },
+        ],
+      },
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([
+      {
+        type: "tool_call",
+        name: "Agent",
+        args: "Run tests and report results",
+      },
+    ]);
+  });
+
+  it("filters out non-allowlisted tools (Read, Glob, Grep, Edit, Write)", () => {
+    for (const name of ["Read", "Glob", "Grep", "Edit", "Write"]) {
+      const line = JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", name, input: { file_path: "/some/file" } },
+          ],
+        },
+      });
+      expect(parseClaudeStreamLine(line)).toEqual([]);
+    }
+  });
+
+  it("filters out tool_use blocks with missing expected input field", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          // Bash with no `command` field
+          { type: "tool_use", name: "Bash", input: { other: "value" } },
+        ],
+      },
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([]);
+  });
+
+  it("keeps text events even when all tool_use blocks are filtered out", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Looking at files..." },
+          { type: "tool_use", name: "Read", input: { file_path: "/foo" } },
+        ],
+      },
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([
+      { type: "text", text: "Looking at files..." },
+    ]);
+  });
+
+  it("returns only text when event has no tool_use blocks", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "Just text, no tools" }],
+      },
+    });
+    expect(parseClaudeStreamLine(line)).toEqual([
+      { type: "text", text: "Just text, no tools" },
+    ]);
+  });
+
+  it("extracts usage data from result message", () => {
+    const line = JSON.stringify({
+      type: "result",
+      result: "Done.",
+      total_cost_usd: 0.14,
+      num_turns: 3,
+      duration_ms: 12000,
+      usage: {
+        input_tokens: 52340,
+        output_tokens: 3201,
+        cache_read_input_tokens: 10000,
+        cache_creation_input_tokens: 5000,
+      },
+    });
+    const parsed = parseClaudeStreamLine(line);
+    expect(parsed).toEqual([
+      {
+        type: "result",
+        result: "Done.",
+        usage: {
+          input_tokens: 52340,
+          output_tokens: 3201,
+          cache_read_input_tokens: 10000,
+          cache_creation_input_tokens: 5000,
+          total_cost_usd: 0.14,
+          num_turns: 3,
+          duration_ms: 12000,
+        },
+      },
+    ]);
+  });
+
+  it("returns null usage when result message has no usage data", () => {
+    const line = JSON.stringify({
+      type: "result",
+      result: "Done.",
+    });
+    const parsed = parseClaudeStreamLine(line);
+    expect(parsed).toEqual([
+      {
+        type: "result",
+        result: "Done.",
+        usage: null,
+      },
+    ]);
+  });
+
+  it("returns null usage when usage fields are partial", () => {
+    const line = JSON.stringify({
+      type: "result",
+      result: "Done.",
+      usage: { input_tokens: 100 },
+    });
+    const parsed = parseClaudeStreamLine(line);
+    expect(parsed).toEqual([
+      {
+        type: "result",
+        result: "Done.",
+        usage: null,
+      },
+    ]);
+  });
+});
+
+describe("parsePiStreamLine", () => {
+  it("extracts text from message_update with text_delta", () => {
+    const line = JSON.stringify({
+      type: "message_update",
+      message: {},
+      assistantMessageEvent: { type: "text_delta", delta: "Hello world" },
+    });
+    expect(parsePiStreamLine(line)).toEqual([
+      { type: "text", text: "Hello world" },
+    ]);
+  });
+
+  it("extracts bash tool call from tool_execution_start", () => {
+    const line = JSON.stringify({
+      type: "tool_execution_start",
+      toolCallId: "call_123",
+      toolName: "bash",
+      args: { command: "npm test" },
+    });
+    expect(parsePiStreamLine(line)).toEqual([
+      { type: "tool_call", name: "Bash", args: "npm test" },
+    ]);
+  });
+
+  it("extracts result from agent_end event", () => {
+    const line = JSON.stringify({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "All done." }],
+        },
+      ],
+    });
+    expect(parsePiStreamLine(line)).toEqual([
+      { type: "result", result: "All done.", usage: null },
+    ]);
+  });
+
+  it("extracts result from last assistant message in agent_end", () => {
+    const line = JSON.stringify({
+      type: "agent_end",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Do something" }] },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "First reply" }],
+        },
+        { role: "user", content: [{ type: "text", text: "And more" }] },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Final reply" }],
+        },
+      ],
+    });
+    expect(parsePiStreamLine(line)).toEqual([
+      { type: "result", result: "Final reply", usage: null },
+    ]);
+  });
+
+  it("returns empty array for non-JSON lines", () => {
+    expect(parsePiStreamLine("not json")).toEqual([]);
+    expect(parsePiStreamLine("")).toEqual([]);
+  });
+
+  it("returns empty array for unrecognized event types", () => {
+    const line = JSON.stringify({ type: "turn_start" });
+    expect(parsePiStreamLine(line)).toEqual([]);
+  });
+
+  it("returns empty array for message_update without text_delta", () => {
+    const line = JSON.stringify({
+      type: "message_update",
+      message: {},
+      assistantMessageEvent: { type: "thinking_delta", delta: "..." },
+    });
+    expect(parsePiStreamLine(line)).toEqual([]);
+  });
+
+  it("filters out non-allowlisted tool calls", () => {
+    const line = JSON.stringify({
+      type: "tool_execution_start",
+      toolCallId: "call_456",
+      toolName: "read",
+      args: { path: "/some/file" },
+    });
+    expect(parsePiStreamLine(line)).toEqual([]);
+  });
+
+  it("handles agent_end with no assistant messages", () => {
+    const line = JSON.stringify({
+      type: "agent_end",
+      messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+    });
+    expect(parsePiStreamLine(line)).toEqual([]);
+  });
+
+  it("concatenates multiple text blocks in agent_end assistant message", () => {
+    const line = JSON.stringify({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Part 1. " },
+            { type: "text", text: "Part 2." },
+          ],
+        },
+      ],
+    });
+    expect(parsePiStreamLine(line)).toEqual([
+      { type: "result", result: "Part 1. Part 2.", usage: null },
+    ]);
+  });
+
+  it("handles malformed JSON gracefully", () => {
+    expect(parsePiStreamLine("{bad json")).toEqual([]);
   });
 });

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -1,10 +1,64 @@
 import { SANDBOX_WORKSPACE_DIR } from "./SandboxFactory.js";
 
+// ---------------------------------------------------------------------------
+// Shared types used by providers and the orchestrator
+// ---------------------------------------------------------------------------
+
+export interface TokenUsage {
+  readonly input_tokens: number;
+  readonly output_tokens: number;
+  readonly cache_read_input_tokens: number;
+  readonly cache_creation_input_tokens: number;
+  readonly total_cost_usd: number;
+  readonly num_turns: number;
+  readonly duration_ms: number;
+}
+
+export type ParsedStreamEvent =
+  | { type: "text"; text: string }
+  | { type: "result"; result: string; usage: TokenUsage | null }
+  | { type: "tool_call"; name: string; args: string };
+
+// ---------------------------------------------------------------------------
+// AgentProvider interface
+// ---------------------------------------------------------------------------
+
 export interface AgentProvider {
   readonly name: string;
   readonly envManifest: Record<string, string>;
   readonly dockerfileTemplate: string;
+  readonly defaultModel: string;
+
+  /**
+   * Build the shell command for a non-interactive (print) agent invocation
+   * inside the sandbox.
+   */
+  readonly buildPrintCommand: (opts: {
+    model: string;
+    prompt: string;
+  }) => string;
+
+  /**
+   * Build the CLI arguments for an interactive agent session.
+   * These are passed to `docker exec -it <container> <...args>`.
+   */
+  readonly buildInteractiveArgs: (opts: { model: string }) => string[];
+
+  /**
+   * Parse a single line of streaming output from the agent into display events.
+   */
+  readonly parseStreamLine: (line: string) => ParsedStreamEvent[];
 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const shellEscape = (s: string): string => "'" + s.replace(/'/g, "'\\''") + "'";
+
+// ---------------------------------------------------------------------------
+// Claude Code provider
+// ---------------------------------------------------------------------------
 
 const CLAUDE_CODE_DOCKERFILE = `FROM node:22-bookworm
 
@@ -23,7 +77,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \\
   && apt-get update && apt-get install -y gh \\
   && rm -rf /var/lib/apt/lists/*
 
-# Create a non-root user for Claude to run as
+# Create a non-root user for the agent to run as
 RUN useradd -m -s /bin/bash agent
 USER agent
 
@@ -41,8 +95,100 @@ WORKDIR /home/agent
 ENTRYPOINT ["sleep", "infinity"]
 `;
 
+/** Maps allowlisted tool names to the input field containing the display arg */
+const CLAUDE_TOOL_ARG_FIELDS: Record<string, string> = {
+  Bash: "command",
+  WebSearch: "query",
+  WebFetch: "url",
+  Agent: "description",
+};
+
+const extractClaudeUsage = (
+  obj: Record<string, unknown>,
+): TokenUsage | null => {
+  const usage = obj.usage as Record<string, unknown> | undefined;
+  if (
+    !usage ||
+    typeof usage.input_tokens !== "number" ||
+    typeof usage.output_tokens !== "number"
+  ) {
+    return null;
+  }
+  return {
+    input_tokens: usage.input_tokens,
+    output_tokens: usage.output_tokens,
+    cache_read_input_tokens:
+      typeof usage.cache_read_input_tokens === "number"
+        ? usage.cache_read_input_tokens
+        : 0,
+    cache_creation_input_tokens:
+      typeof usage.cache_creation_input_tokens === "number"
+        ? usage.cache_creation_input_tokens
+        : 0,
+    total_cost_usd:
+      typeof obj.total_cost_usd === "number" ? obj.total_cost_usd : 0,
+    num_turns: typeof obj.num_turns === "number" ? obj.num_turns : 0,
+    duration_ms: typeof obj.duration_ms === "number" ? obj.duration_ms : 0,
+  };
+};
+
+/**
+ * Parse a line of Claude Code's `stream-json` output format into display events.
+ */
+export const parseClaudeStreamLine = (line: string): ParsedStreamEvent[] => {
+  if (!line.startsWith("{")) return [];
+  try {
+    const obj = JSON.parse(line);
+    if (obj.type === "assistant" && Array.isArray(obj.message?.content)) {
+      const events: ParsedStreamEvent[] = [];
+      const texts: string[] = [];
+      for (const block of obj.message.content as {
+        type: string;
+        text?: string;
+        name?: string;
+        input?: Record<string, unknown>;
+      }[]) {
+        if (block.type === "text" && typeof block.text === "string") {
+          texts.push(block.text);
+        } else if (
+          block.type === "tool_use" &&
+          typeof block.name === "string" &&
+          block.input !== undefined
+        ) {
+          const argField = CLAUDE_TOOL_ARG_FIELDS[block.name];
+          if (argField === undefined) continue; // not allowlisted
+          const argValue = block.input[argField];
+          if (typeof argValue !== "string") continue; // missing/wrong arg field
+          if (texts.length > 0) {
+            events.push({ type: "text", text: texts.join("") });
+            texts.length = 0;
+          }
+          events.push({
+            type: "tool_call",
+            name: block.name,
+            args: argValue,
+          });
+        }
+      }
+      if (texts.length > 0) {
+        events.push({ type: "text", text: texts.join("") });
+      }
+      return events;
+    }
+    if (obj.type === "result" && typeof obj.result === "string") {
+      return [
+        { type: "result", result: obj.result, usage: extractClaudeUsage(obj) },
+      ];
+    }
+  } catch {
+    // Not valid JSON — skip
+  }
+  return [];
+};
+
 export const claudeCodeProvider: AgentProvider = {
   name: "claude-code",
+  defaultModel: "claude-opus-4-6",
 
   envManifest: {
     ANTHROPIC_API_KEY: "Anthropic API key",
@@ -50,10 +196,172 @@ export const claudeCodeProvider: AgentProvider = {
   },
 
   dockerfileTemplate: CLAUDE_CODE_DOCKERFILE,
+
+  buildPrintCommand: ({ model, prompt }) =>
+    `claude --print --verbose --dangerously-skip-permissions --output-format stream-json --model ${shellEscape(model)} -p ${shellEscape(prompt)}`,
+
+  buildInteractiveArgs: ({ model }) => [
+    "claude",
+    "--dangerously-skip-permissions",
+    "--model",
+    model, // Interactive args are passed as array elements — no shell escaping needed
+  ],
+
+  parseStreamLine: parseClaudeStreamLine,
 };
+
+// ---------------------------------------------------------------------------
+// Pi provider
+// ---------------------------------------------------------------------------
+
+const PI_DOCKERFILE = `FROM node:22-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \\
+  git \\
+  curl \\
+  jq \\
+  && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \\
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \\
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \\
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \\
+  && apt-get update && apt-get install -y gh \\
+  && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user for the agent to run as
+RUN useradd -m -s /bin/bash agent
+USER agent
+
+# Configure npm global prefix for non-root installs
+ENV NPM_CONFIG_PREFIX=/home/agent/.npm-global
+ENV PATH="/home/agent/.npm-global/bin:$PATH"
+
+# Install pi coding agent
+RUN npm install -g @mariozechner/pi-coding-agent
+
+WORKDIR /home/agent
+
+# In worktree sandbox mode, Sandcastle bind-mounts the git worktree at ${SANDBOX_WORKSPACE_DIR}
+# and overrides the working directory to ${SANDBOX_WORKSPACE_DIR} at container start.
+# Structure your Dockerfile so that ${SANDBOX_WORKSPACE_DIR} can serve as the project root.
+ENTRYPOINT ["sleep", "infinity"]
+`;
+
+/**
+ * Maps pi tool names to display name + arg field.
+ * Pi uses lowercase names for built-in tools (e.g. "bash", "read", "edit").
+ *
+ * Currently only bash is allowlisted — other tools (read, edit, grep) are
+ * filtered out to match Claude Code's display behavior. Expand this map
+ * as pi's JSON event schema stabilizes.
+ */
+const PI_TOOL_DISPLAY: Record<
+  string,
+  { displayName: string; argField: string } | undefined
+> = {
+  bash: { displayName: "Bash", argField: "command" },
+};
+
+/**
+ * Parse a line of pi's `--mode json` output format into display events.
+ *
+ * Pi emits JSONL events with types like `message_update`, `tool_execution_start`,
+ * and `agent_end`. See the pi coding agent documentation for the full event schema.
+ */
+export const parsePiStreamLine = (line: string): ParsedStreamEvent[] => {
+  if (!line.startsWith("{")) return [];
+  try {
+    const obj = JSON.parse(line);
+
+    // Text delta from assistant
+    if (
+      obj.type === "message_update" &&
+      obj.assistantMessageEvent?.type === "text_delta" &&
+      typeof obj.assistantMessageEvent.delta === "string"
+    ) {
+      return [{ type: "text", text: obj.assistantMessageEvent.delta }];
+    }
+
+    // Tool execution start — show allowlisted tools
+    if (
+      obj.type === "tool_execution_start" &&
+      typeof obj.toolName === "string"
+    ) {
+      const mapping = PI_TOOL_DISPLAY[obj.toolName];
+      if (
+        mapping &&
+        obj.args &&
+        typeof obj.args[mapping.argField] === "string"
+      ) {
+        return [
+          {
+            type: "tool_call",
+            name: mapping.displayName,
+            args: obj.args[mapping.argField] as string,
+          },
+        ];
+      }
+    }
+
+    // Agent end — extract final result text from the last assistant message
+    if (obj.type === "agent_end" && Array.isArray(obj.messages)) {
+      const messages = obj.messages as {
+        role: string;
+        content: { type: string; text?: string }[];
+      }[];
+      const lastAssistant = [...messages]
+        .reverse()
+        .find((m) => m.role === "assistant");
+      if (lastAssistant && Array.isArray(lastAssistant.content)) {
+        const text = lastAssistant.content
+          .filter(
+            (block) => block.type === "text" && typeof block.text === "string",
+          )
+          .map((block) => block.text)
+          .join("");
+        if (text) {
+          // Pi's JSON mode does not include token usage data in agent_end.
+          return [{ type: "result", result: text, usage: null }];
+        }
+      }
+    }
+  } catch {
+    // Not valid JSON — skip
+  }
+  return [];
+};
+
+export const piProvider: AgentProvider = {
+  name: "pi",
+  // Sonnet balances cost and capability for automated workflows.
+  // The model can be overridden via RunOptions.
+  defaultModel: "claude-sonnet-4-6",
+
+  envManifest: {
+    ANTHROPIC_API_KEY: "Anthropic API key",
+    GH_TOKEN: "GitHub personal access token",
+  },
+
+  dockerfileTemplate: PI_DOCKERFILE,
+
+  buildPrintCommand: ({ model, prompt }) =>
+    `pi -p --mode json --no-session --model ${shellEscape(model)} ${shellEscape(prompt)}`,
+
+  buildInteractiveArgs: ({ model }) => ["pi", "--model", model],
+
+  parseStreamLine: parsePiStreamLine,
+};
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
 
 const AGENT_REGISTRY: Record<string, AgentProvider> = {
   "claude-code": claudeCodeProvider,
+  pi: piProvider,
 };
 
 export const getAgentProvider = (name: string): AgentProvider => {

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -19,11 +19,16 @@ const runScaffold = (...args: Parameters<typeof scaffold>) =>
 
 const fakeProvider: AgentProvider = {
   name: "fake-agent",
+  defaultModel: "fake-model-1",
   envManifest: {
     FAKE_TOKEN: "Fake agent token",
     FAKE_SECRET: "Fake agent secret",
   },
   dockerfileTemplate: "FROM ubuntu:latest\nRUN echo fake\n",
+  buildPrintCommand: ({ model, prompt }) =>
+    `fake-agent --print --model ${model} '${prompt}'`,
+  buildInteractiveArgs: ({ model }) => ["fake-agent", "--model", model],
+  parseStreamLine: () => [],
 };
 
 describe("InitService scaffold", () => {

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -9,12 +9,8 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { Display, type DisplayEntry, SilentDisplay } from "./Display.js";
 import { makeLocalSandboxLayer } from "./testSandbox.js";
-import {
-  DEFAULT_MODEL,
-  formatToolCall,
-  orchestrate,
-  parseStreamJsonLine,
-} from "./Orchestrator.js";
+import { DEFAULT_MODEL, orchestrate } from "./Orchestrator.js";
+import { piProvider } from "./AgentProvider.js";
 import { Sandbox } from "./SandboxFactory.js";
 import type { DockerError, SandboxError } from "./errors.js";
 import { TimeoutError } from "./errors.js";
@@ -58,6 +54,30 @@ const toStreamJson = (output: string): string => {
     }),
   );
   lines.push(JSON.stringify({ type: "result", result: output }));
+  return lines.join("\n");
+};
+
+/** Format a mock agent result as pi JSON mode lines */
+const toPiStreamJson = (output: string): string => {
+  const lines: string[] = [];
+  lines.push(
+    JSON.stringify({
+      type: "message_update",
+      message: {},
+      assistantMessageEvent: { type: "text_delta", delta: output },
+    }),
+  );
+  lines.push(
+    JSON.stringify({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: output }],
+        },
+      ],
+    }),
+  );
   return lines.join("\n");
 };
 
@@ -126,11 +146,12 @@ const makeTestSandboxFactory = (
 };
 
 /**
- * Create a mock sandbox layer that intercepts `claude` commands
- * and runs a mock script instead. All other commands pass through
- * to the filesystem sandbox.
+ * Create a mock sandbox layer that intercepts agent commands matching `commandPrefix`
+ * and runs a mock script instead. All other commands pass through to the filesystem sandbox.
  */
-const makeMockAgentLayer = (
+const makeMockAgentLayerFor = (
+  commandPrefix: string,
+  toStream: (output: string) => string,
   sandboxDir: string,
   mockAgentBehavior: (sandboxRepoDir: string) => Promise<string>,
 ): Layer.Layer<Sandbox> => {
@@ -138,34 +159,29 @@ const makeMockAgentLayer = (
 
   return Layer.succeed(Sandbox, {
     exec: (command, options) => {
-      // Intercept claude invocations
-      if (command.startsWith("claude ")) {
+      if (command.startsWith(commandPrefix)) {
         return Effect.gen(function* () {
           const cwd = options?.cwd ?? sandboxDir;
           const output = yield* Effect.promise(() => mockAgentBehavior(cwd));
           return { stdout: output, stderr: "", exitCode: 0 };
         });
       }
-      // Pass through to real filesystem sandbox
       return Effect.flatMap(Sandbox, (real) =>
         real.exec(command, options),
       ).pipe(Effect.provide(fsLayer));
     },
     execStreaming: (command, onStdoutLine, options) => {
-      // Intercept claude invocations
-      if (command.startsWith("claude ")) {
+      if (command.startsWith(commandPrefix)) {
         return Effect.gen(function* () {
           const cwd = options?.cwd ?? sandboxDir;
           const output = yield* Effect.promise(() => mockAgentBehavior(cwd));
-          const streamOutput = toStreamJson(output);
-          // Emit each line to the callback
+          const streamOutput = toStream(output);
           for (const line of streamOutput.split("\n")) {
             onStdoutLine(line);
           }
           return { stdout: streamOutput, stderr: "", exitCode: 0 };
         });
       }
-      // Pass through to real filesystem sandbox
       return Effect.flatMap(Sandbox, (real) =>
         real.execStreaming(command, onStdoutLine, options),
       ).pipe(Effect.provide(fsLayer));
@@ -180,6 +196,20 @@ const makeMockAgentLayer = (
       ).pipe(Effect.provide(fsLayer)),
   });
 };
+
+/** Create a mock layer that intercepts `claude` commands (Claude Code provider) */
+const makeMockAgentLayer = (
+  sandboxDir: string,
+  mockAgentBehavior: (sandboxRepoDir: string) => Promise<string>,
+): Layer.Layer<Sandbox> =>
+  makeMockAgentLayerFor("claude ", toStreamJson, sandboxDir, mockAgentBehavior);
+
+/** Create a mock layer that intercepts `pi` commands (pi provider) */
+const makeMockPiAgentLayer = (
+  sandboxDir: string,
+  mockAgentBehavior: (sandboxRepoDir: string) => Promise<string>,
+): Layer.Layer<Sandbox> =>
+  makeMockAgentLayerFor("pi ", toPiStreamJson, sandboxDir, mockAgentBehavior);
 
 describe("Orchestrator", () => {
   it("runs a single iteration: sync-in, agent, sync-out", async () => {
@@ -684,339 +714,105 @@ describe("OrchestrateResult", () => {
   });
 });
 
-describe("parseStreamJsonLine", () => {
-  it("extracts text from assistant message", () => {
-    const line = JSON.stringify({
-      type: "assistant",
-      message: { content: [{ type: "text", text: "Hello world" }] },
-    });
-    expect(parseStreamJsonLine(line)).toEqual([
-      { type: "text", text: "Hello world" },
-    ]);
+// Stream parsing unit tests live in AgentProvider.test.ts
+// (they are part of the AgentProvider contract).
+
+describe("Orchestrator with pi provider", () => {
+  it("runs a single iteration using piProvider", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-pi-host-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
+      hostDir,
+      (dir) =>
+        makeMockPiAgentLayer(dir, async (repoDir) => {
+          await writeFile(join(repoDir, "pi-output.txt"), "pi was here");
+          await execAsync("git add -A", { cwd: repoDir });
+          await execAsync('git config user.email "agent@test.com"', {
+            cwd: repoDir,
+          });
+          await execAsync('git config user.name "Agent"', { cwd: repoDir });
+          await execAsync('git commit -m "pi: agent commit"', {
+            cwd: repoDir,
+          });
+          return "Done with iteration.";
+        }),
+    );
+
+    const result = await Effect.runPromise(
+      orchestrate({
+        hostRepoDir: hostDir,
+        sandboxRepoDir,
+        iterations: 1,
+        prompt: "do some work",
+        agentProvider: piProvider,
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(result.iterationsRun).toBe(1);
+
+    // Verify the agent's commit was synced back to host
+    const content = await readFile(join(hostDir, "pi-output.txt"), "utf-8");
+    expect(content).toBe("pi was here");
   });
 
-  it("extracts result from result message", () => {
-    const line = JSON.stringify({
-      type: "result",
-      result: "Final answer <promise>COMPLETE</promise>",
-    });
-    expect(parseStreamJsonLine(line)).toEqual([
-      {
-        type: "result",
-        result: "Final answer <promise>COMPLETE</promise>",
-        usage: null,
-      },
-    ]);
+  it("stops early on completion signal with piProvider", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-pi-host-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
+      hostDir,
+      (dir) =>
+        makeMockPiAgentLayer(dir, async () => {
+          return "All done. <promise>COMPLETE</promise>";
+        }),
+    );
+
+    const result = await Effect.runPromise(
+      orchestrate({
+        hostRepoDir: hostDir,
+        sandboxRepoDir,
+        iterations: 5,
+        prompt: "do some work",
+        agentProvider: piProvider,
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(result.iterationsRun).toBe(1);
+    expect(result.completionSignal).toBe("<promise>COMPLETE</promise>");
   });
 
-  it("returns empty array for non-JSON lines", () => {
-    expect(parseStreamJsonLine("not json")).toEqual([]);
-    expect(parseStreamJsonLine("")).toEqual([]);
-  });
+  it("uses piProvider default model when no model specified", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-pi-host-"));
 
-  it("returns empty array for malformed JSON starting with {", () => {
-    expect(parseStreamJsonLine("{bad json")).toEqual([]);
-    expect(parseStreamJsonLine('{"type": "assistant", broken')).toEqual([]);
-  });
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
 
-  it("returns empty array for unrecognized JSON types", () => {
-    const line = JSON.stringify({ type: "system", data: "something" });
-    expect(parseStreamJsonLine(line)).toEqual([]);
-  });
+    const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
+      hostDir,
+      (dir) =>
+        makeMockPiAgentLayer(dir, async () => {
+          return "Done.";
+        }),
+    );
 
-  it("handles multiple text content blocks", () => {
-    const line = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [
-          { type: "text", text: "Hello " },
-          { type: "text", text: "world" },
-        ],
-      },
-    });
-    expect(parseStreamJsonLine(line)).toEqual([
-      { type: "text", text: "Hello world" },
-    ]);
-  });
+    // Should not throw — piProvider.defaultModel is used as fallback
+    const result = await Effect.runPromise(
+      orchestrate({
+        hostRepoDir: hostDir,
+        sandboxRepoDir,
+        iterations: 1,
+        prompt: "do some work",
+        agentProvider: piProvider,
+        // model intentionally omitted
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
 
-  it("skips malformed tool_use blocks (no name/input)", () => {
-    const line = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [
-          { type: "tool_use", id: "123" },
-          { type: "text", text: "result" },
-        ],
-      },
-    });
-    expect(parseStreamJsonLine(line)).toEqual([
-      { type: "text", text: "result" },
-    ]);
-  });
-
-  it("extracts tool_use block from assistant event (Bash → command arg)", () => {
-    const line = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [
-          { type: "tool_use", name: "Bash", input: { command: "npm test" } },
-        ],
-      },
-    });
-    expect(parseStreamJsonLine(line)).toEqual([
-      { type: "tool_call", name: "Bash", args: "npm test" },
-    ]);
-  });
-
-  it("handles mixed text and tool_use content blocks", () => {
-    const line = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [
-          { type: "text", text: "Running tests..." },
-          { type: "tool_use", name: "Bash", input: { command: "npm test" } },
-        ],
-      },
-    });
-    expect(parseStreamJsonLine(line)).toEqual([
-      { type: "text", text: "Running tests..." },
-      { type: "tool_call", name: "Bash", args: "npm test" },
-    ]);
-  });
-
-  it("handles multiple tool_use blocks in one event", () => {
-    const line = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [
-          { type: "tool_use", name: "Bash", input: { command: "npm test" } },
-          {
-            type: "tool_use",
-            name: "WebSearch",
-            input: { query: "typescript types" },
-          },
-        ],
-      },
-    });
-    expect(parseStreamJsonLine(line)).toEqual([
-      { type: "tool_call", name: "Bash", args: "npm test" },
-      { type: "tool_call", name: "WebSearch", args: "typescript types" },
-    ]);
-  });
-
-  it("extracts WebFetch tool_use with url arg", () => {
-    const line = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [
-          {
-            type: "tool_use",
-            name: "WebFetch",
-            input: { url: "https://example.com" },
-          },
-        ],
-      },
-    });
-    expect(parseStreamJsonLine(line)).toEqual([
-      { type: "tool_call", name: "WebFetch", args: "https://example.com" },
-    ]);
-  });
-
-  it("extracts Agent tool_use with description arg", () => {
-    const line = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [
-          {
-            type: "tool_use",
-            name: "Agent",
-            input: { description: "Run tests and report results" },
-          },
-        ],
-      },
-    });
-    expect(parseStreamJsonLine(line)).toEqual([
-      {
-        type: "tool_call",
-        name: "Agent",
-        args: "Run tests and report results",
-      },
-    ]);
-  });
-
-  it("filters out non-allowlisted tools (Read, Glob, Grep, Edit, Write)", () => {
-    for (const name of ["Read", "Glob", "Grep", "Edit", "Write"]) {
-      const line = JSON.stringify({
-        type: "assistant",
-        message: {
-          content: [
-            { type: "tool_use", name, input: { file_path: "/some/file" } },
-          ],
-        },
-      });
-      expect(parseStreamJsonLine(line)).toEqual([]);
-    }
-  });
-
-  it("filters out tool_use blocks with missing expected input field", () => {
-    const line = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [
-          // Bash with no `command` field
-          { type: "tool_use", name: "Bash", input: { other: "value" } },
-        ],
-      },
-    });
-    expect(parseStreamJsonLine(line)).toEqual([]);
-  });
-
-  it("keeps text events even when all tool_use blocks are filtered out", () => {
-    const line = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [
-          { type: "text", text: "Looking at files..." },
-          { type: "tool_use", name: "Read", input: { file_path: "/foo" } },
-        ],
-      },
-    });
-    expect(parseStreamJsonLine(line)).toEqual([
-      { type: "text", text: "Looking at files..." },
-    ]);
-  });
-
-  it("returns only text when event has no tool_use blocks", () => {
-    const line = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [{ type: "text", text: "Just text, no tools" }],
-      },
-    });
-    expect(parseStreamJsonLine(line)).toEqual([
-      { type: "text", text: "Just text, no tools" },
-    ]);
-  });
-
-  it("extracts usage data from result message", () => {
-    const line = JSON.stringify({
-      type: "result",
-      result: "Done.",
-      total_cost_usd: 0.14,
-      num_turns: 3,
-      duration_ms: 12000,
-      usage: {
-        input_tokens: 52340,
-        output_tokens: 3201,
-        cache_read_input_tokens: 10000,
-        cache_creation_input_tokens: 5000,
-      },
-    });
-    const parsed = parseStreamJsonLine(line);
-    expect(parsed).toEqual([
-      {
-        type: "result",
-        result: "Done.",
-        usage: {
-          input_tokens: 52340,
-          output_tokens: 3201,
-          cache_read_input_tokens: 10000,
-          cache_creation_input_tokens: 5000,
-          total_cost_usd: 0.14,
-          num_turns: 3,
-          duration_ms: 12000,
-        },
-      },
-    ]);
-  });
-
-  it("returns null usage when result message has no usage data", () => {
-    const line = JSON.stringify({
-      type: "result",
-      result: "Done.",
-    });
-    const parsed = parseStreamJsonLine(line);
-    expect(parsed).toEqual([
-      {
-        type: "result",
-        result: "Done.",
-        usage: null,
-      },
-    ]);
-  });
-
-  it("returns null usage when usage fields are partial", () => {
-    const line = JSON.stringify({
-      type: "result",
-      result: "Done.",
-      usage: { input_tokens: 100 },
-    });
-    const parsed = parseStreamJsonLine(line);
-    expect(parsed).toEqual([
-      {
-        type: "result",
-        result: "Done.",
-        usage: null,
-      },
-    ]);
-  });
-});
-
-describe("formatToolCall", () => {
-  it("formats Bash tool call using command field", () => {
-    expect(formatToolCall("Bash", { command: "npm test" })).toEqual({
-      name: "Bash",
-      formattedArgs: "npm test",
-    });
-  });
-
-  it("formats WebSearch tool call using query field", () => {
-    expect(
-      formatToolCall("WebSearch", { query: "npm trusted publishing OIDC" }),
-    ).toEqual({
-      name: "WebSearch",
-      formattedArgs: "npm trusted publishing OIDC",
-    });
-  });
-
-  it("formats WebFetch tool call using url field", () => {
-    expect(
-      formatToolCall("WebFetch", { url: "https://example.com/docs" }),
-    ).toEqual({ name: "WebFetch", formattedArgs: "https://example.com/docs" });
-  });
-
-  it("formats Agent tool call using description field", () => {
-    expect(
-      formatToolCall("Agent", { description: "Run tests and report results" }),
-    ).toEqual({ name: "Agent", formattedArgs: "Run tests and report results" });
-  });
-
-  it("returns null for Read (not in allowlist)", () => {
-    expect(formatToolCall("Read", { file_path: "/some/path" })).toBeNull();
-  });
-
-  it("returns null for Glob (not in allowlist)", () => {
-    expect(formatToolCall("Glob", { pattern: "**/*.ts" })).toBeNull();
-  });
-
-  it("returns null for Grep (not in allowlist)", () => {
-    expect(formatToolCall("Grep", { pattern: "foo" })).toBeNull();
-  });
-
-  it("returns null for Edit (not in allowlist)", () => {
-    expect(formatToolCall("Edit", { file_path: "/foo.ts" })).toBeNull();
-  });
-
-  it("returns null for Write (not in allowlist)", () => {
-    expect(formatToolCall("Write", { file_path: "/foo.ts" })).toBeNull();
-  });
-
-  it("returns null for unknown tool", () => {
-    expect(formatToolCall("UnknownTool", { x: 1 })).toBeNull();
-  });
-
-  it("returns null when the arg field is missing", () => {
-    expect(formatToolCall("Bash", {})).toBeNull();
+    expect(result.iterationsRun).toBe(1);
   });
 });
 
@@ -1544,7 +1340,7 @@ describe("Orchestrator streaming", () => {
       }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
     );
 
-    expect(capturedCommand).toContain(`--model ${DEFAULT_MODEL}`);
+    expect(capturedCommand).toContain(`--model '${DEFAULT_MODEL}'`);
   });
 
   it("uses custom model when specified in options", async () => {
@@ -1604,7 +1400,7 @@ describe("Orchestrator streaming", () => {
       }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
     );
 
-    expect(capturedCommand).toContain("--model claude-sonnet-4-6");
+    expect(capturedCommand).toContain("--model 'claude-sonnet-4-6'");
     expect(capturedCommand).not.toContain(DEFAULT_MODEL);
   });
 });

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -6,136 +6,21 @@ import type { SandboxError } from "./errors.js";
 import type { SandboxService } from "./SandboxFactory.js";
 import { SandboxFactory } from "./SandboxFactory.js";
 import { withSandboxLifecycle, type SandboxHooks } from "./SandboxLifecycle.js";
+import type {
+  AgentProvider,
+  TokenUsage,
+  ParsedStreamEvent,
+} from "./AgentProvider.js";
+import { claudeCodeProvider } from "./AgentProvider.js";
 
-export interface TokenUsage {
-  readonly input_tokens: number;
-  readonly output_tokens: number;
-  readonly cache_read_input_tokens: number;
-  readonly cache_creation_input_tokens: number;
-  readonly total_cost_usd: number;
-  readonly num_turns: number;
-  readonly duration_ms: number;
-}
-
-export const DEFAULT_MODEL = "claude-opus-4-6";
-
-const extractUsage = (obj: Record<string, unknown>): TokenUsage | null => {
-  const usage = obj.usage as Record<string, unknown> | undefined;
-  if (
-    !usage ||
-    typeof usage.input_tokens !== "number" ||
-    typeof usage.output_tokens !== "number"
-  ) {
-    return null;
-  }
-  return {
-    input_tokens: usage.input_tokens,
-    output_tokens: usage.output_tokens,
-    cache_read_input_tokens:
-      typeof usage.cache_read_input_tokens === "number"
-        ? usage.cache_read_input_tokens
-        : 0,
-    cache_creation_input_tokens:
-      typeof usage.cache_creation_input_tokens === "number"
-        ? usage.cache_creation_input_tokens
-        : 0,
-    total_cost_usd:
-      typeof obj.total_cost_usd === "number" ? obj.total_cost_usd : 0,
-    num_turns: typeof obj.num_turns === "number" ? obj.num_turns : 0,
-    duration_ms: typeof obj.duration_ms === "number" ? obj.duration_ms : 0,
-  };
-};
-
-export type ParsedStreamEvent =
-  | { type: "text"; text: string }
-  | { type: "result"; result: string; usage: TokenUsage | null }
-  | { type: "tool_call"; name: string; args: string };
-
-/** Maps allowlisted tool names to the input field containing the display arg */
-const TOOL_ARG_FIELDS: Record<string, string> = {
-  Bash: "command",
-  WebSearch: "query",
-  WebFetch: "url",
-  Agent: "description",
-};
-
-/** Extract displayable events from a stream-json line */
-export const parseStreamJsonLine = (line: string): ParsedStreamEvent[] => {
-  if (!line.startsWith("{")) return [];
-  try {
-    const obj = JSON.parse(line);
-    if (obj.type === "assistant" && Array.isArray(obj.message?.content)) {
-      const events: ParsedStreamEvent[] = [];
-      const texts: string[] = [];
-      for (const block of obj.message.content as {
-        type: string;
-        text?: string;
-        name?: string;
-        input?: Record<string, unknown>;
-      }[]) {
-        if (block.type === "text" && typeof block.text === "string") {
-          texts.push(block.text);
-        } else if (
-          block.type === "tool_use" &&
-          typeof block.name === "string" &&
-          block.input !== undefined
-        ) {
-          const argField = TOOL_ARG_FIELDS[block.name];
-          if (argField === undefined) continue; // not allowlisted
-          const argValue = block.input[argField];
-          if (typeof argValue !== "string") continue; // missing/wrong arg field
-          if (texts.length > 0) {
-            events.push({ type: "text", text: texts.join("") });
-            texts.length = 0;
-          }
-          events.push({
-            type: "tool_call",
-            name: block.name,
-            args: argValue,
-          });
-        }
-      }
-      if (texts.length > 0) {
-        events.push({ type: "text", text: texts.join("") });
-      }
-      return events;
-    }
-    if (obj.type === "result" && typeof obj.result === "string") {
-      return [{ type: "result", result: obj.result, usage: extractUsage(obj) }];
-    }
-  } catch {
-    // Not valid JSON — skip
-  }
-  return [];
-};
-
-const TOOL_ARG_EXTRACTORS: Record<
-  string,
-  (input: Record<string, unknown>) => string | undefined
-> = {
-  Bash: (input) =>
-    typeof input.command === "string" ? input.command : undefined,
-  WebSearch: (input) =>
-    typeof input.query === "string" ? input.query : undefined,
-  WebFetch: (input) => (typeof input.url === "string" ? input.url : undefined),
-  Agent: (input) =>
-    typeof input.description === "string" ? input.description : undefined,
-};
+// Re-export types that were previously defined here for backward compatibility
+export type { TokenUsage, ParsedStreamEvent } from "./AgentProvider.js";
 
 /**
- * Format a tool call for display. Returns null if the tool is not in the
- * allowlist or the required arg field is missing.
+ * Default model for the claude-code provider.
+ * Prefer `agentProvider.defaultModel` when a provider is available.
  */
-export const formatToolCall = (
-  name: string,
-  input: Record<string, unknown>,
-): { name: string; formattedArgs: string } | null => {
-  const extractor = TOOL_ARG_EXTRACTORS[name];
-  if (!extractor) return null;
-  const arg = extractor(input);
-  if (arg === undefined) return null;
-  return { name, formattedArgs: arg };
-};
+export const DEFAULT_MODEL = claudeCodeProvider.defaultModel;
 
 const invokeAgent = (
   sandbox: SandboxService,
@@ -145,6 +30,7 @@ const invokeAgent = (
   idleTimeoutMs: number,
   onText: (text: string) => void,
   onToolCall: (name: string, formattedArgs: string) => void,
+  provider: AgentProvider,
 ): Effect.Effect<{ result: string; usage: TokenUsage | null }, SandboxError> =>
   Effect.gen(function* () {
     let resultText = "";
@@ -172,11 +58,13 @@ const invokeAgent = (
 
     resetIdleTimer();
 
+    const command = provider.buildPrintCommand({ model, prompt });
+
     const execEffect = Effect.gen(function* () {
       const execResult = yield* sandbox.execStreaming(
-        `claude --print --verbose --dangerously-skip-permissions --output-format stream-json --model ${model} -p ${shellEscape(prompt)}`,
+        command,
         (line) => {
-          for (const parsed of parseStreamJsonLine(line)) {
+          for (const parsed of provider.parseStreamLine(line)) {
             if (parsed.type === "text") {
               resetIdleTimer();
               onText(parsed.text);
@@ -195,7 +83,7 @@ const invokeAgent = (
       if (execResult.exitCode !== 0) {
         return yield* Effect.fail(
           new AgentError({
-            message: `Claude exited with code ${execResult.exitCode}:\n${execResult.stderr}`,
+            message: `${provider.name} exited with code ${execResult.exitCode}:\n${execResult.stderr}`,
           }),
         );
       }
@@ -214,8 +102,6 @@ const invokeAgent = (
 
     return yield* Effect.raceFirst(execEffect, Deferred.await(timeoutSignal));
   });
-
-const shellEscape = (s: string): string => "'" + s.replace(/'/g, "'\\''") + "'";
 
 const formatNumber = (n: number): string => n.toLocaleString("en-US");
 
@@ -240,6 +126,8 @@ export interface OrchestrateOptions {
   readonly idleTimeoutSeconds?: number;
   /** Optional name for the run, prepended to status messages as [name] */
   readonly name?: string;
+  /** The agent provider to use. Defaults to claude-code when not specified. */
+  readonly agentProvider?: AgentProvider;
 }
 
 export interface OrchestrateResult {
@@ -256,6 +144,7 @@ export interface OrchestrateResult {
 export const orchestrate = (
   options: OrchestrateOptions,
 ): Effect.Effect<OrchestrateResult, SandboxError, SandboxFactory | Display> => {
+  const provider = options.agentProvider ?? claudeCodeProvider;
   const idleTimeoutMs =
     (options.idleTimeoutSeconds ?? DEFAULT_IDLE_TIMEOUT_SECONDS) * 1000;
   return Effect.gen(function* () {
@@ -263,7 +152,7 @@ export const orchestrate = (
     const display = yield* Display;
     const { hostRepoDir, sandboxRepoDir, iterations, hooks, prompt, branch } =
       options;
-    const resolvedModel = options.model ?? DEFAULT_MODEL;
+    const resolvedModel = options.model ?? provider.defaultModel;
     let completionSignals: string[];
     if (options.completionSignal === undefined) {
       completionSignals = [DEFAULT_COMPLETION_SIGNAL];
@@ -319,6 +208,7 @@ export const orchestrate = (
                 idleTimeoutMs,
                 onText,
                 onToolCall,
+                provider,
               );
 
               yield* display.status(label("Agent stopped"), "info");

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -66,14 +66,14 @@ describe("sandcastle CLI", () => {
     expect(stdout).toContain("--template");
   });
 
-  it("init --help does not expose --agent flag", async () => {
+  it("init --help shows --agent flag", async () => {
     const { stdout } = await runCli("init --help", process.cwd());
-    expect(stdout).not.toContain("--agent");
+    expect(stdout).toContain("--agent");
   });
 
-  it("interactive --help does not expose --agent flag", async () => {
+  it("interactive --help shows --agent flag", async () => {
     const { stdout } = await runCli("interactive --help", process.cwd());
-    expect(stdout).not.toContain("--agent");
+    expect(stdout).toContain("--agent");
   });
 
   it("init --template nonexistent produces error listing available templates", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,12 +7,13 @@ import { execSync, spawn } from "node:child_process";
 import { join } from "node:path";
 import { styleText } from "node:util";
 import { Display } from "./Display.js";
-import { DEFAULT_MODEL } from "./Orchestrator.js";
+
 import { buildImage, removeImage } from "./DockerLifecycle.js";
 import { scaffold, listTemplates, getNextStepsLines } from "./InitService.js";
-import { defaultImageName } from "./run.js";
+import { defaultImageName, DEFAULT_AGENT } from "./run.js";
 import { getAgentProvider } from "./AgentProvider.js";
 import { AgentError, ConfigDirError, InitError } from "./errors.js";
+import type { AgentProvider } from "./AgentProvider.js";
 import {
   SandboxFactory,
   WorktreeDockerSandboxFactory,
@@ -33,6 +34,11 @@ const resolveImageName = (
   cliFlag: import("effect").Option.Option<string>,
   cwd: string,
 ): string => (cliFlag._tag === "Some" ? cliFlag.value : defaultImageName(cwd));
+
+const agentOption = Options.text("agent").pipe(
+  Options.withDescription('Agent provider to use (e.g. "claude-code", "pi")'),
+  Options.withDefault(DEFAULT_AGENT),
+);
 
 // --- Config directory check ---
 
@@ -69,15 +75,15 @@ const initCommand = Command.make(
   {
     imageName: imageNameOption,
     template: templateOption,
+    agent: agentOption,
   },
-  ({ imageName: imageNameFlag, template }) =>
+  ({ imageName: imageNameFlag, template, agent }) =>
     Effect.gen(function* () {
       const d = yield* Display;
       const cwd = process.cwd();
       const imageName = resolveImageName(imageNameFlag, cwd);
 
-      // Agent is hardcoded to claude-code (agent selection is not part of the public API)
-      const agentName = "claude-code";
+      const agentName = agent;
       const provider = yield* Effect.try({
         try: () => getAgentProvider(agentName),
         catch: (e) =>
@@ -254,15 +260,16 @@ const modelOption = Options.text("model").pipe(
 const interactiveSession = (options: {
   hostRepoDir: string;
   model?: string;
+  agentName: string;
+  interactiveArgs: string[];
 }): Effect.Effect<
   void,
   import("./errors.js").SandboxError,
   SandboxFactory | Display
 > =>
   Effect.gen(function* () {
-    const { hostRepoDir } = options;
+    const { hostRepoDir, interactiveArgs } = options;
     const sandboxRepoDir = SANDBOX_WORKSPACE_DIR;
-    const resolvedModel = options.model ?? DEFAULT_MODEL;
     const factory = yield* SandboxFactory;
     const d = yield* Display;
 
@@ -275,8 +282,11 @@ const interactiveSession = (options: {
             const hostnameResult = yield* ctx.sandbox.exec("hostname");
             const containerId = hostnameResult.stdout.trim();
 
-            // Launch interactive Claude session with TTY passthrough
-            yield* d.status("Launching interactive Claude session...", "info");
+            // Launch interactive agent session with TTY passthrough
+            yield* d.status(
+              `Launching interactive ${options.agentName} session...`,
+              "info",
+            );
 
             const exitCode = yield* Effect.async<number, AgentError>(
               (resume) => {
@@ -288,10 +298,7 @@ const interactiveSession = (options: {
                     "-w",
                     ctx.sandboxRepoDir,
                     containerId,
-                    "claude",
-                    "--dangerously-skip-permissions",
-                    "--model",
-                    resolvedModel,
+                    ...interactiveArgs,
                   ],
                   { stdio: "inherit" },
                 );
@@ -300,7 +307,7 @@ const interactiveSession = (options: {
                   resume(
                     Effect.fail(
                       new AgentError({
-                        message: `Failed to launch Claude: ${error.message}`,
+                        message: `Failed to launch ${options.agentName}: ${error.message}`,
                       }),
                     ),
                   );
@@ -326,21 +333,38 @@ const interactiveCommand = Command.make(
   {
     imageName: imageNameOption,
     model: modelOption,
+    agent: agentOption,
   },
-  ({ imageName: imageNameFlag, model }) =>
+  ({ imageName: imageNameFlag, model, agent }) =>
     Effect.gen(function* () {
       const hostRepoDir = process.cwd();
       yield* requireConfigDir(hostRepoDir);
 
       const imageName = resolveImageName(imageNameFlag, hostRepoDir);
 
+      // Resolve agent provider
+      const provider = yield* Effect.try({
+        try: () => getAgentProvider(agent),
+        catch: (e) =>
+          new InitError({
+            message: `${e instanceof Error ? e.message : e}`,
+          }),
+      });
+
+      const resolvedModel =
+        model._tag === "Some" ? model.value : provider.defaultModel;
+      const interactiveArgs = provider.buildInteractiveArgs({
+        model: resolvedModel,
+      });
+
       // Resolve env vars
       const env = yield* resolveEnv(hostRepoDir);
 
-      const resolvedModel = model._tag === "Some" ? model.value : undefined;
-
       const d = yield* Display;
-      yield* d.summary("Sandcastle Interactive", { Image: imageName });
+      yield* d.summary("Sandcastle Interactive", {
+        Agent: provider.name,
+        Image: imageName,
+      });
 
       const factoryLayer = Layer.provide(
         WorktreeDockerSandboxFactory.layer,
@@ -357,6 +381,8 @@ const interactiveCommand = Command.make(
       yield* interactiveSession({
         hostRepoDir,
         model: resolvedModel,
+        agentName: provider.name,
+        interactiveArgs,
       }).pipe(Effect.provide(factoryLayer));
     }),
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
 export { run } from "./run.js";
 export type { RunOptions, RunResult, LoggingOption } from "./run.js";
 export type { PromptArgs } from "./PromptArgumentSubstitution.js";
+export type { AgentProvider } from "./AgentProvider.js";
+export {
+  getAgentProvider,
+  claudeCodeProvider,
+  piProvider,
+} from "./AgentProvider.js";

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -142,10 +142,14 @@ describe("DEFAULT_MAX_ITERATIONS", () => {
 });
 
 describe("RunOptions", () => {
-  it("does not expose agent field", () => {
+  it("defaults agent to undefined when not specified", () => {
     const opts: RunOptions = { prompt: "test" };
-    // @ts-expect-error agent should not be a property of RunOptions
     expect(opts.agent).toBeUndefined();
+  });
+
+  it("allows agent to be specified", () => {
+    const opts: RunOptions = { prompt: "test", agent: "pi" };
+    expect(opts.agent).toBe("pi");
   });
 
   it("allows idleTimeoutSeconds to be specified", () => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -28,6 +28,9 @@ import {
 /** Default maximum number of iterations for a run. */
 export const DEFAULT_MAX_ITERATIONS = 1;
 
+/** Default agent provider name. */
+export const DEFAULT_AGENT = "claude-code";
+
 /** Replace characters that are invalid or problematic in file paths with dashes. */
 export const sanitizeBranchForFilename = (branch: string): string =>
   branch.replace(/[/\\:*?"<>|]/g, "-");
@@ -158,7 +161,7 @@ export interface RunOptions {
   };
   /** Target branch name for sandbox work */
   readonly branch?: string;
-  /** Model to use for the agent (default: claude-opus-4-6) */
+  /** Model to use for the agent (default: provider-specific) */
   readonly model?: string;
   /** Docker image name to use for the sandbox (default: sandcastle:<repo-dir-name>) */
   readonly imageName?: string;
@@ -174,6 +177,8 @@ export interface RunOptions {
   readonly name?: string;
   /** Paths relative to the host repo root to copy into the worktree before container start. */
   readonly copyToSandbox?: string[];
+  /** Agent provider to use (default: "claude-code"). Available: "claude-code", "pi" */
+  readonly agent?: "claude-code" | "pi" | (string & {});
 }
 
 export interface RunResult {
@@ -212,12 +217,13 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
     ),
   );
 
-  // Resolve model: explicit option > default
-  const resolvedModel = model;
-
-  // Agent is hardcoded to claude-code (agent selection is not part of the public API)
-  const agentName = "claude-code";
+  // Resolve agent provider
+  const agentName = options.agent ?? DEFAULT_AGENT;
   const provider = getAgentProvider(agentName);
+
+  // Model resolution: explicit option is passed through to orchestrate(),
+  // which falls back to provider.defaultModel when undefined.
+  const resolvedModel = model;
 
   // Resolve image name: explicit option > default
   const resolvedImageName = options.imageName ?? defaultImageName(hostRepoDir);
@@ -257,7 +263,7 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
       ? (() => {
           printFileDisplayStartup({
             logPath: resolvedLogging.path,
-            agentName: options.name,
+            agentName: options.name ?? agentName,
             branch: resolvedBranch,
           });
           return Layer.provide(
@@ -330,6 +336,7 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
         completionSignal: options.completionSignal,
         idleTimeoutSeconds: options.idleTimeoutSeconds,
         name: options.name,
+        agentProvider: provider,
       });
 
       const completion = buildCompletionMessage(


### PR DESCRIPTION
Ref #199 — adds pi as an alternative agent provider

## Summary

Adds [pi](https://github.com/badlogic/pi-mono) as a second agent provider alongside Claude Code.

## Changes

### `AgentProvider` interface extended

The existing `AgentProvider` interface now includes agent-specific behavior that was previously hardcoded in the Orchestrator:

- `defaultModel` — provider's default model
- `buildPrintCommand()` — builds the CLI command for non-interactive invocations
- `buildInteractiveArgs()` — builds CLI args for interactive sessions
- `parseStreamLine()` — parses provider-specific streaming output format

### New `piProvider`

- Dockerfile template with pi CLI installation (via npm)
- Pi's `--mode json` output format parser (handles `message_update`, `tool_execution_start`, `agent_end` events)
- Default model: `claude-sonnet-4-6`

### Public API

- `RunOptions.agent` — optional field (default: `"claude-code"`, available: `"pi"`)
- `--agent` CLI flag on `init` and `interactive` commands
- Exported: `AgentProvider` type, `getAgentProvider()`, `claudeCodeProvider`, `piProvider`

### Orchestrator refactored

The Orchestrator now delegates command building and stream parsing to the agent provider instead of hardcoding Claude Code's CLI and `stream-json` format. Both `model` and `prompt` parameters are shell-escaped in `buildPrintCommand`.

## Usage

```typescript
import { run } from "@ai-hero/sandcastle";

await run({
  agent: "pi",
  promptFile: ".sandcastle/prompt.md",
});
```

```bash
npx sandcastle init --agent pi
npx sandcastle interactive --agent pi
```

## Testing

- Pi stream parser: unit tests for `message_update`, `tool_execution_start`, `agent_end`, and edge cases
- Orchestrator integration: 3 tests with `piProvider` (single iteration, completion signal, default model)
- Shell escaping: both providers tested for model and prompt escaping
- All existing Claude Code tests pass unchanged

## Backward compatibility

- Default agent remains `"claude-code"` — no breaking changes
- `DEFAULT_MODEL` and `TokenUsage`/`ParsedStreamEvent` types re-exported from Orchestrator for backward compat
