### PR TITLE
docs: fix .gitignore description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Creates the following files:
 ├── Dockerfile      # Sandbox environment (customize as needed)
 ├── prompt.md       # Agent instructions
 ├── .env.example    # Token placeholders
-└── .gitignore      # Ignores .env, patches/, logs/
+└── .gitignore      # Ignores .env, logs/, worktrees/
 ```
 
 Errors if `.sandcastle/` already exists to prevent overwriting customizations.


### PR DESCRIPTION
The README lists `patches/` in the `.gitignore` file tree, but the actual `.gitignore` scaffolded by `sandcastle init` ignores `worktrees/`, not `patches/`.

```
# InitService.ts
const GITIGNORE = `.env
logs/
worktrees/
`;
```

One-line fix.