### PR TITLE
fix: shell-escape model parameter in agent invocation

### DIFF
--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -1544,7 +1544,7 @@ describe("Orchestrator streaming", () => {
       }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
     );
 
-    expect(capturedCommand).toContain(`--model ${DEFAULT_MODEL}`);
+    expect(capturedCommand).toContain(`--model '${DEFAULT_MODEL}'`);
   });
 
   it("uses custom model when specified in options", async () => {
@@ -1604,7 +1604,7 @@ describe("Orchestrator streaming", () => {
       }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
     );
 
-    expect(capturedCommand).toContain("--model claude-sonnet-4-6");
+    expect(capturedCommand).toContain("--model 'claude-sonnet-4-6'");
     expect(capturedCommand).not.toContain(DEFAULT_MODEL);
   });
 });

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -174,7 +174,7 @@ const invokeAgent = (
 
     const execEffect = Effect.gen(function* () {
       const execResult = yield* sandbox.execStreaming(
-        `claude --print --verbose --dangerously-skip-permissions --output-format stream-json --model ${model} -p ${shellEscape(prompt)}`,
+        `claude --print --verbose --dangerously-skip-permissions --output-format stream-json --model ${shellEscape(model)} -p ${shellEscape(prompt)}`,
         (line) => {
           for (const parsed of parseStreamJsonLine(line)) {
             if (parsed.type === "text") {


### PR DESCRIPTION
The `model` parameter in `invokeAgent` is interpolated raw into the shell command string passed to `docker exec`:

```typescript
`claude ... --model ${model} -p ${shellEscape(prompt)}`
//                  ^^^^^^^^ not escaped
//                                ^^^^^^^^^^^^^^^^ escaped
```

The `prompt` is correctly escaped via `shellEscape()`, but `model` is not. Since the sandbox container has the host worktree bind-mounted at `.sandcastle/worktrees/`, a crafted model string could execute arbitrary commands that affect host files.

This PR applies `shellEscape()` to `model` as well.