### PR TITLE
Add package manager support to init scaffolding

### DIFF
--- a/.changeset/add-package-manager-support.md
+++ b/.changeset/add-package-manager-support.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add package manager support to `init` command — users can now choose npm, pnpm, yarn, or bun via the `--package-manager` flag or interactive prompt. Generated Dockerfiles, scripts, and prompts are rewritten to use the selected package manager.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ai-hero/sandcastle",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ai-hero/sandcastle",
-      "version": "0.1.8",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -11,7 +11,7 @@ import {
   getAgent,
   listTemplates,
 } from "./InitService.js";
-import type { AgentEntry, ScaffoldOptions } from "./InitService.js";
+import type { ScaffoldOptions } from "./InitService.js";
 import { SANDBOX_WORKSPACE_DIR } from "./SandboxFactory.js";
 import { SKELETON_PROMPT } from "./templates.js";
 
@@ -422,11 +422,10 @@ describe("InitService scaffold", () => {
       expect(joined).toContain("npm run sandcastle");
     });
 
-    it("non-blank template includes a note about customizing the install command", () => {
+    it("non-blank template includes a note about the install hook", () => {
       const lines = getNextStepsLines("simple-loop");
       const joined = lines.join("\n");
       expect(joined).toContain("npm install");
-      expect(joined).toContain("onSandboxReady");
     });
 
     it("non-blank template mentions copyToSandbox and node_modules", () => {
@@ -473,6 +472,36 @@ describe("InitService scaffold", () => {
       const lines = getNextStepsLines("simple-loop");
       const numberedSteps = lines.filter((l) => /^\d+\./.test(l));
       expect(numberedSteps.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("uses pnpm in next steps when packageManager is pnpm", () => {
+      const lines = getNextStepsLines("simple-loop", "pnpm");
+      const joined = lines.join("\n");
+      expect(joined).toContain("pnpm run sandcastle");
+      expect(joined).toContain("pnpm install");
+      // "pnpm run" contains "npm run" as substring, so check no standalone "npm run"
+      expect(joined).not.toMatch(/(?<![p])npm run/);
+      expect(joined).not.toMatch(/(?<![p])npm install/);
+    });
+
+    it("uses yarn in next steps when packageManager is yarn", () => {
+      const lines = getNextStepsLines("simple-loop", "yarn");
+      const joined = lines.join("\n");
+      expect(joined).toContain("yarn run sandcastle");
+      expect(joined).toContain("yarn install");
+    });
+
+    it("uses bun in next steps when packageManager is bun", () => {
+      const lines = getNextStepsLines("simple-loop", "bun");
+      const joined = lines.join("\n");
+      expect(joined).toContain("bun run sandcastle");
+      expect(joined).toContain("bun install");
+    });
+
+    it("uses pnpm in blank template next steps", () => {
+      const lines = getNextStepsLines("blank", "pnpm");
+      const joined = lines.join("\n");
+      expect(joined).toContain("pnpm run sandcastle");
     });
   });
 
@@ -629,6 +658,199 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(envExample).toContain("ANTHROPIC_API_KEY=");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Package manager support
+  // -------------------------------------------------------------------------
+
+  describe("package manager support", () => {
+    it("scaffolds with npm by default (no Dockerfile changes)", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, { templateName: "simple-loop" });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfile).not.toContain("corepack");
+      expect(dockerfile).not.toContain("pnpm");
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.ts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain("npm install");
+    });
+
+    it("scaffolds with pnpm: Dockerfile installs pnpm, main.ts uses pnpm", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        packageManager: { name: "pnpm", version: "9.1.0" },
+      });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfile).toContain("corepack enable");
+      expect(dockerfile).toContain("corepack prepare pnpm@9.1.0 --activate");
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.ts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain("pnpm install");
+      expect(mainTs).not.toMatch(/(?<![p])npm install/);
+    });
+
+    it("scaffolds with yarn: Dockerfile installs yarn via corepack", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        packageManager: { name: "yarn", version: "4.0.0" },
+      });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfile).toContain("corepack enable");
+      expect(dockerfile).toContain("corepack prepare yarn@4.0.0 --activate");
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.ts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain("yarn install");
+    });
+
+    it("scaffolds with bun: Dockerfile installs bun via npm", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        packageManager: { name: "bun" },
+      });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfile).toContain("npm install -g bun");
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.ts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain("bun install");
+    });
+
+    it("pnpm without version uses latest", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        packageManager: { name: "pnpm" },
+      });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfile).toContain("corepack prepare pnpm@latest --activate");
+    });
+
+    it("strips +sha512 hash from version in Dockerfile", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        packageManager: {
+          name: "pnpm",
+          version: "10.30.3+sha512.abc123def",
+        },
+      });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfile).toContain("corepack prepare pnpm@10.30.3 --activate");
+      expect(dockerfile).not.toContain("sha512");
+    });
+
+    it("inserts package manager install before USER line (runs as root)", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        packageManager: { name: "pnpm", version: "9.1.0" },
+      });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      const corepackIdx = dockerfile.indexOf("corepack enable");
+      const userIdx = dockerfile.indexOf("USER agent");
+      expect(corepackIdx).toBeGreaterThan(-1);
+      expect(userIdx).toBeGreaterThan(-1);
+      expect(corepackIdx).toBeLessThan(userIdx);
+    });
+
+    it("substitutes package manager in prompt .md files", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        packageManager: { name: "pnpm" },
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("pnpm run typecheck");
+      expect(prompt).toContain("pnpm run test");
+      expect(prompt).not.toMatch(/(?<![p])npm run/);
+    });
+
+    it("substitutes package manager in sequential-reviewer template files", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "sequential-reviewer",
+        packageManager: { name: "yarn" },
+      });
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.ts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain("yarn install");
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "implement-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("yarn run typecheck");
+    });
+
+    it("substitutes package manager in parallel-planner template files", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner",
+        packageManager: { name: "bun" },
+      });
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.ts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain("bun install");
+
+      const mergePrompt = await readFile(
+        join(dir, ".sandcastle", "merge-prompt.md"),
+        "utf-8",
+      );
+      expect(mergePrompt).toContain("bun run typecheck");
     });
   });
 });

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -4,6 +4,13 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { SANDBOX_WORKSPACE_DIR } from "./SandboxFactory.js";
 
+export type PackageManagerName = "npm" | "pnpm" | "yarn" | "bun";
+
+export interface DetectedPackageManager {
+  readonly name: PackageManagerName;
+  readonly version?: string;
+}
+
 const GITIGNORE = `.env
 logs/
 worktrees/
@@ -183,7 +190,11 @@ export const getAgent = (name: string): AgentEntry | undefined =>
 // Next steps
 // ---------------------------------------------------------------------------
 
-export function getNextStepsLines(template: string): string[] {
+export function getNextStepsLines(
+  template: string,
+  packageManager: PackageManagerName = "npm",
+): string[] {
+  const pm = packageManager;
   if (template === "blank") {
     return [
       "Next steps:",
@@ -191,18 +202,72 @@ export function getNextStepsLines(template: string): string[] {
       "2. Read and customize .sandcastle/prompt.md to describe what you want the agent to do",
       `3. Customize .sandcastle/main.ts — it uses the JS API (\`run()\`) to control how the agent runs`,
       `4. Add "sandcastle": "npx tsx .sandcastle/main.ts" to your package.json scripts`,
-      "5. Run `npm run sandcastle` to start the agent",
+      `5. Run \`${pm} run sandcastle\` to start the agent`,
     ];
   } else {
     return [
       "Next steps:",
       `1. Set the required env vars in .sandcastle/.env (see .sandcastle/.env.example)`,
       `2. Add "sandcastle": "npx tsx .sandcastle/main.ts" to your package.json scripts`,
-      '3. Templates use `copyToSandbox: ["node_modules"]` to copy your host node_modules into the sandbox for fast startup — the `npm install` in the onSandboxReady hook is a safety net for platform-specific binaries. Adjust both if you use a different package manager',
+      `3. Templates use \`copyToSandbox: ["node_modules"]\` to copy your host node_modules into the sandbox for fast startup — the \`${pm} install\` in the onSandboxReady hook is a safety net for platform-specific binaries`,
       "4. Read and customize the prompt files in .sandcastle/ — they shape what the agent does",
-      "5. Run `npm run sandcastle` to start the agent",
+      `5. Run \`${pm} run sandcastle\` to start the agent`,
     ];
   }
+}
+
+// ---------------------------------------------------------------------------
+// Package manager Dockerfile helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Dockerfile RUN instruction to install the given package manager.
+ * Returns undefined for npm (already available in the Node base image).
+ */
+function buildPackageManagerInstallLine(
+  pm: DetectedPackageManager,
+): string | undefined {
+  switch (pm.name) {
+    case "npm":
+      return undefined;
+    case "pnpm":
+    case "yarn": {
+      // Strip +sha512.xxx integrity hash from version — corepack doesn't need it
+      const version = pm.version?.replace(/\+.*$/, "");
+      const spec = version ? `${pm.name}@${version}` : `${pm.name}@latest`;
+      return `RUN corepack enable && corepack prepare ${spec} --activate`;
+    }
+    case "bun":
+      return "RUN npm install -g bun";
+  }
+}
+
+/**
+ * Insert a package-manager install line into a Dockerfile string,
+ * before the USER line so it runs as root.
+ */
+function insertPackageManagerInDockerfile(
+  dockerfile: string,
+  installLine: string,
+): string {
+  return dockerfile.replace(
+    /^(USER .*)$/m,
+    `# Install project package manager\n${installLine}\n\n$1`,
+  );
+}
+
+/**
+ * Replace npm command references in file content with the target package manager.
+ * Handles: "npm install", "npm run <script>", and comment references.
+ */
+function substitutePackageManager(
+  content: string,
+  pm: PackageManagerName,
+): string {
+  if (pm === "npm") return content;
+  return content
+    .replace(/\bnpm install\b/g, `${pm} install`)
+    .replace(/\bnpm run\b/g, `${pm} run`);
 }
 
 // ---------------------------------------------------------------------------
@@ -306,6 +371,7 @@ export interface ScaffoldOptions {
   agent: AgentEntry;
   model: string;
   templateName?: string;
+  packageManager?: DetectedPackageManager;
 }
 
 export const scaffold = (
@@ -313,7 +379,12 @@ export const scaffold = (
   options: ScaffoldOptions,
 ): Effect.Effect<void, Error, FileSystem.FileSystem> =>
   Effect.gen(function* () {
-    const { agent, model, templateName = "blank" } = options;
+    const {
+      agent,
+      model,
+      templateName = "blank",
+      packageManager = { name: "npm" as const },
+    } = options;
     const fs = yield* FileSystem.FileSystem;
     const configDir = join(repoDir, ".sandcastle");
 
@@ -334,13 +405,17 @@ export const scaffold = (
 
     const templateDir = yield* getTemplateDir(templateName);
 
+    // Build Dockerfile with optional package manager install line
+    let dockerfile = agent.dockerfileTemplate;
+    const installLine = buildPackageManagerInstallLine(packageManager);
+    if (installLine) {
+      dockerfile = insertPackageManagerInDockerfile(dockerfile, installLine);
+    }
+
     yield* Effect.all(
       [
         fs
-          .writeFileString(
-            join(configDir, "Dockerfile"),
-            agent.dockerfileTemplate,
-          )
+          .writeFileString(join(configDir, "Dockerfile"), dockerfile)
           .pipe(Effect.mapError((e) => new Error(e.message))),
         fs
           .writeFileString(join(configDir, ".gitignore"), GITIGNORE)
@@ -352,4 +427,45 @@ export const scaffold = (
 
     // Rewrite main.ts with the selected agent factory and model
     yield* rewriteMainTs(configDir, agent, model);
+
+    // Substitute package manager in all generated files
+    if (packageManager.name !== "npm") {
+      yield* rewritePackageManagerRefs(configDir, packageManager.name);
+    }
+  });
+
+/**
+ * Rewrite npm references in all .ts and .md files in the config directory.
+ */
+const rewritePackageManagerRefs = (
+  configDir: string,
+  pm: PackageManagerName,
+): Effect.Effect<void, Error, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const files = yield* fs
+      .readDirectory(configDir)
+      .pipe(Effect.mapError((e) => new Error(e.message)));
+
+    const rewritable = files.filter(
+      (f) => f.endsWith(".ts") || f.endsWith(".md"),
+    );
+
+    yield* Effect.all(
+      rewritable.map((f) =>
+        Effect.gen(function* () {
+          const path = join(configDir, f);
+          let content = yield* fs
+            .readFileString(path)
+            .pipe(Effect.mapError((e) => new Error(e.message)));
+          const updated = substitutePackageManager(content, pm);
+          if (updated !== content) {
+            yield* fs
+              .writeFileString(path, updated)
+              .pipe(Effect.mapError((e) => new Error(e.message)));
+          }
+        }),
+      ),
+      { concurrency: "unbounded" },
+    );
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import {
   getNextStepsLines,
 } from "./InitService.js";
 import { defaultImageName } from "./run.js";
+import type { PackageManagerName } from "./InitService.js";
 import {
   claudeCode,
   codex as codexFactory,
@@ -88,6 +89,15 @@ const initModelOption = Options.text("model").pipe(
   Options.optional,
 );
 
+const packageManagerOption = Options.text("package-manager").pipe(
+  Options.withDescription(
+    "Package manager to use in generated files (npm, pnpm, yarn, bun). Prompted interactively if omitted",
+  ),
+  Options.optional,
+);
+
+const VALID_PACKAGE_MANAGERS = ["npm", "pnpm", "yarn", "bun"] as const;
+
 const initCommand = Command.make(
   "init",
   {
@@ -95,12 +105,14 @@ const initCommand = Command.make(
     template: templateOption,
     agent: agentOption,
     model: initModelOption,
+    packageManager: packageManagerOption,
   },
   ({
     imageName: imageNameFlag,
     template,
     agent: agentFlag,
     model: modelFlag,
+    packageManager: packageManagerFlag,
   }) =>
     Effect.gen(function* () {
       const d = yield* Display;
@@ -202,12 +214,48 @@ const initCommand = Command.make(
         }).pipe(Effect.ignore);
       }
 
+      // Resolve package manager: CLI flag > interactive select
+      let selectedPm: PackageManagerName;
+      if (packageManagerFlag._tag === "Some") {
+        const name = packageManagerFlag.value;
+        if (
+          !VALID_PACKAGE_MANAGERS.includes(
+            name as (typeof VALID_PACKAGE_MANAGERS)[number],
+          )
+        ) {
+          yield* Effect.fail(
+            new InitError({
+              message: `Unknown package manager "${name}". Available: ${VALID_PACKAGE_MANAGERS.join(", ")}`,
+            }),
+          );
+        }
+        selectedPm = name as PackageManagerName;
+      } else {
+        const selected = yield* Effect.promise(() =>
+          clack.select({
+            message: "Select a package manager:",
+            initialValue: "npm" as const,
+            options: VALID_PACKAGE_MANAGERS.map((pm) => ({
+              value: pm,
+              label: pm,
+            })),
+          }),
+        );
+        if (clack.isCancel(selected)) {
+          yield* Effect.fail(
+            new InitError({ message: "Package manager selection cancelled." }),
+          );
+        }
+        selectedPm = selected as PackageManagerName;
+      }
+
       yield* d.spinner(
         "Scaffolding .sandcastle/ config directory...",
         scaffold(cwd, {
           agent: selectedAgent,
           model: selectedModel,
           templateName: selectedTemplate,
+          packageManager: { name: selectedPm },
         }).pipe(
           Effect.mapError(
             (e) =>
@@ -241,7 +289,7 @@ const initCommand = Command.make(
       }
 
       // Show template-specific next steps
-      const nextSteps = getNextStepsLines(selectedTemplate);
+      const nextSteps = getNextStepsLines(selectedTemplate, selectedPm);
       for (const [i, line] of nextSteps.entries()) {
         yield* d.text(i === 0 ? line : styleText("dim", line));
       }


### PR DESCRIPTION
Allow users to select npm, pnpm, yarn, or bun during `sandcastle init` via a new `--package-manager` flag or interactive prompt. Dockerfiles are patched with corepack/bun install lines, and all generated .ts/.md files have npm references rewritten to the chosen package manager.