### PR TITLE
fix: support git worktrees in Docker sandbox volume mounts

### DIFF
--- a/.changeset/fix-worktree-support.md
+++ b/.changeset/fix-worktree-support.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix Docker sandbox failing when run from a git worktree. When `.git` is a worktree file (not a directory), also mount the parent repository's `.git` directory so git can resolve the repository inside the container.

--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -11,6 +11,15 @@ vi.mock("node:child_process", () => ({
   spawn: vi.fn(),
 }));
 
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    statSync: vi.fn(actual.statSync),
+    readFileSync: vi.fn(actual.readFileSync),
+  };
+});
+
 vi.mock("./WorktreeManager.js", () => ({
   create: vi.fn(),
   remove: vi.fn(),
@@ -19,6 +28,7 @@ vi.mock("./WorktreeManager.js", () => ({
 }));
 
 import { execFile } from "node:child_process";
+import { statSync, readFileSync } from "node:fs";
 import * as WorktreeManager from "./WorktreeManager.js";
 import {
   SandboxFactory,
@@ -28,6 +38,8 @@ import {
 } from "./SandboxFactory.js";
 
 const mockExecFile = vi.mocked(execFile);
+const mockStatSync = vi.mocked(statSync);
+const mockReadFileSync = vi.mocked(readFileSync);
 const mockCreate = vi.mocked(WorktreeManager.create);
 const mockRemove = vi.mocked(WorktreeManager.remove);
 const mockPruneStale = vi.mocked(WorktreeManager.pruneStale);
@@ -82,6 +94,8 @@ describe("WorktreeDockerSandboxFactory", () => {
     mockPruneStale.mockReturnValue(Effect.void);
     // Default: clean worktree (no uncommitted changes)
     mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
+    // Default: .git is a directory (normal repo)
+    mockStatSync.mockReturnValue({ isDirectory: () => true } as any);
     mockDockerSuccess();
   });
 
@@ -556,6 +570,45 @@ describe("WorktreeDockerSandboxFactory", () => {
       );
 
       expect(receivedInfo?.hostWorktreePath).toBeUndefined();
+    });
+
+    it("mounts only one git volume when .git is a directory (normal repo)", async () => {
+      mockStatSync.mockReturnValue({ isDirectory: () => true } as any);
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const factory = yield* SandboxFactory;
+          yield* factory.withSandbox(() => Effect.void);
+        }).pipe(Effect.provide(makeNoneLayer())),
+      );
+
+      const runArgs = capturedArgs().find((args) => args[0] === "run");
+      expect(runArgs).toBeDefined();
+      // Should have exactly one git-related -v mount (the .git directory)
+      const gitMounts = runArgs!.filter((arg) => arg.includes(".git:"));
+      expect(gitMounts).toHaveLength(1);
+      expect(gitMounts[0]).toBe(`${hostRepoDir}/.git:${hostRepoDir}/.git`);
+    });
+
+    it("mounts both .git file and parent .git dir when .git is a worktree file", async () => {
+      mockStatSync.mockReturnValue({ isDirectory: () => false } as any);
+      mockReadFileSync.mockReturnValue(
+        "gitdir: /real/repo/.git/worktrees/my-worktree\n" as any,
+      );
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const factory = yield* SandboxFactory;
+          yield* factory.withSandbox(() => Effect.void);
+        }).pipe(Effect.provide(makeNoneLayer())),
+      );
+
+      const runArgs = capturedArgs().find((args) => args[0] === "run");
+      expect(runArgs).toBeDefined();
+      const gitMounts = runArgs!.filter((arg) => arg.includes(".git"));
+      // Should mount both the .git file and the parent .git directory
+      expect(gitMounts).toContain(`${hostRepoDir}/.git:${hostRepoDir}/.git`);
+      expect(gitMounts).toContain("/real/repo/.git:/real/repo/.git");
     });
   });
 

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -345,26 +345,23 @@ const startSandboxContainer = (
 };
 
 /**
- * Worktree sandbox mode: creates a git worktree and bind-mounts it into the
- * container at SANDBOX_WORKSPACE_DIR. The host's .git directory is also bind-mounted at
- * its original host path so the worktree's .git file pointer resolves correctly.
- *
- * In 'none' mode: bind-mounts the host's working directory directly into the container.
- * No worktree is created, pruned, or cleaned up.
- */
-/**
  * Resolves the git-related volume mounts needed for the Docker container.
  * Handles both normal repos (where .git is a directory) and worktrees
  * (where .git is a file pointing to the parent repo's .git/worktrees/<name>).
  */
-function resolveGitVolumeMounts(gitPath: string): string[] {
+export function resolveGitVolumeMounts(gitPath: string): string[] {
   const stat = statSync(gitPath);
   if (stat.isDirectory()) {
     return [`${gitPath}:${gitPath}`];
   }
   // Worktree: .git is a file with "gitdir: <path>"
   const content = readFileSync(gitPath, "utf-8").trim();
-  const gitdirPath = content.replace(/^gitdir:\s*/, "");
+  const match = content.match(/^gitdir:\s*(.+)$/);
+  if (!match) {
+    // Unrecognized format — fall back to mounting the file as-is
+    return [`${gitPath}:${gitPath}`];
+  }
+  const gitdirPath = match[1]!;
   // gitdirPath is like /path/to/repo/.git/worktrees/<name>
   // Mount both the .git file and the parent .git directory
   const parentGitDir = resolve(gitdirPath, "..", "..");

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -3,7 +3,8 @@ import { FileSystem } from "@effect/platform";
 import { NodeFileSystem } from "@effect/platform-node";
 import { randomUUID } from "node:crypto";
 import { execFile, execFileSync, spawn } from "node:child_process";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { statSync, readFileSync } from "node:fs";
 import { createInterface } from "node:readline";
 import {
   startContainer,
@@ -351,6 +352,24 @@ const startSandboxContainer = (
  * In 'none' mode: bind-mounts the host's working directory directly into the container.
  * No worktree is created, pruned, or cleaned up.
  */
+/**
+ * Resolves the git-related volume mounts needed for the Docker container.
+ * Handles both normal repos (where .git is a directory) and worktrees
+ * (where .git is a file pointing to the parent repo's .git/worktrees/<name>).
+ */
+function resolveGitVolumeMounts(gitPath: string): string[] {
+  const stat = statSync(gitPath);
+  if (stat.isDirectory()) {
+    return [`${gitPath}:${gitPath}`];
+  }
+  // Worktree: .git is a file with "gitdir: <path>"
+  const content = readFileSync(gitPath, "utf-8").trim();
+  const gitdirPath = content.replace(/^gitdir:\s*/, "");
+  // gitdirPath is like /path/to/repo/.git/worktrees/<name>
+  // Mount both the .git file and the parent .git directory
+  const parentGitDir = resolve(gitdirPath, "..", "..");
+  return [`${gitPath}:${gitPath}`, `${parentGitDir}:${parentGitDir}`];
+}
 export const WorktreeDockerSandboxFactory = {
   layer: Layer.effect(
     SandboxFactory,
@@ -380,10 +399,10 @@ export const WorktreeDockerSandboxFactory = {
 
           if (isNoneMode) {
             // None mode: bind-mount host directory directly, no worktree
-            const gitDir = join(hostRepoDir, ".git");
+            const gitPath = join(hostRepoDir, ".git");
             const volumeMounts = [
               `${hostRepoDir}:${SANDBOX_WORKSPACE_DIR}`,
-              `${gitDir}:${gitDir}`,
+              ...resolveGitVolumeMounts(gitPath),
             ];
             return Effect.acquireUseRelease(
               startSandboxContainer(
@@ -458,10 +477,10 @@ export const WorktreeDockerSandboxFactory = {
               )
               .pipe(
                 Effect.flatMap((worktreeInfo) => {
-                  const gitDir = join(hostRepoDir, ".git");
+                  const gitPath = join(hostRepoDir, ".git");
                   const volumeMounts = [
                     `${worktreeInfo.path}:${SANDBOX_WORKSPACE_DIR}`,
-                    `${gitDir}:${gitDir}`,
+                    ...resolveGitVolumeMounts(gitPath),
                   ];
 
                   return startSandboxContainer(

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -35,6 +35,7 @@ import {
   SandboxFactory,
   SANDBOX_WORKSPACE_DIR,
   makeDockerSandboxLayer,
+  resolveGitVolumeMounts,
 } from "./SandboxFactory.js";
 import * as WorktreeManager from "./WorktreeManager.js";
 import { copyToSandbox } from "./CopyToSandbox.js";
@@ -158,10 +159,10 @@ export const createSandbox = async (
       resolveEnv(hostRepoDir).pipe(Effect.provide(NodeContext.layer)),
     );
 
-    const gitDir = join(hostRepoDir, ".git");
+    const gitPath = join(hostRepoDir, ".git");
     const volumeMounts = [
       `${worktreePath}:${SANDBOX_WORKSPACE_DIR}`,
-      `${gitDir}:${gitDir}`,
+      ...resolveGitVolumeMounts(gitPath),
     ];
 
     const hostUid = process.getuid?.() ?? 1000;

--- a/src/resolveGitVolumeMounts.test.ts
+++ b/src/resolveGitVolumeMounts.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveGitVolumeMounts } from "./SandboxFactory.js";
+
+describe("resolveGitVolumeMounts", () => {
+  const dirs: string[] = [];
+
+  const makeTempDir = async () => {
+    const dir = await mkdtemp(join(tmpdir(), "git-mount-test-"));
+    dirs.push(dir);
+    return dir;
+  };
+
+  afterEach(async () => {
+    await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+    dirs.length = 0;
+  });
+
+  it("returns single mount when .git is a directory", async () => {
+    const repoDir = await makeTempDir();
+    const gitDir = join(repoDir, ".git");
+    await mkdir(gitDir);
+
+    const mounts = resolveGitVolumeMounts(gitDir);
+
+    expect(mounts).toEqual([`${gitDir}:${gitDir}`]);
+  });
+
+  it("returns both mounts when .git is a worktree file", async () => {
+    const parentRepoDir = await makeTempDir();
+    const parentGitDir = join(parentRepoDir, ".git");
+    await mkdir(parentGitDir);
+    await mkdir(join(parentGitDir, "worktrees", "my-worktree"), {
+      recursive: true,
+    });
+
+    const worktreeDir = await makeTempDir();
+    const gitFile = join(worktreeDir, ".git");
+    await writeFile(gitFile, `gitdir: ${parentGitDir}/worktrees/my-worktree\n`);
+
+    const mounts = resolveGitVolumeMounts(gitFile);
+
+    expect(mounts).toEqual([
+      `${gitFile}:${gitFile}`,
+      `${parentGitDir}:${parentGitDir}`,
+    ]);
+  });
+
+  it("falls back to single mount when .git file has unexpected content", async () => {
+    const dir = await makeTempDir();
+    const gitFile = join(dir, ".git");
+    await writeFile(gitFile, "something unexpected\n");
+
+    const mounts = resolveGitVolumeMounts(gitFile);
+
+    expect(mounts).toEqual([`${gitFile}:${gitFile}`]);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix Docker sandbox failing when run from inside a git worktree
- Detect worktree `.git` files and mount the parent `.git` directory into the container

## Problem

When sandcastle runs from a **git worktree** (not the main repo clone), the Docker container fails with:

```
fatal: not a git repository: /path/to/repo/.git/worktrees/<name>
```

This happens because in a worktree, `.git` is a **file** containing a `gitdir:` pointer to the parent repo's `.git/worktrees/<name>` directory. Sandcastle mounts the `.git` file into the container, but not the directory it points to — so git can't resolve the repository.

We discovered this while using [Conductor](https://www.conductor.build/), a Mac app that runs multiple coding agents in parallel. Conductor uses git worktrees to give each agent its own isolated workspace, which means sandcastle always runs from within a worktree rather than the main repo clone.

## Fix

Added a `resolveGitVolumeMounts()` helper in `SandboxFactory.ts` that:

1. Checks if `.git` is a file or directory
2. If it's a directory (normal repo): mounts it as before (no behavior change)
3. If it's a file (worktree): parses the `gitdir:` pointer, resolves the parent `.git` directory, and mounts both the `.git` file and the parent `.git` directory

Applied to both `mode: "none"` and worktree mode volume mount logic.

## Test plan

- [ ] Added tests for worktree `.git` file detection and volume mount resolution
- [ ] Verified existing tests still pass (no regression for normal repos)
- [ ] Build and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)