### PR TITLE
feat: add OpenCode agent provider

### DIFF
--- a/.changeset/opencode-provider.md
+++ b/.changeset/opencode-provider.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add OpenCode as a built-in agent provider for runtime execution, interactive sessions, and `sandcastle init` scaffolding.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A TypeScript library for orchestrating AI coding agents in isolated Docker conta
 
 Great for parallelizing multiple AFK agents, creating review pipelines, or even just orchestrating your own agents.
 
+Built-in agent providers include Claude Code, Pi, Codex, and OpenCode.
+
 ## Prerequisites
 
 - [Docker Desktop](https://www.docker.com/)
@@ -35,7 +37,7 @@ npm install @ai-hero/sandcastle
 npx sandcastle init
 ```
 
-3. Edit `.sandcastle/.env` and fill in your default values for `ANTHROPIC_API_KEY`
+3. Copy `.sandcastle/.env.example` to `.sandcastle/.env` and add any credentials your chosen agent needs. For Claude Code, fill in `ANTHROPIC_API_KEY`. The default OpenCode model, `opencode/big-pickle`, does not require extra env vars.
 
 ```bash
 cp .sandcastle/.env.example .sandcastle/.env
@@ -72,6 +74,24 @@ const result = await run({
 console.log(result.iterationsRun); // number of iterations executed
 console.log(result.commits); // array of { sha } for commits created
 console.log(result.branch); // target branch name
+```
+
+### Agent providers
+
+Sandcastle ships with four built-in agent providers:
+
+- `claudeCode("claude-opus-4-6")`
+- `pi("claude-sonnet-4-6")`
+- `codex("gpt-5.4-mini")`
+- `opencode("opencode/big-pickle")`
+
+```typescript
+import { opencode, run } from "@ai-hero/sandcastle";
+
+await run({
+  agent: opencode("opencode/big-pickle"),
+  promptFile: ".sandcastle/prompt.md",
+});
 ```
 
 ### All options
@@ -219,17 +239,17 @@ if (closeResult.preservedWorktreePath) {
 
 #### `SandboxRunOptions`
 
-| Option               | Type               | Default                       | Description                                                         |
-| -------------------- | ------------------ | ----------------------------- | ------------------------------------------------------------------- |
-| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-6")`) |
-| `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                |
-| `promptFile`         | string             | —                             | Path to prompt file (mutually exclusive with `prompt`)              |
-| `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                |
-| `maxIterations`      | number             | `1`                           | Maximum iterations to run                                           |
-| `completionSignal`   | string \| string[] | `<promise>COMPLETE</promise>` | String(s) the agent emits to stop the iteration loop early          |
-| `idleTimeoutSeconds` | number             | `600`                         | Idle timeout in seconds — resets on each agent output event         |
-| `name`               | string             | —                             | Display name for the run                                            |
-| `logging`            | object             | file (auto-generated)         | `{ type: 'file', path }` or `{ type: 'stdout' }`                    |
+| Option               | Type               | Default                       | Description                                                                                            |
+| -------------------- | ------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-6")`, `opencode("opencode/big-pickle")`) |
+| `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                                                   |
+| `promptFile`         | string             | —                             | Path to prompt file (mutually exclusive with `prompt`)                                                 |
+| `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                                                   |
+| `maxIterations`      | number             | `1`                           | Maximum iterations to run                                                                              |
+| `completionSignal`   | string \| string[] | `<promise>COMPLETE</promise>` | String(s) the agent emits to stop the iteration loop early                                             |
+| `idleTimeoutSeconds` | number             | `600`                         | Idle timeout in seconds — resets on each agent output event                                            |
+| `name`               | string             | —                             | Display name for the run                                                                               |
+| `logging`            | object             | file (auto-generated)         | `{ type: 'file', path }` or `{ type: 'stdout' }`                                                       |
 
 #### `SandboxRunResult`
 
@@ -380,7 +400,7 @@ Scaffolds the `.sandcastle/` config directory and builds the Docker image. This 
 | Option         | Required | Default                      | Description                                                          |
 | -------------- | -------- | ---------------------------- | -------------------------------------------------------------------- |
 | `--image-name` | No       | `sandcastle:<repo-dir-name>` | Docker image name                                                    |
-| `--agent`      | No       | Interactive prompt           | Agent to use (`claude-code`, `pi`, `codex`)                          |
+| `--agent`      | No       | Interactive prompt           | Agent to use (`claude-code`, `pi`, `codex`, `opencode`)              |
 | `--model`      | No       | Agent's default model        | Model to use (e.g. `claude-sonnet-4-6`). Defaults to agent's default |
 | `--template`   | No       | Interactive prompt           | Template to scaffold (e.g. `blank`, `simple-loop`)                   |
 
@@ -415,21 +435,21 @@ Removes the Docker image.
 
 ### `RunOptions`
 
-| Option               | Type               | Default                       | Description                                                                                                             |
-| -------------------- | ------------------ | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-6")`, `pi("claude-sonnet-4-6")`, `codex("gpt-5.4-mini")`) |
-| `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                                                                    |
-| `promptFile`         | string             | —                             | Path to prompt file (mutually exclusive with `prompt`)                                                                  |
-| `maxIterations`      | number             | `1`                           | Maximum iterations to run                                                                                               |
-| `hooks`              | object             | —                             | Lifecycle hooks (`onSandboxReady`)                                                                                      |
-| `worktree`           | WorktreeMode       | `{ mode: 'temp-branch' }`     | Worktree mode: `{ mode: 'none' }`, `{ mode: 'temp-branch' }`, or `{ mode: 'branch', branch }`                           |
-| `imageName`          | string             | `sandcastle:<repo-dir-name>`  | Docker image name for the sandbox                                                                                       |
-| `name`               | string             | —                             | Display name for the run, shown as a prefix in log output                                                               |
-| `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                                                                    |
-| `copyToSandbox`      | string[]           | —                             | Host-relative file paths to copy into the worktree before start (not supported with `mode: 'none'`)                     |
-| `logging`            | object             | file (auto-generated)         | `{ type: 'file', path }` or `{ type: 'stdout' }`                                                                        |
-| `completionSignal`   | string \| string[] | `<promise>COMPLETE</promise>` | String or array of strings the agent emits to stop the iteration loop early                                             |
-| `idleTimeoutSeconds` | number             | `600`                         | Idle timeout in seconds — resets on each agent output event                                                             |
+| Option               | Type               | Default                       | Description                                                                                                                                                |
+| -------------------- | ------------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-6")`, `pi("claude-sonnet-4-6")`, `codex("gpt-5.4-mini")`, `opencode("opencode/big-pickle")`) |
+| `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                                                                                                       |
+| `promptFile`         | string             | —                             | Path to prompt file (mutually exclusive with `prompt`)                                                                                                     |
+| `maxIterations`      | number             | `1`                           | Maximum iterations to run                                                                                                                                  |
+| `hooks`              | object             | —                             | Lifecycle hooks (`onSandboxReady`)                                                                                                                         |
+| `worktree`           | WorktreeMode       | `{ mode: 'temp-branch' }`     | Worktree mode: `{ mode: 'none' }`, `{ mode: 'temp-branch' }`, or `{ mode: 'branch', branch }`                                                              |
+| `imageName`          | string             | `sandcastle:<repo-dir-name>`  | Docker image name for the sandbox                                                                                                                          |
+| `name`               | string             | —                             | Display name for the run, shown as a prefix in log output                                                                                                  |
+| `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                                                                                                       |
+| `copyToSandbox`      | string[]           | —                             | Host-relative file paths to copy into the worktree before start (not supported with `mode: 'none'`)                                                        |
+| `logging`            | object             | file (auto-generated)         | `{ type: 'file', path }` or `{ type: 'stdout' }`                                                                                                           |
+| `completionSignal`   | string \| string[] | `<promise>COMPLETE</promise>` | String or array of strings the agent emits to stop the iteration loop early                                                                                |
+| `idleTimeoutSeconds` | number             | `600`                         | Idle timeout in seconds — resets on each agent output event                                                                                                |
 
 ### `RunResult`
 

--- a/docs/content/docs/agents.mdx
+++ b/docs/content/docs/agents.mdx
@@ -7,9 +7,9 @@ description: Learn about agent providers and how to configure them.
 
 An agent provider defines how Sandcastle interacts with a specific AI coding tool. Each provider declares:
 
-- An **env manifest** -- which environment variables it requires
-- An **env check** -- validation that runs before the agent starts
-- A **Dockerfile template** -- used during `sandcastle init` to scaffold the sandbox
+- A command builder for non-interactive runs
+- A command builder for interactive sessions
+- A stream parser that normalizes provider output into Sandcastle events
 
 ## Built-in Providers
 
@@ -17,13 +17,29 @@ An agent provider defines how Sandcastle interacts with a specific AI coding too
 
 The default agent provider. Uses Claude Code as the AI coding agent inside the sandbox.
 
-Required environment variables:
+### Pi
 
-| Variable | Description |
-| --- | --- |
-| `ANTHROPIC_API_KEY` | Anthropic API key |
-| `GH_TOKEN` | GitHub personal access token |
+Uses the Pi coding agent inside the sandbox.
+
+### Codex
+
+Uses the OpenAI Codex CLI inside the sandbox.
+
+### OpenCode
+
+Uses the OpenCode CLI inside the sandbox.
+
+Example:
+
+```ts
+import { opencode, run } from "@ai-hero/sandcastle";
+
+await run({
+  agent: opencode("opencode/big-pickle"),
+  promptFile: ".sandcastle/prompt.md",
+});
+```
 
 ## Custom Providers
 
-Agent providers are swappable. To add support for a different AI coding tool, create a new provider that implements the agent provider interface with its own env manifest, env check, and Dockerfile template.
+Agent providers are swappable. To add support for a different AI coding tool, create a new provider that implements the agent provider interface and translates that tool's CLI output into Sandcastle's normalized stream events.

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { claudeCode, codex, pi } from "./AgentProvider.js";
+import { claudeCode, codex, opencode, pi } from "./AgentProvider.js";
 
 describe("claudeCode factory", () => {
   it("returns a provider with name 'claude-code'", () => {
@@ -391,6 +391,104 @@ describe("codex factory", () => {
   it("bakes model into each provider instance independently", () => {
     const provider1 = codex("model-a");
     const provider2 = codex("model-b");
+    expect(provider1.buildPrintCommand("test")).toContain("model-a");
+    expect(provider2.buildPrintCommand("test")).toContain("model-b");
+    expect(provider1.buildPrintCommand("test")).not.toContain("model-b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenCode factory
+// ---------------------------------------------------------------------------
+
+describe("opencode factory", () => {
+  it("returns a provider with name 'opencode'", () => {
+    const provider = opencode("opencode/big-pickle");
+    expect(provider.name).toBe("opencode");
+  });
+
+  it("does not expose envManifest or dockerfileTemplate", () => {
+    const provider = opencode("opencode/big-pickle");
+    expect(provider).not.toHaveProperty("envManifest");
+    expect(provider).not.toHaveProperty("dockerfileTemplate");
+  });
+
+  it("buildPrintCommand includes the model and JSON format flag", () => {
+    const provider = opencode("opencode/big-pickle");
+    const command = provider.buildPrintCommand("do something");
+    expect(command).toContain("opencode/big-pickle");
+    expect(command).toContain("opencode run");
+    expect(command).toContain("--format json");
+  });
+
+  it("buildPrintCommand shell-escapes the prompt", () => {
+    const provider = opencode("opencode/big-pickle");
+    const command = provider.buildPrintCommand("it's a test");
+    expect(command).toContain("'it'\\''s a test'");
+  });
+
+  it("buildPrintCommand shell-escapes the model", () => {
+    const provider = opencode("opencode/big-pickle");
+    const command = provider.buildPrintCommand("do something");
+    expect(command).toContain("--model 'opencode/big-pickle'");
+  });
+
+  it("buildInteractiveArgs includes the binary and model", () => {
+    const provider = opencode("opencode/big-pickle");
+    const args = provider.buildInteractiveArgs("");
+    expect(args[0]).toBe("opencode");
+    expect(args).toContain("opencode/big-pickle");
+    expect(args).toContain("--model");
+  });
+
+  it("parseStreamLine extracts text from completed text events", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "text",
+      part: { type: "text", text: "Hello world" },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "text", text: "Hello world" },
+    ]);
+  });
+
+  it("parseStreamLine extracts tool calls from OpenCode tool events", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: {
+        tool: "bash",
+        state: { input: { command: "npm test" } },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "Bash", args: "npm test" },
+    ]);
+  });
+
+  it("parseStreamLine maps task tool calls to Agent", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: {
+        tool: "task",
+        state: { input: { description: "Inspect codebase" } },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "Agent", args: "Inspect codebase" },
+    ]);
+  });
+
+  it("parseStreamLine returns empty array for non-JSON lines", () => {
+    const provider = opencode("opencode/big-pickle");
+    expect(provider.parseStreamLine("not json")).toEqual([]);
+    expect(provider.parseStreamLine("")).toEqual([]);
+  });
+
+  it("bakes model into each provider instance independently", () => {
+    const provider1 = opencode("model-a");
+    const provider2 = opencode("model-b");
     expect(provider1.buildPrintCommand("test")).toContain("model-a");
     expect(provider2.buildPrintCommand("test")).toContain("model-b");
     expect(provider1.buildPrintCommand("test")).not.toContain("model-b");

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -101,6 +101,7 @@ const parseStreamJsonLine = (line: string): ParsedStreamEvent[] => {
 
 export interface AgentProvider {
   readonly name: string;
+  readonly resultStrategy?: "stdout" | "streamed-text";
   buildPrintCommand(prompt: string): string;
   buildInteractiveArgs(prompt: string): string[];
   parseStreamLine(line: string): ParsedStreamEvent[];
@@ -247,5 +248,66 @@ export const claudeCode = (model: string): AgentProvider => ({
 
   parseStreamLine(line: string): ParsedStreamEvent[] {
     return parseStreamJsonLine(line);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// OpenCode agent provider
+// ---------------------------------------------------------------------------
+
+const OPENCODE_TOOL_NAMES: Record<string, string> = {
+  bash: "Bash",
+  webfetch: "WebFetch",
+  websearch: "WebSearch",
+  task: "Agent",
+};
+
+const parseOpenCodeStreamLine = (line: string): ParsedStreamEvent[] => {
+  if (!line.startsWith("{")) return [];
+  try {
+    const obj = JSON.parse(line);
+
+    if (
+      obj.type === "text" &&
+      obj.part?.type === "text" &&
+      typeof obj.part.text === "string"
+    ) {
+      return [{ type: "text", text: obj.part.text }];
+    }
+
+    if (obj.type === "tool_use") {
+      const toolName = obj.part?.tool;
+      if (typeof toolName !== "string") return [];
+      const displayName = OPENCODE_TOOL_NAMES[toolName] ?? toolName;
+      const argField = TOOL_ARG_FIELDS[displayName];
+      if (argField === undefined) return [];
+      const input = obj.part?.state?.input as
+        | Record<string, unknown>
+        | undefined;
+      if (!input) return [];
+      const argValue = input[argField];
+      if (typeof argValue !== "string") return [];
+      return [{ type: "tool_call", name: displayName, args: argValue }];
+    }
+  } catch {
+    // Not valid JSON — skip
+  }
+  return [];
+};
+
+export const opencode = (model: string): AgentProvider => ({
+  name: "opencode",
+  resultStrategy: "streamed-text",
+
+  buildPrintCommand(prompt: string): string {
+    return `opencode run --format json --model ${shellEscape(model)} ${shellEscape(prompt)}`;
+  },
+
+  buildInteractiveArgs(_prompt: string): string[] {
+    return ["opencode", "--model", model];
+  },
+
+  parseStreamLine(line: string): ParsedStreamEvent[] {
+    return parseOpenCodeStreamLine(line);
   },
 });

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -20,6 +20,7 @@ const makeDir = () => mkdtemp(join(tmpdir(), "init-service-"));
 const claudeCodeAgent = getAgent("claude-code")!;
 const piAgent = getAgent("pi")!;
 const codexAgent = getAgent("codex")!;
+const opencodeAgent = getAgent("opencode")!;
 
 const defaultOptions: ScaffoldOptions = {
   agent: claudeCodeAgent,
@@ -86,6 +87,21 @@ describe("Agent registry", () => {
     expect(agent!.factoryImport).toBe("codex");
     expect(agent!.dockerfileTemplate).toContain("FROM");
     expect(agent!.dockerfileTemplate).toContain("@openai/codex");
+  });
+
+  it("listAgents includes opencode", () => {
+    const agents = listAgents();
+    expect(agents.some((a) => a.name === "opencode")).toBe(true);
+  });
+
+  it("getAgent returns opencode entry with expected fields", () => {
+    const agent = getAgent("opencode");
+    expect(agent).toBeDefined();
+    expect(agent!.name).toBe("opencode");
+    expect(agent!.defaultModel).toBe("opencode/big-pickle");
+    expect(agent!.factoryImport).toBe("opencode");
+    expect(agent!.dockerfileTemplate).toContain("FROM");
+    expect(agent!.dockerfileTemplate).toContain("opencode-ai@latest");
   });
 });
 
@@ -548,6 +564,37 @@ describe("InitService scaffold", () => {
       "utf-8",
     );
     expect(mainTs).toContain('codex("gpt-5.4-mini")');
+    expect(mainTs).not.toContain("claudeCode");
+  });
+
+  it("scaffolds opencode agent with OpenCode Dockerfile", async () => {
+    const dir = await makeDir();
+    await runScaffold(dir, {
+      agent: opencodeAgent,
+      model: "opencode/big-pickle",
+    });
+
+    const dockerfile = await readFile(
+      join(dir, ".sandcastle", "Dockerfile"),
+      "utf-8",
+    );
+    expect(dockerfile).toBe(opencodeAgent.dockerfileTemplate);
+    expect(dockerfile).toContain("opencode-ai@latest");
+    expect(dockerfile).toContain("apt-get install -y \\");
+  });
+
+  it("scaffolds main.mts with OpenCode factory import when OpenCode agent selected", async () => {
+    const dir = await makeDir();
+    await runScaffold(dir, {
+      agent: opencodeAgent,
+      model: "opencode/big-pickle",
+    });
+
+    const mainTs = await readFile(
+      join(dir, ".sandcastle", "main.mts"),
+      "utf-8",
+    );
+    expect(mainTs).toContain('opencode("opencode/big-pickle")');
     expect(mainTs).not.toContain("claudeCode");
   });
 

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -150,6 +150,39 @@ WORKDIR /home/agent
 ENTRYPOINT ["sleep", "infinity"]
 `;
 
+const OPENCODE_DOCKERFILE = `FROM node:22-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \\
+  git \\
+  curl \\
+  jq \\
+  && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \\
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \\
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \\
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \\
+  && apt-get update && apt-get install -y gh \\
+  && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user
+RUN useradd -m -s /bin/bash agent
+
+# Install OpenCode CLI (run as root before USER agent)
+RUN npm install -g opencode-ai@latest
+
+USER agent
+
+WORKDIR /home/agent
+
+# In worktree sandbox mode, Sandcastle bind-mounts the git worktree at ${SANDBOX_WORKSPACE_DIR}
+# and overrides the working directory to ${SANDBOX_WORKSPACE_DIR} at container start.
+# Structure your Dockerfile so that ${SANDBOX_WORKSPACE_DIR} can serve as the project root.
+ENTRYPOINT ["sleep", "infinity"]
+`;
+
 const AGENT_REGISTRY: AgentEntry[] = [
   {
     name: "claude-code",
@@ -171,6 +204,13 @@ const AGENT_REGISTRY: AgentEntry[] = [
     defaultModel: "gpt-5.4-mini",
     factoryImport: "codex",
     dockerfileTemplate: CODEX_DOCKERFILE,
+  },
+  {
+    name: "opencode",
+    label: "OpenCode",
+    defaultModel: "opencode/big-pickle",
+    factoryImport: "opencode",
+    dockerfileTemplate: OPENCODE_DOCKERFILE,
   },
 ];
 

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -13,6 +13,7 @@ import { orchestrate } from "./Orchestrator.js";
 import {
   claudeCode,
   codex as codexFactory,
+  opencode as opencodeFactory,
   pi as piFactory,
   DEFAULT_MODEL,
 } from "./AgentProvider.js";
@@ -2651,5 +2652,181 @@ describe("Orchestrator with codex provider", () => {
 
     expect(result.iterationsRun).toBe(1);
     expect(result.completionSignal).toBe("<promise>COMPLETE</promise>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenCode provider integration tests
+// ---------------------------------------------------------------------------
+
+const opencodeTestProvider = opencodeFactory("opencode/big-pickle");
+
+/** Format mock agent output as OpenCode JSON stream lines */
+const toOpenCodeStreamJson = (output: string | string[]): string => {
+  const chunks = Array.isArray(output) ? output : [output];
+  return chunks
+    .map((chunk) =>
+      JSON.stringify({
+        type: "text",
+        part: { type: "text", text: chunk },
+      }),
+    )
+    .join("\n");
+};
+
+/**
+ * Create a mock sandbox layer that intercepts `opencode` commands
+ * and runs a mock script instead.
+ */
+const makeMockOpenCodeAgentLayer = (
+  sandboxDir: string,
+  mockAgentBehavior: (sandboxRepoDir: string) => Promise<string | string[]>,
+): Layer.Layer<Sandbox> => {
+  const fsLayer = makeLocalSandboxLayer(sandboxDir);
+
+  return Layer.succeed(Sandbox, {
+    exec: (command, options) => {
+      if (command.startsWith("opencode ")) {
+        return Effect.gen(function* () {
+          const cwd = options?.cwd ?? sandboxDir;
+          const output = yield* Effect.promise(() => mockAgentBehavior(cwd));
+          const stdout: string = Array.isArray(output)
+            ? output.join("")
+            : output;
+          return {
+            stdout,
+            stderr: "",
+            exitCode: 0,
+          };
+        });
+      }
+      return Effect.flatMap(Sandbox, (real) =>
+        real.exec(command, options),
+      ).pipe(Effect.provide(fsLayer));
+    },
+    execStreaming: (command, onStdoutLine, options) => {
+      if (command.startsWith("opencode ")) {
+        return Effect.gen(function* () {
+          const cwd = options?.cwd ?? sandboxDir;
+          const output = yield* Effect.promise(() => mockAgentBehavior(cwd));
+          const streamOutput = toOpenCodeStreamJson(output);
+          for (const line of streamOutput.split("\n")) {
+            onStdoutLine(line);
+          }
+          return { stdout: streamOutput, stderr: "", exitCode: 0 };
+        });
+      }
+      return Effect.flatMap(Sandbox, (real) =>
+        real.execStreaming(command, onStdoutLine, options),
+      ).pipe(Effect.provide(fsLayer));
+    },
+    copyIn: (hostPath, sandboxPath) =>
+      Effect.flatMap(Sandbox, (real) =>
+        real.copyIn(hostPath, sandboxPath),
+      ).pipe(Effect.provide(fsLayer)),
+    copyOut: (sandboxPath, hostPath) =>
+      Effect.flatMap(Sandbox, (real) =>
+        real.copyOut(sandboxPath, hostPath),
+      ).pipe(Effect.provide(fsLayer)),
+  });
+};
+
+describe("Orchestrator with opencode provider", () => {
+  it("runs a single iteration with opencode provider and produces a commit", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-opencode-host-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
+      hostDir,
+      (dir) =>
+        makeMockOpenCodeAgentLayer(dir, async (repoDir) => {
+          await writeFile(
+            join(repoDir, "opencode-output.txt"),
+            "opencode was here",
+          );
+          await execAsync("git add -A", { cwd: repoDir });
+          await execAsync('git config user.email "agent@test.com"', {
+            cwd: repoDir,
+          });
+          await execAsync('git config user.name "Agent"', { cwd: repoDir });
+          await execAsync('git commit -m "RALPH: opencode agent commit"', {
+            cwd: repoDir,
+          });
+          return "Done with iteration.";
+        }),
+    );
+
+    const result = await Effect.runPromise(
+      orchestrate({
+        provider: opencodeTestProvider,
+        hostRepoDir: hostDir,
+        sandboxRepoDir,
+        iterations: 1,
+        prompt: "do some work",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(result.iterationsRun).toBe(1);
+    const content = await readFile(
+      join(hostDir, "opencode-output.txt"),
+      "utf-8",
+    );
+    expect(content).toBe("opencode was here");
+  });
+
+  it("stops early on completion signal with opencode provider", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-opencode-host-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
+      hostDir,
+      (dir) =>
+        makeMockOpenCodeAgentLayer(dir, async () => {
+          return "All done. <promise>COMPLETE</promise>";
+        }),
+    );
+
+    const result = await Effect.runPromise(
+      orchestrate({
+        provider: opencodeTestProvider,
+        hostRepoDir: hostDir,
+        sandboxRepoDir,
+        iterations: 5,
+        prompt: "do some work",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(result.iterationsRun).toBe(1);
+    expect(result.completionSignal).toBe("<promise>COMPLETE</promise>");
+  });
+
+  it("concatenates multi-part OpenCode text output before checking completion", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-opencode-host-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
+      hostDir,
+      (dir) =>
+        makeMockOpenCodeAgentLayer(dir, async () => {
+          return ["All done. <promise>", "COMPLETE</promise>"];
+        }),
+    );
+
+    const result = await Effect.runPromise(
+      orchestrate({
+        provider: opencodeTestProvider,
+        hostRepoDir: hostDir,
+        sandboxRepoDir,
+        iterations: 5,
+        prompt: "do some work",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(result.iterationsRun).toBe(1);
+    expect(result.completionSignal).toBe("<promise>COMPLETE</promise>");
+    expect(result.stdout).toBe("All done. <promise>COMPLETE</promise>");
   });
 });

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -26,6 +26,7 @@ const invokeAgent = (
 ): Effect.Effect<{ result: string; usage: TokenUsage | null }, SandboxError> =>
   Effect.gen(function* () {
     let resultText = "";
+    let streamedText = "";
     let tokenUsage: TokenUsage | null = null;
 
     // Deferred that will be failed when the idle timer fires
@@ -71,6 +72,7 @@ const invokeAgent = (
         (line) => {
           for (const parsed of provider.parseStreamLine(line)) {
             if (parsed.type === "text") {
+              streamedText += parsed.text;
               resetIdleTimer();
               onText(parsed.text);
             } else if (parsed.type === "result") {
@@ -93,7 +95,12 @@ const invokeAgent = (
         );
       }
 
-      return { result: resultText || execResult.stdout, usage: tokenUsage };
+      const fallbackResult =
+        provider.resultStrategy === "streamed-text"
+          ? streamedText || execResult.stdout
+          : execResult.stdout;
+
+      return { result: resultText || fallbackResult, usage: tokenUsage };
     }).pipe(
       Effect.ensuring(
         Effect.sync(() => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import { defaultImageName } from "./run.js";
 import {
   claudeCode,
   codex as codexFactory,
+  opencode as opencodeFactory,
   pi as piFactory,
   DEFAULT_MODEL,
   type AgentProvider,
@@ -320,6 +321,10 @@ const AGENT_REGISTRY: Record<
   "claude-code": { factory: claudeCode, defaultModel: DEFAULT_MODEL },
   pi: { factory: piFactory, defaultModel: "claude-sonnet-4-6" },
   codex: { factory: codexFactory, defaultModel: "gpt-5.4-mini" },
+  opencode: {
+    factory: opencodeFactory,
+    defaultModel: "opencode/big-pickle",
+  },
 };
 
 const interactiveAgentOption = Options.text("agent").pipe(

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,5 +14,5 @@ export type {
   CloseResult,
 } from "./createSandbox.js";
 export type { PromptArgs } from "./PromptArgumentSubstitution.js";
-export { claudeCode, codex, pi } from "./AgentProvider.js";
+export { claudeCode, codex, opencode, pi } from "./AgentProvider.js";
 export type { AgentProvider } from "./AgentProvider.js";


### PR DESCRIPTION
## Summary
- add OpenCode as a built-in Sandcastle provider across the public API, interactive CLI selection, and `sandcastle init` scaffolding
- normalize OpenCode JSON stream output, including multi-part text aggregation so completion signals and final stdout work correctly
- add provider coverage, init/orchestrator tests, docs updates, and a changeset for the new provider

Closes #233.

## Testing
- `npm test -- src/AgentProvider.test.ts src/InitService.test.ts src/Orchestrator.test.ts`
- `npm run typecheck`

## Notes
- `npm test` still has two unrelated local failures in `src/PromptPreprocessor.test.ts` and `src/WorktreeManager.test.ts`