### PR TITLE
Add Codex ChatGPT Subscription Option

### DIFF
--- a/.changeset/codex-chatgpt-auth.md
+++ b/.changeset/codex-chatgpt-auth.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add ChatGPT subscription auth for Codex agent. Users can now authenticate via `codex login` instead of an API key by passing `{ provider: "chatgpt" }` to the `codex()` factory. `sandcastle init` prompts for the auth type when Codex is selected.

--- a/README.md
+++ b/README.md
@@ -518,8 +518,7 @@ Or configure it manually by passing `{ provider: "chatgpt" }` to the `codex()` f
 
 When `provider: "chatgpt"` is set:
 
-- Sandcastle mounts `~/.codex/` from the host into the container at `/home/agent/.codex/`, so the Codex CLI inside the sandbox can use your credentials.
-- The CLI is invoked with `-c model_provider="chatgpt"` to route requests through your ChatGPT subscription.
+- Sandcastle mounts `~/.codex/` from the host into the container at `/home/agent/.codex/`, so the Codex CLI inside the sandbox can use your file-based credentials automatically.
 - No `OPENAI_API_KEY` environment variable is needed.
 
 If `~/.codex/auth.json` is missing on the host, Sandcastle fails immediately with an error asking you to run `codex login`.

--- a/README.md
+++ b/README.md
@@ -415,21 +415,21 @@ Removes the Docker image.
 
 ### `RunOptions`
 
-| Option               | Type               | Default                       | Description                                                                                                             |
-| -------------------- | ------------------ | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-6")`, `pi("claude-sonnet-4-6")`, `codex("gpt-5.4-mini")`) |
-| `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                                                                    |
-| `promptFile`         | string             | —                             | Path to prompt file (mutually exclusive with `prompt`)                                                                  |
-| `maxIterations`      | number             | `1`                           | Maximum iterations to run                                                                                               |
-| `hooks`              | object             | —                             | Lifecycle hooks (`onSandboxReady`)                                                                                      |
-| `worktree`           | WorktreeMode       | `{ mode: 'temp-branch' }`     | Worktree mode: `{ mode: 'none' }`, `{ mode: 'temp-branch' }`, or `{ mode: 'branch', branch }`                           |
-| `imageName`          | string             | `sandcastle:<repo-dir-name>`  | Docker image name for the sandbox                                                                                       |
-| `name`               | string             | —                             | Display name for the run, shown as a prefix in log output                                                               |
-| `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                                                                    |
-| `copyToSandbox`      | string[]           | —                             | Host-relative file paths to copy into the worktree before start (not supported with `mode: 'none'`)                     |
-| `logging`            | object             | file (auto-generated)         | `{ type: 'file', path }` or `{ type: 'stdout' }`                                                                        |
-| `completionSignal`   | string \| string[] | `<promise>COMPLETE</promise>` | String or array of strings the agent emits to stop the iteration loop early                                             |
-| `idleTimeoutSeconds` | number             | `600`                         | Idle timeout in seconds — resets on each agent output event                                                             |
+| Option               | Type               | Default                       | Description                                                                                                                                                               |
+| -------------------- | ------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-6")`, `pi("claude-sonnet-4-6")`, `codex("gpt-5.4-mini")`, `codex("gpt-5.4-mini", { provider: "chatgpt" })`) |
+| `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                                                                                                                      |
+| `promptFile`         | string             | —                             | Path to prompt file (mutually exclusive with `prompt`)                                                                                                                    |
+| `maxIterations`      | number             | `1`                           | Maximum iterations to run                                                                                                                                                 |
+| `hooks`              | object             | —                             | Lifecycle hooks (`onSandboxReady`)                                                                                                                                        |
+| `worktree`           | WorktreeMode       | `{ mode: 'temp-branch' }`     | Worktree mode: `{ mode: 'none' }`, `{ mode: 'temp-branch' }`, or `{ mode: 'branch', branch }`                                                                             |
+| `imageName`          | string             | `sandcastle:<repo-dir-name>`  | Docker image name for the sandbox                                                                                                                                         |
+| `name`               | string             | —                             | Display name for the run, shown as a prefix in log output                                                                                                                 |
+| `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                                                                                                                      |
+| `copyToSandbox`      | string[]           | —                             | Host-relative file paths to copy into the worktree before start (not supported with `mode: 'none'`)                                                                       |
+| `logging`            | object             | file (auto-generated)         | `{ type: 'file', path }` or `{ type: 'stdout' }`                                                                                                                          |
+| `completionSignal`   | string \| string[] | `<promise>COMPLETE</promise>` | String or array of strings the agent emits to stop the iteration loop early                                                                                               |
+| `idleTimeoutSeconds` | number             | `600`                         | Idle timeout in seconds — resets on each agent output event                                                                                                               |
 
 ### `RunResult`
 
@@ -489,6 +489,40 @@ await run({
   // ...
 });
 ```
+
+### Codex with ChatGPT subscription
+
+You can use the [Codex CLI](https://github.com/openai/codex) with a ChatGPT subscription instead of an OpenAI API key. This uses file-based credentials managed by `codex login`.
+
+#### Prerequisites
+
+1. Install the Codex CLI on your **host** machine: `npm install -g @openai/codex`
+2. Run `codex login` on the host and complete the authentication flow. This creates `~/.codex/auth.json`.
+
+#### Setup
+
+During `sandcastle init`, select **Codex** as the agent and then **ChatGPT subscription** as the auth type. This scaffolds a `main.ts` that uses the ChatGPT provider:
+
+```typescript
+import { run, codex } from "@ai-hero/sandcastle";
+
+await run({
+  agent: codex("gpt-5.4-mini", { provider: "chatgpt" }),
+  promptFile: ".sandcastle/prompt.md",
+});
+```
+
+Or configure it manually by passing `{ provider: "chatgpt" }` to the `codex()` factory.
+
+#### How it works
+
+When `provider: "chatgpt"` is set:
+
+- Sandcastle mounts `~/.codex/` from the host into the container at `/home/agent/.codex/`, so the Codex CLI inside the sandbox can use your credentials.
+- The CLI is invoked with `-c model_provider="chatgpt"` to route requests through your ChatGPT subscription.
+- No `OPENAI_API_KEY` environment variable is needed.
+
+If `~/.codex/auth.json` is missing on the host, Sandcastle fails immediately with an error asking you to run `codex login`.
 
 ## Development
 

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1,3 +1,4 @@
+import { homedir } from "node:os";
 import { describe, expect, it } from "vitest";
 import { claudeCode, codex, pi } from "./AgentProvider.js";
 
@@ -394,5 +395,98 @@ describe("codex factory", () => {
     expect(provider1.buildPrintCommand("test")).toContain("model-a");
     expect(provider2.buildPrintCommand("test")).toContain("model-b");
     expect(provider1.buildPrintCommand("test")).not.toContain("model-b");
+  });
+
+  it("has no hostMounts without options", () => {
+    const provider = codex("gpt-5.4-mini");
+    expect(provider.hostMounts).toBeUndefined();
+  });
+
+  it("has no hostMounts with empty options", () => {
+    const provider = codex("gpt-5.4-mini", {});
+    expect(provider.hostMounts).toBeUndefined();
+  });
+
+  it("buildPrintCommand does not include -c flag without options", () => {
+    const provider = codex("gpt-5.4-mini");
+    const command = provider.buildPrintCommand("do something");
+    expect(command).not.toContain("-c");
+    expect(command).not.toContain("model_provider");
+  });
+
+  it("buildInteractiveArgs does not include -c flag without options", () => {
+    const provider = codex("gpt-5.4-mini");
+    const args = provider.buildInteractiveArgs("");
+    expect(args).not.toContain("-c");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// codex factory with ChatGPT provider
+// ---------------------------------------------------------------------------
+
+describe("codex factory with { provider: 'chatgpt' }", () => {
+  it("returns a provider with name 'codex'", () => {
+    const provider = codex("gpt-5.4-mini", { provider: "chatgpt" });
+    expect(provider.name).toBe("codex");
+  });
+
+  it("populates hostMounts with ~/.codex mount", () => {
+    const provider = codex("gpt-5.4-mini", { provider: "chatgpt" });
+    expect(provider.hostMounts).toEqual([
+      `${homedir()}/.codex:/home/agent/.codex:ro`,
+    ]);
+  });
+
+  it("buildPrintCommand includes -c model_provider flag", () => {
+    const provider = codex("gpt-5.4-mini", { provider: "chatgpt" });
+    const command = provider.buildPrintCommand("do something");
+    expect(command).toContain("-c model_provider='chatgpt'");
+    expect(command).toContain("--json");
+    expect(command).toContain("-m 'gpt-5.4-mini'");
+  });
+
+  it("buildPrintCommand shell-escapes the prompt", () => {
+    const provider = codex("gpt-5.4-mini", { provider: "chatgpt" });
+    const command = provider.buildPrintCommand("it's a test");
+    expect(command).toContain("'it'\\''s a test'");
+  });
+
+  it("buildInteractiveArgs includes -c model_provider flag", () => {
+    const provider = codex("gpt-5.4-mini", { provider: "chatgpt" });
+    const args = provider.buildInteractiveArgs("");
+    expect(args[0]).toBe("codex");
+    expect(args).toContain("-c");
+    expect(args).toContain("model_provider=chatgpt");
+    expect(args).toContain("--model");
+    expect(args).toContain("gpt-5.4-mini");
+  });
+
+  it("parseStreamLine still works for ChatGPT-configured provider", () => {
+    const provider = codex("gpt-5.4-mini", { provider: "chatgpt" });
+    const line = JSON.stringify({
+      type: "item.completed",
+      item: { type: "agent_message", content: "Hello world" },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "text", text: "Hello world" },
+      { type: "result", result: "Hello world", usage: null },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hostMounts across providers
+// ---------------------------------------------------------------------------
+
+describe("hostMounts across providers", () => {
+  it("claudeCode has no hostMounts", () => {
+    const provider = claudeCode("claude-opus-4-6");
+    expect(provider.hostMounts).toBeUndefined();
+  });
+
+  it("pi has no hostMounts", () => {
+    const provider = pi("claude-sonnet-4-6");
+    expect(provider.hostMounts).toBeUndefined();
   });
 });

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -434,7 +434,7 @@ describe("codex factory with { provider: 'chatgpt' }", () => {
   it("populates hostMounts with ~/.codex mount", () => {
     const provider = codex("gpt-5.4-mini", { provider: "chatgpt" });
     expect(provider.hostMounts).toEqual([
-      `${homedir()}/.codex:/home/agent/.codex:ro`,
+      `${homedir()}/.codex:/home/agent/.codex`,
     ]);
   });
 

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -438,10 +438,11 @@ describe("codex factory with { provider: 'chatgpt' }", () => {
     ]);
   });
 
-  it("buildPrintCommand includes -c model_provider flag", () => {
+  it("buildPrintCommand does not include -c model_provider flag", () => {
     const provider = codex("gpt-5.4-mini", { provider: "chatgpt" });
     const command = provider.buildPrintCommand("do something");
-    expect(command).toContain("-c model_provider='chatgpt'");
+    expect(command).not.toContain("-c");
+    expect(command).not.toContain("model_provider");
     expect(command).toContain("--json");
     expect(command).toContain("-m 'gpt-5.4-mini'");
   });
@@ -452,12 +453,12 @@ describe("codex factory with { provider: 'chatgpt' }", () => {
     expect(command).toContain("'it'\\''s a test'");
   });
 
-  it("buildInteractiveArgs includes -c model_provider flag", () => {
+  it("buildInteractiveArgs does not include -c model_provider flag", () => {
     const provider = codex("gpt-5.4-mini", { provider: "chatgpt" });
     const args = provider.buildInteractiveArgs("");
     expect(args[0]).toBe("codex");
-    expect(args).toContain("-c");
-    expect(args).toContain("model_provider=chatgpt");
+    expect(args).not.toContain("-c");
+    expect(args).not.toContain("model_provider=chatgpt");
     expect(args).toContain("--model");
     expect(args).toContain("gpt-5.4-mini");
   });

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+
 export interface TokenUsage {
   readonly input_tokens: number;
   readonly output_tokens: number;
@@ -101,6 +103,7 @@ const parseStreamJsonLine = (line: string): ParsedStreamEvent[] => {
 
 export interface AgentProvider {
   readonly name: string;
+  readonly hostMounts?: readonly string[];
   buildPrintCommand(prompt: string): string;
   buildInteractiveArgs(prompt: string): string[];
   parseStreamLine(line: string): ParsedStreamEvent[];
@@ -214,21 +217,38 @@ const parseCodexStreamLine = (line: string): ParsedStreamEvent[] => {
   return [];
 };
 
-export const codex = (model: string): AgentProvider => ({
-  name: "codex",
+export interface CodexOptions {
+  readonly provider?: "chatgpt";
+}
 
-  buildPrintCommand(prompt: string): string {
-    return `codex exec --json --dangerously-bypass-approvals-and-sandbox -m ${shellEscape(model)} ${shellEscape(prompt)}`;
-  },
+export const codex = (model: string, options?: CodexOptions): AgentProvider => {
+  const isChatGPT = options?.provider === "chatgpt";
+  const configFlag = isChatGPT
+    ? `-c model_provider=${shellEscape("chatgpt")} `
+    : "";
 
-  buildInteractiveArgs(_prompt: string): string[] {
-    return ["codex", "--model", model];
-  },
+  return {
+    name: "codex",
 
-  parseStreamLine(line: string): ParsedStreamEvent[] {
-    return parseCodexStreamLine(line);
-  },
-});
+    hostMounts: isChatGPT
+      ? [`${homedir()}/.codex:/home/agent/.codex:ro`]
+      : undefined,
+
+    buildPrintCommand(prompt: string): string {
+      return `codex exec ${configFlag}--json --dangerously-bypass-approvals-and-sandbox -m ${shellEscape(model)} ${shellEscape(prompt)}`;
+    },
+
+    buildInteractiveArgs(_prompt: string): string[] {
+      return isChatGPT
+        ? ["codex", "-c", "model_provider=chatgpt", "--model", model]
+        : ["codex", "--model", model];
+    },
+
+    parseStreamLine(line: string): ParsedStreamEvent[] {
+      return parseCodexStreamLine(line);
+    },
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Claude Code agent provider

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -231,7 +231,7 @@ export const codex = (model: string, options?: CodexOptions): AgentProvider => {
     name: "codex",
 
     hostMounts: isChatGPT
-      ? [`${homedir()}/.codex:/home/agent/.codex:ro`]
+      ? [`${homedir()}/.codex:/home/agent/.codex`]
       : undefined,
 
     buildPrintCommand(prompt: string): string {

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -223,9 +223,6 @@ export interface CodexOptions {
 
 export const codex = (model: string, options?: CodexOptions): AgentProvider => {
   const isChatGPT = options?.provider === "chatgpt";
-  const configFlag = isChatGPT
-    ? `-c model_provider=${shellEscape("chatgpt")} `
-    : "";
 
   return {
     name: "codex",
@@ -235,13 +232,11 @@ export const codex = (model: string, options?: CodexOptions): AgentProvider => {
       : undefined,
 
     buildPrintCommand(prompt: string): string {
-      return `codex exec ${configFlag}--json --dangerously-bypass-approvals-and-sandbox -m ${shellEscape(model)} ${shellEscape(prompt)}`;
+      return `codex exec --json --dangerously-bypass-approvals-and-sandbox -m ${shellEscape(model)} ${shellEscape(prompt)}`;
     },
 
     buildInteractiveArgs(_prompt: string): string[] {
-      return isChatGPT
-        ? ["codex", "-c", "model_provider=chatgpt", "--model", model]
-        : ["codex", "--model", model];
+      return ["codex", "--model", model];
     },
 
     parseStreamLine(line: string): ParsedStreamEvent[] {

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -117,13 +117,31 @@ export const startContainer = (
  * Fix ownership of a directory inside the container.
  * Runs as root so the target owner can write to the path.
  * @param owner - chown-compatible owner spec, e.g. "1000:1000" or "agent"
+ * @param excludePaths - paths to skip (e.g. bind-mounted dirs that can't be chowned)
  */
 export const chownInContainer = (
   containerName: string,
   owner: string,
   path: string,
-): Effect.Effect<void, DockerError> =>
-  Effect.asVoid(
+  excludePaths?: readonly string[],
+): Effect.Effect<void, DockerError> => {
+  if (excludePaths && excludePaths.length > 0) {
+    const pruneArgs = excludePaths
+      .flatMap((p) => ["-path", p, "-prune", "-o"])
+      .join(" ");
+    return Effect.asVoid(
+      dockerExec([
+        "exec",
+        "-u",
+        "root",
+        containerName,
+        "sh",
+        "-c",
+        `find ${path} ${pruneArgs} -exec chown ${owner} {} +`,
+      ]),
+    );
+  }
+  return Effect.asVoid(
     dockerExec([
       "exec",
       "-u",
@@ -135,6 +153,7 @@ export const chownInContainer = (
       path,
     ]),
   );
+};
 
 /**
  * Stop and remove a container without removing the image.

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -551,6 +551,126 @@ describe("InitService scaffold", () => {
     expect(mainTs).not.toContain("claudeCode");
   });
 
+  // --- Codex ChatGPT provider scaffolding ---
+
+  describe("codex ChatGPT provider", () => {
+    it("scaffolds main.mts with { provider: 'chatgpt' } in codex factory call", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        agent: codexAgent,
+        model: "gpt-5.4-mini",
+        codexProvider: "chatgpt",
+      });
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain(
+        'codex("gpt-5.4-mini", { provider: "chatgpt" })',
+      );
+      expect(mainTs).not.toContain("claudeCode");
+    });
+
+    it("generates .env.example without API key and with ChatGPT auth comment", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        agent: codexAgent,
+        model: "gpt-5.4-mini",
+        codexProvider: "chatgpt",
+      });
+
+      const envExample = await readFile(
+        join(dir, ".sandcastle", ".env.example"),
+        "utf-8",
+      );
+      expect(envExample).not.toContain("ANTHROPIC_API_KEY");
+      expect(envExample).not.toContain("OPENAI_API_KEY");
+      expect(envExample).toContain("codex login");
+      expect(envExample).toContain("GH_TOKEN=");
+    });
+
+    it("works with non-blank templates", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        agent: codexAgent,
+        model: "gpt-5.4-mini",
+        codexProvider: "chatgpt",
+        templateName: "simple-loop",
+      });
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain(
+        'codex("gpt-5.4-mini", { provider: "chatgpt" })',
+      );
+
+      const envExample = await readFile(
+        join(dir, ".sandcastle", ".env.example"),
+        "utf-8",
+      );
+      expect(envExample).not.toContain("ANTHROPIC_API_KEY");
+      expect(envExample).toContain("codex login");
+    });
+
+    it("works with main.ts (ESM module project)", async () => {
+      const dir = await makeDir();
+      await writeFile(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "test", type: "module" }),
+      );
+      await runScaffold(dir, {
+        agent: codexAgent,
+        model: "gpt-5.4-mini",
+        codexProvider: "chatgpt",
+      });
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.ts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain(
+        'codex("gpt-5.4-mini", { provider: "chatgpt" })',
+      );
+      expect(mainTs).not.toContain("claudeCode");
+    });
+  });
+
+  describe("codex API key (no codexProvider)", () => {
+    it("scaffolds main.mts with plain codex() call (no provider option)", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        agent: codexAgent,
+        model: "gpt-5.4-mini",
+      });
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain('codex("gpt-5.4-mini")');
+      expect(mainTs).not.toContain("provider");
+      expect(mainTs).not.toContain("chatgpt");
+    });
+
+    it("generates standard .env.example with ANTHROPIC_API_KEY", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        agent: codexAgent,
+        model: "gpt-5.4-mini",
+      });
+
+      const envExample = await readFile(
+        join(dir, ".sandcastle", ".env.example"),
+        "utf-8",
+      );
+      expect(envExample).toContain("ANTHROPIC_API_KEY=");
+      expect(envExample).toContain("GH_TOKEN=");
+    });
+  });
+
   it("unknown template name throws a clear error", async () => {
     const dir = await makeDir();
     await expect(

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -208,6 +208,12 @@ export function getNextStepsLines(
   }
 }
 
+const CHATGPT_ENV_EXAMPLE = `# ChatGPT subscription — authentication is handled via \`codex login\`.
+# No API key needed. Run \`codex login\` on the host before starting Sandcastle.
+# GitHub personal access token
+GH_TOKEN=
+`;
+
 // ---------------------------------------------------------------------------
 // Scaffolding helpers
 // ---------------------------------------------------------------------------
@@ -280,6 +286,7 @@ const rewriteMainTs = (
   agent: AgentEntry,
   model: string,
   mainFilename: string,
+  options?: { codexProvider?: "chatgpt" },
 ): Effect.Effect<void, Error, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
@@ -314,6 +321,14 @@ const rewriteMainTs = (
       `${agent.factoryImport}("${model}")`,
     );
 
+    // When ChatGPT provider is selected, add { provider: "chatgpt" } to codex calls
+    if (options?.codexProvider === "chatgpt") {
+      content = content.replace(
+        new RegExp(`${agent.factoryImport}\\("${model}"\\)`, "g"),
+        `${agent.factoryImport}("${model}", { provider: "chatgpt" })`,
+      );
+    }
+
     yield* fs
       .writeFileString(mainTsPath, content)
       .pipe(Effect.mapError((e) => new Error(e.message)));
@@ -327,6 +342,7 @@ export interface ScaffoldOptions {
   agent: AgentEntry;
   model: string;
   templateName?: string;
+  codexProvider?: "chatgpt";
 }
 
 export interface ScaffoldResult {
@@ -363,7 +379,7 @@ export const scaffold = (
   options: ScaffoldOptions,
 ): Effect.Effect<ScaffoldResult, Error, FileSystem.FileSystem> =>
   Effect.gen(function* () {
-    const { agent, model, templateName = "blank" } = options;
+    const { agent, model, templateName = "blank", codexProvider } = options;
     const fs = yield* FileSystem.FileSystem;
     const configDir = join(repoDir, ".sandcastle");
 
@@ -403,7 +419,17 @@ export const scaffold = (
     );
 
     // Rewrite main file with the selected agent factory and model
-    yield* rewriteMainTs(configDir, agent, model, mainFilename);
+    yield* rewriteMainTs(configDir, agent, model, mainFilename, {
+      codexProvider,
+    });
+
+    // When ChatGPT provider is selected, replace .env.example with
+    // one that omits the API key and explains file-based auth.
+    if (codexProvider === "chatgpt") {
+      yield* fs
+        .writeFileString(join(configDir, ".env.example"), CHATGPT_ENV_EXAMPLE)
+        .pipe(Effect.mapError((e) => new Error(e.message)));
+    }
 
     return { mainFilename };
   });

--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -28,6 +28,7 @@ import {
   WorktreeSandboxConfig,
   WorktreeDockerSandboxFactory,
   SANDBOX_WORKSPACE_DIR,
+  validateHostMounts,
 } from "./SandboxFactory.js";
 
 const mockExecFile = vi.mocked(execFile);
@@ -639,5 +640,118 @@ describe("WorktreeDockerSandboxFactory", () => {
 
     expect(result.preservedWorktreePath).toBeUndefined();
     expect(result.value).toBe("done");
+  });
+
+  describe("hostMounts propagation", () => {
+    const makeLayerWithHostMounts = (
+      hostMounts: string[],
+      worktree?: { mode: "none" } | { mode: "branch"; branch: string },
+    ) =>
+      Layer.provide(
+        WorktreeDockerSandboxFactory.layer,
+        Layer.mergeAll(
+          Layer.succeed(WorktreeSandboxConfig, {
+            imageName: "test-image",
+            env: {},
+            hostRepoDir,
+            worktree,
+            hostMounts,
+          }),
+          NodeFileSystem.layer,
+          SilentDisplay.layer(Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([])),
+        ),
+      );
+
+    it("includes hostMounts in volume flags in worktree mode", async () => {
+      const layer = makeLayerWithHostMounts([
+        "/home/user/.codex:/home/agent/.codex:ro",
+      ]);
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const factory = yield* SandboxFactory;
+          yield* factory.withSandbox(() => Effect.void);
+        }).pipe(Effect.provide(layer)),
+      );
+
+      const runArgs = capturedArgs().find((args) => args[0] === "run");
+      expect(runArgs).toContain("/home/user/.codex:/home/agent/.codex:ro");
+    });
+
+    it("includes hostMounts in volume flags in none mode", async () => {
+      const layer = makeLayerWithHostMounts(
+        ["/home/user/.codex:/home/agent/.codex:ro"],
+        { mode: "none" },
+      );
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const factory = yield* SandboxFactory;
+          yield* factory.withSandbox(() => Effect.void);
+        }).pipe(Effect.provide(layer)),
+      );
+
+      const runArgs = capturedArgs().find((args) => args[0] === "run");
+      expect(runArgs).toContain("/home/user/.codex:/home/agent/.codex:ro");
+    });
+
+    it("does not add extra mounts when hostMounts is undefined", async () => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const factory = yield* SandboxFactory;
+          yield* factory.withSandbox(() => Effect.void);
+        }).pipe(Effect.provide(makeLayer())),
+      );
+
+      const runArgs = capturedArgs().find((args) => args[0] === "run");
+      // Should only have workspace + .git mounts, no codex mount
+      const volumeArgs = runArgs!.filter((arg) => arg.includes(":/"));
+      expect(volumeArgs.every((a) => !a.includes(".codex"))).toBe(true);
+    });
+  });
+});
+
+describe("validateHostMounts", () => {
+  it("does nothing when mounts is undefined", () => {
+    expect(() => validateHostMounts(undefined)).not.toThrow();
+  });
+
+  it("does nothing when mounts is empty", () => {
+    expect(() => validateHostMounts([])).not.toThrow();
+  });
+
+  it("does nothing when mounts do not reference ~/.codex", () => {
+    expect(() =>
+      validateHostMounts(["/some/path:/container/path"], "/fake/home"),
+    ).not.toThrow();
+  });
+
+  it("throws with 'codex login' message when ~/.codex is mounted but auth.json is missing", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "codex-validate-test-"));
+    const fakeCodexDir = join(tempDir, ".codex");
+    await mkdir(fakeCodexDir, { recursive: true });
+
+    try {
+      expect(() =>
+        validateHostMounts([`${fakeCodexDir}:/home/agent/.codex:ro`], tempDir),
+      ).toThrow(/codex login/);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes when ~/.codex/auth.json exists", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "codex-validate-test-"));
+    const fakeCodexDir = join(tempDir, ".codex");
+    await mkdir(fakeCodexDir, { recursive: true });
+    await writeFile(join(fakeCodexDir, "auth.json"), "{}");
+
+    try {
+      expect(() =>
+        validateHostMounts([`${fakeCodexDir}:/home/agent/.codex:ro`], tempDir),
+      ).not.toThrow();
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -664,7 +664,7 @@ describe("WorktreeDockerSandboxFactory", () => {
 
     it("includes hostMounts in volume flags in worktree mode", async () => {
       const layer = makeLayerWithHostMounts([
-        "/home/user/.codex:/home/agent/.codex:ro",
+        "/home/user/.codex:/home/agent/.codex",
       ]);
 
       await Effect.runPromise(
@@ -675,12 +675,12 @@ describe("WorktreeDockerSandboxFactory", () => {
       );
 
       const runArgs = capturedArgs().find((args) => args[0] === "run");
-      expect(runArgs).toContain("/home/user/.codex:/home/agent/.codex:ro");
+      expect(runArgs).toContain("/home/user/.codex:/home/agent/.codex");
     });
 
     it("includes hostMounts in volume flags in none mode", async () => {
       const layer = makeLayerWithHostMounts(
-        ["/home/user/.codex:/home/agent/.codex:ro"],
+        ["/home/user/.codex:/home/agent/.codex"],
         { mode: "none" },
       );
 
@@ -692,7 +692,7 @@ describe("WorktreeDockerSandboxFactory", () => {
       );
 
       const runArgs = capturedArgs().find((args) => args[0] === "run");
-      expect(runArgs).toContain("/home/user/.codex:/home/agent/.codex:ro");
+      expect(runArgs).toContain("/home/user/.codex:/home/agent/.codex");
     });
 
     it("does not add extra mounts when hostMounts is undefined", async () => {

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -312,6 +312,7 @@ const startSandboxContainer = (
   imageName: string,
   env: Record<string, string>,
   volumeMounts: string[],
+  hostMounts?: readonly string[],
 ) => {
   const cleanupContainerOnly = () => {
     forceRemoveContainerSync(containerName);
@@ -335,7 +336,12 @@ const startSandboxContainer = (
     },
   ).pipe(
     Effect.andThen(
-      chownInContainer(containerName, `${hostUid}:${hostGid}`, "/home/agent"),
+      chownInContainer(
+        containerName,
+        `${hostUid}:${hostGid}`,
+        "/home/agent",
+        hostMounts?.map((m) => m.split(":")[1]).filter((p): p is string => !!p),
+      ),
     ),
     Effect.tap(() =>
       Effect.sync(() => {
@@ -454,6 +460,7 @@ export const WorktreeDockerSandboxFactory = {
                     imageName,
                     env,
                     volumeMounts,
+                    hostMounts,
                   ),
                   // Use
                   () =>
@@ -544,6 +551,7 @@ export const WorktreeDockerSandboxFactory = {
                         imageName,
                         env,
                         volumeMounts,
+                        hostMounts,
                       ).pipe(
                         Effect.tap(({ cleanupContainerOnly, onSignal }) =>
                           Effect.sync(() => {

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -3,7 +3,9 @@ import { FileSystem } from "@effect/platform";
 import { NodeFileSystem } from "@effect/platform-node";
 import { randomUUID } from "node:crypto";
 import { execFile, execFileSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
 import type { PlatformError } from "@effect/platform/Error";
 import { createInterface } from "node:readline";
 import {
@@ -284,6 +286,8 @@ export class WorktreeSandboxConfig extends Context.Tag("WorktreeSandboxConfig")<
     readonly copyToSandbox?: string[];
     /** When specified, the run name is included in the auto-generated branch and worktree names. */
     readonly name?: string;
+    /** Additional host paths to bind-mount into the container (Docker volume mount syntax). */
+    readonly hostMounts?: readonly string[];
   }
 >() {}
 
@@ -371,6 +375,33 @@ export const resolveGitVolumeMounts = (
     const parentGitDir = resolve(gitdirPath, "..", "..");
     return [`${gitPath}:${gitPath}`, `${parentGitDir}:${parentGitDir}`];
   });
+
+/**
+ * Validate host mounts before starting a container.
+ * If any mount references the `~/.codex` directory, checks that
+ * `~/.codex/auth.json` exists on the host. Throws if it does not.
+ */
+export const validateHostMounts = (
+  mounts: readonly string[] | undefined,
+  homeDir?: string,
+): void => {
+  if (!mounts) return;
+  const codexDir = join(homeDir ?? homedir(), ".codex");
+  const needsCodexAuth = mounts.some((m) => {
+    const hostPath = m.split(":")[0]!;
+    return hostPath === codexDir || hostPath.startsWith(codexDir + "/");
+  });
+  if (needsCodexAuth) {
+    const authPath = join(codexDir, "auth.json");
+    if (!existsSync(authPath)) {
+      throw new Error(
+        `Codex auth file not found at ${authPath}. ` +
+          `Please run \`codex login\` to authenticate before using the ChatGPT provider.`,
+      );
+    }
+  }
+};
+
 export const WorktreeDockerSandboxFactory = {
   layer: Layer.effect(
     SandboxFactory,
@@ -382,6 +413,7 @@ export const WorktreeDockerSandboxFactory = {
         worktree: worktreeMode,
         copyToSandbox: copyPaths,
         name,
+        hostMounts,
       } = yield* WorktreeSandboxConfig;
       const isNoneMode = worktreeMode?.mode === "none";
       const branch =
@@ -397,6 +429,7 @@ export const WorktreeDockerSandboxFactory = {
           Exclude<R, Sandbox>
         > => {
           const containerName = `sandcastle-${randomUUID()}`;
+          validateHostMounts(hostMounts);
 
           if (isNoneMode) {
             // None mode: bind-mount host directory directly, no worktree
@@ -413,6 +446,7 @@ export const WorktreeDockerSandboxFactory = {
                 const volumeMounts = [
                   `${hostRepoDir}:${SANDBOX_WORKSPACE_DIR}`,
                   ...gitMounts,
+                  ...(hostMounts ?? []),
                 ];
                 return Effect.acquireUseRelease(
                   startSandboxContainer(
@@ -502,6 +536,7 @@ export const WorktreeDockerSandboxFactory = {
                       const volumeMounts = [
                         `${worktreeInfo.path}:${SANDBOX_WORKSPACE_DIR}`,
                         ...gitMounts,
+                        ...(hostMounts ?? []),
                       ];
 
                       return startSandboxContainer(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,6 +141,37 @@ const initCommand = Command.make(
         selectedAgent = getAgent(selected as string)!;
       }
 
+      // If Codex agent, ask about auth type
+      let codexProvider: "chatgpt" | undefined;
+      if (selectedAgent.name === "codex") {
+        const authType = yield* Effect.promise(() =>
+          clack.select({
+            message: "How do you want to authenticate with Codex?",
+            initialValue: "api-key",
+            options: [
+              {
+                value: "api-key",
+                label: "API key",
+                hint: "Set OPENAI_API_KEY in .env",
+              },
+              {
+                value: "chatgpt",
+                label: "ChatGPT subscription",
+                hint: "Uses `codex login` file-based auth",
+              },
+            ],
+          }),
+        );
+        if (clack.isCancel(authType)) {
+          yield* Effect.fail(
+            new InitError({ message: "Auth type selection cancelled." }),
+          );
+        }
+        if (authType === "chatgpt") {
+          codexProvider = "chatgpt";
+        }
+      }
+
       // Resolve model: CLI flag > agent default
       const selectedModel =
         modelFlag._tag === "Some"
@@ -208,6 +239,7 @@ const initCommand = Command.make(
           agent: selectedAgent,
           model: selectedModel,
           templateName: selectedTemplate,
+          codexProvider,
         }).pipe(
           Effect.mapError(
             (e) =>

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -36,6 +36,7 @@ import {
   SANDBOX_WORKSPACE_DIR,
   makeDockerSandboxLayer,
   resolveGitVolumeMounts,
+  validateHostMounts,
 } from "./SandboxFactory.js";
 import * as WorktreeManager from "./WorktreeManager.js";
 import { copyToSandbox } from "./CopyToSandbox.js";
@@ -51,6 +52,8 @@ export interface CreateSandboxOptions {
   };
   /** Paths relative to the host repo root to copy into the worktree at creation time. */
   readonly copyToSandbox?: string[];
+  /** Additional host paths to bind-mount into the container (Docker volume mount syntax). */
+  readonly hostMounts?: readonly string[];
   /** @internal Test-only overrides to bypass Docker. */
   readonly _test?: {
     readonly hostRepoDir?: string;
@@ -151,6 +154,7 @@ export const createSandbox = async (
     sandboxLayer = options._test!.buildSandboxLayer!(worktreePath);
     sandboxRepoDir = worktreePath;
   } else {
+    validateHostMounts(options.hostMounts);
     containerName = `sandcastle-${randomUUID()}`;
     const resolvedImageName =
       options.imageName ?? defaultImageName(hostRepoDir);
@@ -168,6 +172,7 @@ export const createSandbox = async (
     const volumeMounts = [
       `${worktreePath}:${SANDBOX_WORKSPACE_DIR}`,
       ...gitMounts,
+      ...(options.hostMounts ?? []),
     ];
 
     const hostUid = process.getuid?.() ?? 1000;

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -194,6 +194,9 @@ export const createSandbox = async (
             containerName,
             `${hostUid}:${hostGid}`,
             "/home/agent",
+            options.hostMounts
+              ?.map((m) => m.split(":")[1])
+              .filter((p): p is string => !!p),
           ),
         ),
       ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,4 @@ export type {
 } from "./createSandbox.js";
 export type { PromptArgs } from "./PromptArgumentSubstitution.js";
 export { claudeCode, codex, pi } from "./AgentProvider.js";
-export type { AgentProvider } from "./AgentProvider.js";
+export type { AgentProvider, CodexOptions } from "./AgentProvider.js";

--- a/src/run.ts
+++ b/src/run.ts
@@ -301,6 +301,7 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
         worktree: worktreeMode,
         copyToSandbox: options.copyToSandbox,
         name: options.name,
+        hostMounts: provider.hostMounts,
       }),
       NodeFileSystem.layer,
       displayLayer,


### PR DESCRIPTION
PRD file: #236 

## Summary

* Add ChatGPT subscription authentication as an alternative to API keys for the Codex agent.
* `sandcastle init` now prompts for the authentication type (API key / ChatGPT subscription) when Codex is selected.
* The `codex()` factory accepts `{ provider: "chatgpt" }`, which mounts `~/.codex/` into the sandbox so the Codex CLI picks up file-based credentials automatically.
* Fail-fast validation: If `~/.codex/auth.json` is missing, Sandcastle errors with a clear message to run `codex login`.
* `chownInContainer` now excludes bind-mounted paths using `find -prune` to avoid permission errors on host-owned files.
* Scaffolded `.env.example` omits the API key when ChatGPT authentication is selected.
* README documents the ChatGPT authentication setup, prerequisites, and how it works.

## Test plan

* `codex()` factory: `hostMounts` populated for ChatGPT, undefined without options, CLI commands unchanged.
* Mount propagation: `hostMounts` included in Docker volume flags in both worktree and none modes.
* Auth validation: Fails with a "codex login" message when `auth.json` is missing, passes when present.
* Scaffold: ChatGPT path generates `{ provider: "chatgpt" }` in `main.mts` and a ChatGPT-specific `.env.example`.
* E2E: Tested via `npm pack` + install in a fresh repo, `sandcastle init` with Codex + ChatGPT, and ran the `simple-loop` template against a real GitHub issue.


Closes #236 