### PR TITLE
add testing for pi agent provider not parsing real inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ai-hero/sandcastle",
-  "version": "0.1.8",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ai-hero/sandcastle",
-      "version": "0.1.8",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
@@ -398,6 +398,7 @@
       "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.95.0.tgz",
       "integrity": "sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-my-way-ts": "^0.1.6",
         "msgpackr": "^1.11.4",
@@ -449,6 +450,7 @@
       "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.48.0.tgz",
       "integrity": "sha512-f/+QVyqACuLkoB+HDDX2XxloslmgMDL+C6ecHBV0cB0zJzJmLCOybwOkRcCI2xJ/DWHEIpoRyvq+Bfdza0AIrA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@effect/typeclass": "^0.39.0",
         "effect": "^3.20.0"
@@ -459,6 +461,7 @@
       "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.48.0.tgz",
       "integrity": "sha512-CzQ5kiomjR9DZ6LPfKAaWmys6JU65c2Q/VQcTKRK4RfaDWeTAehpAVmgOIyKSPkcr9XBhjo2cJx4xyZ4E5nN7g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@effect/printer": "^0.48.0"
       },
@@ -1871,6 +1874,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2396,6 +2400,7 @@
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.20.0.tgz",
       "integrity": "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
@@ -2959,8 +2964,7 @@
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
       "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -4151,6 +4155,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4200,7 +4205,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -4211,6 +4215,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4309,6 +4314,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -147,7 +147,7 @@ describe("pi factory", () => {
     const provider = pi("claude-sonnet-4-6");
     const line = JSON.stringify({
       type: "message_update",
-      content: [{ type: "text_delta", text: "Hello world" }],
+      assistantMessageEvent: [{ type: "text_delta", delta: "Hello world" }],
     });
     expect(provider.parseStreamLine(line)).toEqual([
       { type: "text", text: "Hello world" },
@@ -158,8 +158,9 @@ describe("pi factory", () => {
     const provider = pi("claude-sonnet-4-6");
     const line = JSON.stringify({
       type: "tool_execution_start",
-      tool_name: "Bash",
-      input: { command: "npm test" },
+      toolCallId: "call_xxx",
+      toolName: "Bash",
+      args: { command: "npm test" },
     });
     expect(provider.parseStreamLine(line)).toEqual([
       { type: "tool_call", name: "Bash", args: "npm test" },
@@ -170,8 +171,9 @@ describe("pi factory", () => {
     const provider = pi("claude-sonnet-4-6");
     const line = JSON.stringify({
       type: "tool_execution_start",
-      tool_name: "UnknownTool",
-      input: { foo: "bar" },
+      toolCallId: "call_xxx",
+      toolName: "UnknownTool",
+      args: { foo: "bar" },
     });
     expect(provider.parseStreamLine(line)).toEqual([]);
   });
@@ -180,8 +182,16 @@ describe("pi factory", () => {
     const provider = pi("claude-sonnet-4-6");
     const line = JSON.stringify({
       type: "agent_end",
-      last_assistant_message: "Final answer <promise>COMPLETE</promise>",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Final answer <promise>COMPLETE</promise>" },
+          ],
+        },
+      ],
     });
+
     expect(provider.parseStreamLine(line)).toEqual([
       {
         type: "result",
@@ -196,28 +206,67 @@ describe("pi factory", () => {
     const line = JSON.stringify({
       type: "agent_end",
       last_assistant_message: "Done",
-      usage: {
-        input_tokens: 100,
-        output_tokens: 50,
-        cache_read_input_tokens: 10,
-        cache_creation_input_tokens: 5,
-      },
-      total_cost_usd: 0.01,
-      num_turns: 3,
-      duration_ms: 5000,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Run echo hello using the bash tool,\n then reply done",
+            },
+          ],
+          timestamp: 1000000000000,
+        },
+        {
+          role: "assistant",
+          usage: {
+            input: 100,
+            output: 50,
+            cacheRead: 10,
+            cacheWrite: 5,
+            totalTokens: 165,
+            cost: {
+              input: 3,
+              output: 4,
+              cacheRead: 2,
+              cacheWrite: 1,
+              total: 10,
+            },
+          },
+          timestamp: 1000000010000,
+        },
+        {
+          role: "assistant",
+          usage: {
+            input: 100,
+            output: 50,
+            cacheRead: 10,
+            cacheWrite: 5,
+            totalTokens: 165,
+            cost: {
+              input: 3,
+              output: 4,
+              cacheRead: 2,
+              cacheWrite: 1,
+              total: 10,
+            },
+          },
+          timestamp: 1000000020000,
+        },
+      ],
     });
     const events = provider.parseStreamLine(line);
     expect(events).toHaveLength(1);
     expect(events[0]!.type).toBe("result");
     const result = events[0] as { type: "result"; usage: unknown };
     expect(result.usage).toEqual({
-      input_tokens: 100,
-      output_tokens: 50,
-      cache_read_input_tokens: 10,
-      cache_creation_input_tokens: 5,
-      total_cost_usd: 0.01,
-      num_turns: 3,
-      duration_ms: 5000,
+      input_tokens: 200,
+      output_tokens: 100,
+      cache_read_input_tokens: 20,
+      cache_creation_input_tokens: 10,
+      total_cost_usd: 20,
+      num_turns: 2,
+      duration_ms: 20_000,
     });
   });
 
@@ -248,7 +297,7 @@ describe("pi factory", () => {
     const provider = pi("claude-sonnet-4-6");
     const line = JSON.stringify({
       type: "tool_execution_start",
-      tool_name: "Bash",
+      toolName: "Bash",
       // no input field
     });
     expect(provider.parseStreamLine(line)).toEqual([]);


### PR DESCRIPTION
I have been trying to use pi as a provider but I keep encountering
`TimeoutError: Agent idle for 600 seconds — no output received. Consider increasing the idle timeout with --idle-timeout.` I found the root cause to be that the agent provider is not parsing any of the outputs correctly.

I've updated the tests based on what I found to be outputted using the CLI and the types documented at [/packages/coding-agent/docs/json.md](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/json.md) and [/packages/ai/src/types.ts](https://github.com/badlogic/pi-mono/blob/a99aee3360fbeb742282c7e1f8f14954638e6cb0/packages/ai/src/types.ts) in the pi-mono repo.

I am yet to update the implementation - feels like something AI can update to get the tests passing.

@mattpocock Let me know if I can fix this with an agent or if its something your workflow might be better at.