### PR TITLE
Define BranchStrategy types and wire bind-mount providers

### DIFF
--- a/.changeset/branch-strategy-types.md
+++ b/.changeset/branch-strategy-types.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Define BranchStrategy types (head, merge-to-head, branch) and wire into bind-mount providers. Branch strategy is now configured on the sandbox provider at construction time via `branchStrategy` option, replacing the top-level `worktree` config field on SandboxFactory.

--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -12,6 +12,7 @@ import {
   createBindMountSandboxProvider,
   type SandboxProvider,
   type BindMountSandboxHandle,
+  type BindMountBranchStrategy,
 } from "./SandboxProvider.js";
 import { testIsolated } from "./sandboxes/test-isolated.js";
 
@@ -26,7 +27,7 @@ import * as WorktreeManager from "./WorktreeManager.js";
 import {
   Sandbox,
   SandboxFactory,
-  WorktreeSandboxConfig,
+  SandboxConfig,
   WorktreeDockerSandboxFactory,
   SANDBOX_WORKSPACE_DIR,
 } from "./SandboxFactory.js";
@@ -39,7 +40,9 @@ const mockHasUncommittedChanges = vi.mocked(
 );
 
 /** Create a mock sandbox provider that records calls and delegates to a no-op handle. */
-const makeMockProvider = (): {
+const makeMockProvider = (
+  branchStrategy?: BindMountBranchStrategy,
+): {
   provider: SandboxProvider;
   createCalls: any[];
   closeCalls: number;
@@ -48,6 +51,7 @@ const makeMockProvider = (): {
   let closeCalls = 0;
   const provider = createBindMountSandboxProvider({
     name: "test-provider",
+    branchStrategy,
     create: async (options) => {
       createCalls.push(options);
       const handle: BindMountSandboxHandle = {
@@ -94,7 +98,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     Layer.provide(
       WorktreeDockerSandboxFactory.layer,
       Layer.mergeAll(
-        Layer.succeed(WorktreeSandboxConfig, {
+        Layer.succeed(SandboxConfig, {
           env: { FOO: "bar" },
           hostRepoDir,
           sandboxProvider: mockProvider.provider,
@@ -106,7 +110,7 @@ describe("WorktreeDockerSandboxFactory", () => {
 
   beforeEach(async () => {
     hostRepoDir = await makeTempRepo();
-    mockProvider = makeMockProvider();
+    mockProvider = makeMockProvider({ type: "merge-to-head" });
     mockCreate.mockReturnValue(
       Effect.succeed({
         path: worktreePath,
@@ -126,15 +130,19 @@ describe("WorktreeDockerSandboxFactory", () => {
     tempDirs.length = 0;
   });
 
-  it("passes branch from config to WorktreeManager.create when branch is specified", async () => {
+  it("passes branch from provider's branchStrategy to WorktreeManager.create when branch is specified", async () => {
+    const branchProvider = createBindMountSandboxProvider({
+      name: "test-provider",
+      branchStrategy: { type: "branch", branch: "feature/my-branch" },
+      create: mockProvider.provider.create,
+    });
     const layerWithBranch = Layer.provide(
       WorktreeDockerSandboxFactory.layer,
       Layer.mergeAll(
-        Layer.succeed(WorktreeSandboxConfig, {
+        Layer.succeed(SandboxConfig, {
           env: {},
           hostRepoDir,
-          worktree: { mode: "branch", branch: "feature/my-branch" },
-          sandboxProvider: mockProvider.provider,
+          sandboxProvider: branchProvider,
         }),
         NodeFileSystem.layer,
         SilentDisplay.layer(Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([])),
@@ -174,7 +182,7 @@ describe("WorktreeDockerSandboxFactory", () => {
         return { path: worktreePath, branch: "sandcastle/20240101-000000" };
       }),
     );
-    const { provider } = makeMockProvider();
+    const { provider } = makeMockProvider({ type: "merge-to-head" });
     const origCreate = provider.create;
     (provider as any).create = async (opts: any) => {
       callOrder.push("provider-create");
@@ -184,7 +192,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     const layer = Layer.provide(
       WorktreeDockerSandboxFactory.layer,
       Layer.mergeAll(
-        Layer.succeed(WorktreeSandboxConfig, {
+        Layer.succeed(SandboxConfig, {
           env: { FOO: "bar" },
           hostRepoDir,
           sandboxProvider: provider,
@@ -376,7 +384,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     const layerWithCopy = Layer.provide(
       WorktreeDockerSandboxFactory.layer,
       Layer.mergeAll(
-        Layer.succeed(WorktreeSandboxConfig, {
+        Layer.succeed(SandboxConfig, {
           env: {},
           hostRepoDir,
           copyToSandbox: ["node_modules"],
@@ -513,18 +521,24 @@ describe("WorktreeDockerSandboxFactory", () => {
     ).toBeUndefined();
   });
 
-  describe("mode: none", () => {
-    const makeNoneLayer = (
+  describe("head branch strategy", () => {
+    const makeHeadProvider = () =>
+      createBindMountSandboxProvider({
+        name: "test-provider",
+        branchStrategy: { type: "head" },
+        create: mockProvider.provider.create,
+      });
+
+    const makeHeadLayer = (
       displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]),
     ) =>
       Layer.provide(
         WorktreeDockerSandboxFactory.layer,
         Layer.mergeAll(
-          Layer.succeed(WorktreeSandboxConfig, {
+          Layer.succeed(SandboxConfig, {
             env: { FOO: "bar" },
             hostRepoDir,
-            worktree: { mode: "none" },
-            sandboxProvider: mockProvider.provider,
+            sandboxProvider: makeHeadProvider(),
           }),
           NodeFileSystem.layer,
           SilentDisplay.layer(displayRef),
@@ -536,7 +550,7 @@ describe("WorktreeDockerSandboxFactory", () => {
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
           yield* factory.withSandbox(() => Effect.void);
-        }).pipe(Effect.provide(makeNoneLayer())),
+        }).pipe(Effect.provide(makeHeadLayer())),
       );
 
       expect(mockCreate).not.toHaveBeenCalled();
@@ -549,7 +563,7 @@ describe("WorktreeDockerSandboxFactory", () => {
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
           yield* factory.withSandbox(() => Effect.void);
-        }).pipe(Effect.provide(makeNoneLayer())),
+        }).pipe(Effect.provide(makeHeadLayer())),
       );
 
       expect(mockProvider.createCalls).toHaveLength(1);
@@ -569,7 +583,7 @@ describe("WorktreeDockerSandboxFactory", () => {
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
           return yield* factory.withSandbox(() => Effect.succeed("done"));
-        }).pipe(Effect.provide(makeNoneLayer())),
+        }).pipe(Effect.provide(makeHeadLayer())),
       );
 
       expect(result.preservedWorktreePath).toBeUndefined();
@@ -585,7 +599,7 @@ describe("WorktreeDockerSandboxFactory", () => {
             receivedInfo = info;
             return Effect.void;
           });
-        }).pipe(Effect.provide(makeNoneLayer())),
+        }).pipe(Effect.provide(makeHeadLayer())),
       );
 
       expect(receivedInfo?.hostWorktreePath).toBeUndefined();
@@ -629,14 +643,11 @@ const commitFile = async (
 describe("WorktreeDockerSandboxFactory — isolated providers", () => {
   const tempDirs: string[] = [];
 
-  const makeIsolatedLayer = (
-    hostRepoDir: string,
-    copyToSandbox?: string[],
-  ) =>
+  const makeIsolatedLayer = (hostRepoDir: string, copyToSandbox?: string[]) =>
     Layer.provide(
       WorktreeDockerSandboxFactory.layer,
       Layer.mergeAll(
-        Layer.succeed(WorktreeSandboxConfig, {
+        Layer.succeed(SandboxConfig, {
           env: {},
           hostRepoDir,
           copyToSandbox,
@@ -702,9 +713,7 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
           }),
         );
       }).pipe(
-        Effect.provide(
-          makeIsolatedLayer(hostDir, ["subdir/config.json"]),
-        ),
+        Effect.provide(makeIsolatedLayer(hostDir, ["subdir/config.json"])),
       ),
     );
 
@@ -745,11 +754,7 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
         yield* factory.withSandbox(() => Effect.void);
-      }).pipe(
-        Effect.provide(
-          makeIsolatedLayer(hostDir, ["nonexistent.txt"]),
-        ),
-      ),
+      }).pipe(Effect.provide(makeIsolatedLayer(hostDir, ["nonexistent.txt"]))),
     );
   });
 });

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -19,6 +19,7 @@ import type {
   SandboxProvider,
   BindMountSandboxProvider,
   BindMountSandboxHandle,
+  BindMountBranchStrategy,
   IsolatedSandboxProvider,
   IsolatedSandboxHandle,
 } from "./SandboxProvider.js";
@@ -149,13 +150,11 @@ export class SandboxFactory extends Context.Tag("SandboxFactory")<
   }
 >() {}
 
-export class WorktreeSandboxConfig extends Context.Tag("WorktreeSandboxConfig")<
-  WorktreeSandboxConfig,
+export class SandboxConfig extends Context.Tag("SandboxConfig")<
+  SandboxConfig,
   {
     readonly env: Record<string, string>;
     readonly hostRepoDir: string;
-    /** Worktree mode: none, temp-branch (default), or explicit branch. */
-    readonly worktree?: import("./run.js").WorktreeMode;
     /** Paths relative to the host repo root to copy into the worktree before container start. */
     readonly copyToSandbox?: string[];
     /** When specified, the run name is included in the auto-generated branch and worktree names. */
@@ -164,6 +163,9 @@ export class WorktreeSandboxConfig extends Context.Tag("WorktreeSandboxConfig")<
     readonly sandboxProvider: SandboxProvider;
   }
 >() {}
+
+/** @deprecated Use SandboxConfig instead. */
+export const WorktreeSandboxConfig = SandboxConfig;
 
 /**
  * Print a message to stderr about a preserved worktree, with review and cleanup instructions.
@@ -326,14 +328,19 @@ export const WorktreeDockerSandboxFactory = {
       const {
         env,
         hostRepoDir,
-        worktree: worktreeMode,
         copyToSandbox: copyPaths,
         name,
         sandboxProvider,
-      } = yield* WorktreeSandboxConfig;
-      const isNoneMode = worktreeMode?.mode === "none";
+      } = yield* SandboxConfig;
+
+      // Read branch strategy from the provider for bind-mount providers
+      const branchStrategy: BindMountBranchStrategy | undefined =
+        sandboxProvider.tag === "bind-mount"
+          ? sandboxProvider.branchStrategy
+          : undefined;
+      const isHeadMode = branchStrategy?.type === "head";
       const branch =
-        worktreeMode?.mode === "branch" ? worktreeMode.branch : undefined;
+        branchStrategy?.type === "branch" ? branchStrategy.branch : undefined;
       const fileSystem = yield* FileSystem.FileSystem;
       const display = yield* Display;
       return {
@@ -384,8 +391,8 @@ export const WorktreeDockerSandboxFactory = {
             );
           }
 
-          if (isNoneMode) {
-            // None mode: bind-mount host directory directly, no worktree
+          if (isHeadMode) {
+            // Head mode: bind-mount host directory directly, no worktree
             const gitPath = join(hostRepoDir, ".git");
             return resolveGitMounts(gitPath).pipe(
               Effect.provideService(FileSystem.FileSystem, fileSystem),
@@ -426,7 +433,7 @@ export const WorktreeDockerSandboxFactory = {
             );
           }
 
-          // Worktree mode (temp-branch or explicit branch)
+          // Worktree mode (merge-to-head or explicit branch)
           // Populated by the release phase when a worktree is preserved on failure,
           // so we can attach the path to recognized error types before they propagate.
           let preservedWorktreePath: string | undefined;

--- a/src/SandboxProvider.test.ts
+++ b/src/SandboxProvider.test.ts
@@ -54,6 +54,38 @@ describe("createBindMountSandboxProvider", () => {
 
     expect(provider.tag).toBe("bind-mount");
   });
+
+  it("defaults branchStrategy to head when omitted", () => {
+    const provider = createBindMountSandboxProvider({
+      name: "test-provider",
+      create: async () => makeMockHandle(),
+    });
+
+    expect(provider.branchStrategy).toEqual({ type: "head" });
+  });
+
+  it("stores explicit branchStrategy on the instance", () => {
+    const provider = createBindMountSandboxProvider({
+      name: "test-provider",
+      branchStrategy: { type: "merge-to-head" },
+      create: async () => makeMockHandle(),
+    });
+
+    expect(provider.branchStrategy).toEqual({ type: "merge-to-head" });
+  });
+
+  it("stores branch strategy with named branch", () => {
+    const provider = createBindMountSandboxProvider({
+      name: "test-provider",
+      branchStrategy: { type: "branch", branch: "feature/foo" },
+      create: async () => makeMockHandle(),
+    });
+
+    expect(provider.branchStrategy).toEqual({
+      type: "branch",
+      branch: "feature/foo",
+    });
+  });
 });
 
 describe("createIsolatedSandboxProvider", () => {

--- a/src/SandboxProvider.ts
+++ b/src/SandboxProvider.ts
@@ -48,6 +48,8 @@ export interface BindMountCreateOptions {
 export interface BindMountSandboxProviderConfig {
   /** Human-readable name for this provider (e.g. "docker", "podman"). */
   readonly name: string;
+  /** Branch strategy. Defaults to { type: "head" } if omitted. */
+  readonly branchStrategy?: BindMountBranchStrategy;
   /** Create a sandbox handle from the given options. */
   readonly create: (
     options: BindMountCreateOptions,
@@ -96,6 +98,8 @@ export interface BindMountSandboxProvider {
   readonly tag: "bind-mount";
   /** Human-readable provider name. */
   readonly name: string;
+  /** Branch strategy — controls how the agent's changes relate to branches. Defaults to head. */
+  readonly branchStrategy: BindMountBranchStrategy;
   /** @internal Create a sandbox handle. */
   readonly create: (
     options: BindMountCreateOptions,
@@ -114,6 +118,38 @@ export interface IsolatedSandboxProvider {
   ) => Promise<IsolatedSandboxHandle>;
 }
 
+// ---------- Branch strategy types ----------
+
+/** Head strategy: agent writes directly to host working directory. Bind-mount only. */
+export interface HeadBranchStrategy {
+  readonly type: "head";
+}
+
+/** Merge-to-head strategy: temp branch, merge back to HEAD, delete temp branch. */
+export interface MergeToHeadBranchStrategy {
+  readonly type: "merge-to-head";
+}
+
+/** Branch strategy: commits land on an explicit named branch. */
+export interface NamedBranchStrategy {
+  readonly type: "branch";
+  readonly branch: string;
+}
+
+/** Branch strategy for bind-mount providers (all three variants). */
+export type BindMountBranchStrategy =
+  | HeadBranchStrategy
+  | MergeToHeadBranchStrategy
+  | NamedBranchStrategy;
+
+/** Branch strategy for isolated providers (no head — can't write to host). */
+export type IsolatedBranchStrategy =
+  | MergeToHeadBranchStrategy
+  | NamedBranchStrategy;
+
+/** Union of all branch strategy variants. */
+export type BranchStrategy = BindMountBranchStrategy | IsolatedBranchStrategy;
+
 /**
  * A sandbox provider — the pluggable unit that `run()` and `createSandbox()` accept.
  * Tagged for internal dispatch: "bind-mount" or "isolated".
@@ -131,6 +167,7 @@ export const createBindMountSandboxProvider = (
 ): BindMountSandboxProvider => ({
   tag: "bind-mount",
   name: config.name,
+  branchStrategy: config.branchStrategy ?? { type: "head" },
   create: config.create,
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@ import { AgentError, ConfigDirError, InitError } from "./errors.js";
 import {
   SandboxFactory,
   WorktreeDockerSandboxFactory,
-  WorktreeSandboxConfig,
+  SandboxConfig,
   SANDBOX_WORKSPACE_DIR,
 } from "./SandboxFactory.js";
 import { withSandboxLifecycle } from "./SandboxLifecycle.js";
@@ -447,7 +447,7 @@ const interactiveCommand = Command.make(
       const factoryLayer = Layer.provide(
         WorktreeDockerSandboxFactory.layer,
         Layer.merge(
-          Layer.succeed(WorktreeSandboxConfig, {
+          Layer.succeed(SandboxConfig, {
             env,
             hostRepoDir,
             sandboxProvider: docker({ imageName }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,4 +31,10 @@ export type {
   BindMountSandboxProviderConfig,
   IsolatedCreateOptions,
   IsolatedSandboxProviderConfig,
+  BranchStrategy,
+  BindMountBranchStrategy,
+  IsolatedBranchStrategy,
+  HeadBranchStrategy,
+  MergeToHeadBranchStrategy,
+  NamedBranchStrategy,
 } from "./SandboxProvider.js";

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -303,7 +303,7 @@ describe("copyToSandbox with mode none", () => {
         copyToSandbox: [".env"],
       }),
     ).rejects.toThrow(
-      "copyToSandbox is not supported with worktree mode 'none'",
+      "copyToSandbox is not supported with head branch strategy",
     );
   });
 });

--- a/src/run.ts
+++ b/src/run.ts
@@ -13,10 +13,13 @@ import { orchestrate } from "./Orchestrator.js";
 import { resolvePrompt } from "./PromptResolver.js";
 import {
   WorktreeDockerSandboxFactory,
-  WorktreeSandboxConfig,
+  SandboxConfig,
   SANDBOX_WORKSPACE_DIR,
 } from "./SandboxFactory.js";
-import type { SandboxProvider } from "./SandboxProvider.js";
+import type {
+  SandboxProvider,
+  BindMountBranchStrategy,
+} from "./SandboxProvider.js";
 import { resolveEnv } from "./EnvResolver.js";
 import { generateTempBranchName, getCurrentBranch } from "./WorktreeManager.js";
 import {
@@ -198,26 +201,39 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
     agent: provider,
   } = options;
 
-  // Resolve worktree mode: default to temp-branch when omitted
-  const worktreeMode: WorktreeMode = options.worktree ?? {
-    mode: "temp-branch",
-  };
+  // Derive branch strategy from the sandbox provider (bind-mount providers expose it)
+  const branchStrategy: BindMountBranchStrategy | undefined =
+    options.sandbox.tag === "bind-mount"
+      ? options.sandbox.branchStrategy
+      : undefined;
 
-  // Validate: copyToSandbox is incompatible with mode: 'none'
+  // Also support legacy worktree option as fallback
+  const effectiveBranchType: "head" | "merge-to-head" | "branch" =
+    branchStrategy?.type ??
+    (options.worktree?.mode === "none"
+      ? "head"
+      : options.worktree?.mode === "branch"
+        ? "branch"
+        : "merge-to-head");
+
+  // Validate: copyToSandbox is incompatible with head strategy
   if (
-    worktreeMode.mode === "none" &&
+    effectiveBranchType === "head" &&
     options.copyToSandbox &&
     options.copyToSandbox.length > 0
   ) {
     throw new Error(
-      "copyToSandbox is not supported with worktree mode 'none'. " +
-        "In mode 'none' the host working directory is bind-mounted directly.",
+      "copyToSandbox is not supported with head branch strategy. " +
+        "In head mode the host working directory is bind-mounted directly.",
     );
   }
 
-  // Extract explicit branch when in branch mode, undefined for temp-branch/none mode
+  // Extract explicit branch when in branch mode
   const branch =
-    worktreeMode.mode === "branch" ? worktreeMode.branch : undefined;
+    effectiveBranchType === "branch"
+      ? ((branchStrategy as { type: "branch"; branch: string })?.branch ??
+        (options.worktree as { mode: "branch"; branch: string })?.branch)
+      : undefined;
 
   const hostRepoDir = process.cwd();
 
@@ -241,17 +257,17 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
     getCurrentBranch(hostRepoDir),
   );
 
-  // When in temp-branch mode, generate a temporary branch name.
-  // In none mode, use the host's current branch directly (no worktree).
+  // When in merge-to-head mode, generate a temporary branch name.
+  // In head mode, use the host's current branch directly (no worktree).
   const resolvedBranch =
-    worktreeMode.mode === "none"
+    effectiveBranchType === "head"
       ? currentHostBranch
       : (branch ?? generateTempBranchName(options.name));
 
   // When using a temp branch, prefix the log filename with the target branch
   // (the host's current branch) so developers can tell which branch was targeted.
   const targetBranch =
-    worktreeMode.mode === "temp-branch" ? currentHostBranch : undefined;
+    effectiveBranchType === "merge-to-head" ? currentHostBranch : undefined;
 
   // Resolve logging option
   const resolvedLogging: LoggingOption = options.logging ?? {
@@ -281,10 +297,9 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
   const factoryLayer = Layer.provide(
     WorktreeDockerSandboxFactory.layer,
     Layer.mergeAll(
-      Layer.succeed(WorktreeSandboxConfig, {
+      Layer.succeed(SandboxConfig, {
         env,
         hostRepoDir,
-        worktree: worktreeMode,
         copyToSandbox: options.copyToSandbox,
         name: options.name,
         sandboxProvider: options.sandbox,
@@ -328,10 +343,10 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
         builtInArgKeysSet,
       );
 
-      // In none mode, pass the host branch so SandboxLifecycle skips the merge step.
-      // In temp-branch mode, branch is undefined (triggers merge). In branch mode, it's the explicit branch.
+      // In head mode, pass the host branch so SandboxLifecycle skips the merge step.
+      // In merge-to-head mode, branch is undefined (triggers merge). In branch mode, it's the explicit branch.
       const orchestrateBranch =
-        worktreeMode.mode === "none" ? currentHostBranch : branch;
+        effectiveBranchType === "head" ? currentHostBranch : branch;
 
       const orchestrateResult = yield* orchestrate({
         hostRepoDir,

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -18,4 +18,22 @@ describe("docker()", () => {
     const provider = docker();
     expect(typeof provider.create).toBe("function");
   });
+
+  it("defaults branchStrategy to head", () => {
+    const provider = docker();
+    expect(provider.tag).toBe("bind-mount");
+    if (provider.tag === "bind-mount") {
+      expect(provider.branchStrategy).toEqual({ type: "head" });
+    }
+  });
+
+  it("accepts and threads through branchStrategy", () => {
+    const provider = docker({
+      branchStrategy: { type: "merge-to-head" },
+    });
+    expect(provider.tag).toBe("bind-mount");
+    if (provider.tag === "bind-mount") {
+      expect(provider.branchStrategy).toEqual({ type: "merge-to-head" });
+    }
+  });
 });

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -17,6 +17,7 @@ import {
 } from "../DockerLifecycle.js";
 import {
   createBindMountSandboxProvider,
+  type BindMountBranchStrategy,
   type SandboxProvider,
   type BindMountCreateOptions,
   type BindMountSandboxHandle,
@@ -26,6 +27,8 @@ import {
 export interface DockerOptions {
   /** Docker image name (default: derived from repo directory name). */
   readonly imageName?: string;
+  /** Branch strategy for this provider. Defaults to { type: "head" }. */
+  readonly branchStrategy?: BindMountBranchStrategy;
 }
 
 /**
@@ -39,6 +42,7 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
 
   return createBindMountSandboxProvider({
     name: "docker",
+    branchStrategy: options?.branchStrategy,
     create: async (
       createOptions: BindMountCreateOptions,
     ): Promise<BindMountSandboxHandle> => {


### PR DESCRIPTION
## Summary
- Define `BranchStrategy`, `BindMountBranchStrategy`, and `IsolatedBranchStrategy` types with `type` as discriminant (head, merge-to-head, branch)
- Wire `branchStrategy` into bind-mount providers end-to-end: `docker()` options -> provider instance -> `SandboxFactory` dispatch
- Rename `WorktreeSandboxConfig` to `SandboxConfig`, remove `worktree` field — factory now reads strategy from `provider.branchStrategy`

Closes #264

## Test plan
- [x] 3 new tests verify `createBindMountSandboxProvider` defaults to `{ type: "head" }` and stores explicit strategies
- [x] 2 new tests verify `docker()` defaults to head and threads through custom strategies
- [x] Existing SandboxFactory tests updated to configure strategy on provider instead of config
- [x] All 477 tests pass, `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)