### PR TITLE
Remove Docker references from provider-agnostic JSDoc

### DIFF
--- a/.changeset/remove-docker-jsdoc-references.md
+++ b/.changeset/remove-docker-jsdoc-references.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Remove Docker-specific language from JSDoc comments on provider-agnostic APIs

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -123,7 +123,7 @@ export const makeSandboxLayerFromHandle = (
             ),
   });
 
-/** The mount point inside the container where the project worktree is bound. */
+/** The mount point inside the sandbox where the project worktree is bound. */
 export const SANDBOX_WORKSPACE_DIR = "/home/agent/workspace";
 
 export interface SandboxInfo {
@@ -155,11 +155,11 @@ export class SandboxConfig extends Context.Tag("SandboxConfig")<
   {
     readonly env: Record<string, string>;
     readonly hostRepoDir: string;
-    /** Paths relative to the host repo root to copy into the worktree before container start. */
+    /** Paths relative to the host repo root to copy into the worktree before sandbox start. */
     readonly copyToSandbox?: string[];
     /** When specified, the run name is included in the auto-generated branch and worktree names. */
     readonly name?: string;
-    /** Sandbox provider — delegates container lifecycle to the provider. */
+    /** Sandbox provider — delegates sandbox lifecycle to the provider. */
     readonly sandboxProvider: SandboxProvider;
   }
 >() {}

--- a/src/SandboxLifecycle.test.ts
+++ b/src/SandboxLifecycle.test.ts
@@ -13,7 +13,7 @@ import { withSandboxLifecycle } from "./SandboxLifecycle.js";
 
 /**
  * Creates a sandbox that translates container paths to host paths,
- * simulating Docker's bind mount behavior. When a command uses
+ * simulating a bind-mount sandbox provider. When a command uses
  * `containerPath` as cwd, it's translated to `hostPath`.
  */
 const makePathTranslatingSandbox = (
@@ -377,12 +377,12 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   it("cherry-pick works when sandboxRepoDir differs from host worktree path", async () => {
     const { hostDir, worktreeDir, layer } = await setupWorktree();
 
-    // Simulate Docker: sandboxRepoDir is the container mount point, which differs
-    // from the actual host worktree path. In production the container sees
-    // /home/agent/workspace while the host sees .sandcastle/worktrees/<name>.
+    // Simulate a bind-mount provider: sandboxRepoDir is the container mount point,
+    // which differs from the actual host worktree path. In production the sandbox
+    // sees /home/agent/workspace while the host sees .sandcastle/worktrees/<name>.
     //
     // We use a PathTranslating sandbox that maps the container path to the real
-    // worktree path — exactly what Docker's bind mount does.
+    // worktree path — exactly what a bind-mount provider does.
     const containerPath = "/home/agent/workspace";
     const translatingLayer = Layer.succeed(
       Sandbox,

--- a/src/SandboxLifecycle.ts
+++ b/src/SandboxLifecycle.ts
@@ -37,7 +37,7 @@ export interface SandboxLifecycleOptions {
   readonly hooks?: SandboxHooks;
   readonly branch?: string;
   /** Host-side path to the worktree directory. Required when sandboxRepoDir
-   *  is a container path that doesn't exist on the host (e.g. /home/agent/workspace). */
+   *  is a sandbox path that doesn't exist on the host (e.g. /home/agent/workspace). */
   readonly hostWorktreePath?: string;
 }
 

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -44,7 +44,7 @@ export interface CreateSandboxOptions {
   };
   /** Paths relative to the host repo root to copy into the worktree at creation time. */
   readonly copyToSandbox?: string[];
-  /** @internal Test-only overrides to bypass Docker. */
+  /** @internal Test-only overrides to bypass the sandbox provider. */
   readonly _test?: {
     readonly hostRepoDir?: string;
     readonly buildSandboxLayer?: (
@@ -99,7 +99,7 @@ export interface Sandbox {
   readonly worktreePath: string;
   /** Invoke an agent inside the existing sandbox. */
   run(options: SandboxRunOptions): Promise<SandboxRunResult>;
-  /** Tear down the container and worktree. */
+  /** Tear down the sandbox and worktree. */
   close(): Promise<CloseResult>;
   /** Auto teardown via `await using`. */
   [Symbol.asyncDispose](): Promise<void>;
@@ -107,9 +107,8 @@ export interface Sandbox {
 
 /**
  * Eagerly creates a git worktree on the provided explicit branch and starts
- * a Docker container (or local sandbox in test mode) with the worktree
- * bind-mounted. Returns a Sandbox handle that can be reused across multiple
- * `run()` calls.
+ * a sandbox with the worktree bind-mounted. Returns a Sandbox handle that
+ * can be reused across multiple `run()` calls.
  */
 export const createSandbox = async (
   options: CreateSandboxOptions,

--- a/src/run.ts
+++ b/src/run.ts
@@ -155,7 +155,7 @@ export interface RunOptions {
   readonly idleTimeoutSeconds?: number;
   /** Optional name for the run, shown as a prefix in log output */
   readonly name?: string;
-  /** Paths relative to the host repo root to copy into the worktree before container start. */
+  /** Paths relative to the host repo root to copy into the worktree before sandbox start. */
   readonly copyToSandbox?: string[];
 }
 


### PR DESCRIPTION
## Summary
- Replaces Docker-specific language in JSDoc comments on provider-agnostic APIs with generic "sandbox" / "bind-mount provider" terminology
- Docker-specific files (`DockerLifecycle.ts`, `sandboxes/docker.ts`) retain their Docker references since they ARE Docker code
- Kept `docker()` usage examples in JSDoc where they reference real provider APIs

Closes #275

## Test plan
- [x] `npm run typecheck` passes
- [x] All 475 tests pass (`npm test`)
- [x] No functional code changes — JSDoc/comment only

🤖 Generated with [Claude Code](https://claude.com/claude-code)