### PR TITLE
Improve codex execution robustness and runtime validation

### DIFF
--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -37,6 +37,18 @@ If applicable, use RGR to complete the task.
 
 Before committing, run `npm run typecheck` and `npm run test` to ensure the tests pass.
 
+# VALIDATION EVIDENCE
+
+If the task touches runtime/bootstrap/dev server/build/deployment/server entry/auth/routing, do not treat passing unit tests as sufficient evidence. Collect explicit runtime evidence and record the exact commands plus outcomes.
+
+Examples of acceptable evidence:
+
+- build command passed
+- dev server started and a real probe succeeded
+- CLI/task runner command produced the expected observable output
+
+Do not declare success from a timeout alone. Evidence beats assertion.
+
 # COMMIT
 
 Make a git commit. The commit message must:
@@ -52,6 +64,8 @@ Keep it concise.
 # THE ISSUE
 
 If the task is not complete, leave a comment on the GitHub issue with what was done.
+
+If you leave an issue comment, include a short `Validation` section listing the commands you actually ran and whether they passed, failed, or were skipped.
 
 Do not close the issue - this will be done later.
 

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -58,6 +58,8 @@ If you find improvements to make:
 2. Run `npm run typecheck` and `npm run test` to ensure nothing is broken
 3. Commit with a message starting with `RALPH: Review -` describing the refinements
 
+If the change touches runtime/bootstrap/dev server/build/deployment/server entry/auth/routing, collect explicit runtime evidence instead of inferring success from unit tests alone. Record the exact commands and outcomes in your final answer.
+
 If the code is already clean and well-structured, do nothing.
 
 Once complete, output <promise>COMPLETE</promise>.

--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ Passing `SOURCE_BRANCH` or `TARGET_BRANCH` in `promptArgs` is an error — built
 
 When the agent outputs `<promise>COMPLETE</promise>`, the orchestrator stops the iteration loop early. This is a convention you document in your prompt for the agent to follow — the engine never injects it.
 
+This is only a stop signal. It does not imply semantic success. If your workflow needs stronger guarantees, encode concrete validation steps in the prompt or wrap `run()` with project-specific checks.
+
 This is useful for task-based workflows where the agent should stop once it has finished, rather than running all remaining iterations.
 
 You can override the default signal by passing `completionSignal` to `run()`. It accepts a single string or an array of strings:
@@ -370,6 +372,8 @@ await run({
 ```
 
 Tell the agent to output your chosen string(s) in the prompt, and the orchestrator will stop when it detects any of them. The matched signal is returned as `result.completionSignal`.
+
+For runtime-sensitive tasks, prefer prompts that require evidence such as build output, process health, or HTTP probes rather than allowing the agent to declare success without observable validation.
 
 ### Templates
 

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -362,6 +362,52 @@ describe("codex factory", () => {
     ]);
   });
 
+  it("parseStreamLine emits command completion details for item.completed command_execution", () => {
+    const provider = codex("gpt-5.4-mini");
+    const line = JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "command_execution",
+        command: "npm test",
+        exit_code: 1,
+        stdout: "tests started",
+        stderr: "boom",
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      {
+        type: "text",
+        text: "$ npm test (exit 1)\nstdout: tests started\nstderr: boom",
+      },
+    ]);
+  });
+
+  it("parseStreamLine truncates verbose command completion output", () => {
+    const provider = codex("gpt-5.4-mini");
+    const line = JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "command_execution",
+        command: "npm test",
+        exitCode: 0,
+        stdout: "a".repeat(260),
+      },
+    });
+    const events = provider.parseStreamLine(line);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        type: "text",
+      }),
+    );
+    if (events[0]?.type !== "text") {
+      throw new Error("expected text event");
+    }
+    expect(events[0].text).toContain("$ npm test (exit 0)");
+    expect(events[0].text).toContain("stdout: ");
+    expect(events[0].text).toContain("...");
+  });
+
   it("parseStreamLine skips turn.completed events", () => {
     const provider = codex("gpt-5.4-mini");
     const line = JSON.stringify({ type: "turn.completed" });

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -292,6 +292,20 @@ describe("codex factory", () => {
     expect(provider.name).toBe("codex");
   });
 
+  it("buildPrintCommand includes model and shell-escaped prompt", () => {
+    const provider = codex("gpt-5.4-mini");
+    const command = provider.buildPrintCommand("it's a test");
+    expect(command).toContain("-m 'gpt-5.4-mini'");
+    expect(command).toContain("'it'\\''s a test'");
+  });
+
+  it("buildPrintCommandFromStdin omits the prompt arg", () => {
+    const provider = codex("gpt-5.4-mini");
+    expect(provider.buildPrintCommandFromStdin?.()).toBe(
+      "codex exec --json --dangerously-bypass-approvals-and-sandbox -m 'gpt-5.4-mini' -",
+    );
+  });
+
   it("does not expose envManifest or dockerfileTemplate", () => {
     const provider = codex("gpt-5.4-mini");
     expect(provider).not.toHaveProperty("envManifest");

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -65,6 +65,7 @@ const parseStreamJsonLine = (line: string): ParsedStreamEvent[] => {
 export interface AgentProvider {
   readonly name: string;
   buildPrintCommand(prompt: string): string;
+  buildPrintCommandFromStdin?(): string;
   buildInteractiveArgs(prompt: string): string[];
   parseStreamLine(line: string): ParsedStreamEvent[];
 }
@@ -187,6 +188,10 @@ export const codex = (model: string): AgentProvider => ({
 
   buildPrintCommand(prompt: string): string {
     return `codex exec --json --dangerously-bypass-approvals-and-sandbox -m ${shellEscape(model)} ${shellEscape(prompt)}`;
+  },
+
+  buildPrintCommandFromStdin(): string {
+    return `codex exec --json --dangerously-bypass-approvals-and-sandbox -m ${shellEscape(model)} -`;
   },
 
   buildInteractiveArgs(_prompt: string): string[] {

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -4,6 +4,11 @@ export type ParsedStreamEvent =
   | { type: "tool_call"; name: string; args: string };
 
 const shellEscape = (s: string): string => "'" + s.replace(/'/g, "'\\''") + "'";
+const truncateForLog = (value: string, maxLength: number = 200): string => {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength - 3)}...`;
+};
 
 /** Maps allowlisted tool names to the input field containing the display arg */
 const TOOL_ARG_FIELDS: Record<string, string> = {
@@ -174,6 +179,36 @@ const parseCodexStreamLine = (line: string): ParsedStreamEvent[] => {
       typeof obj.item.command === "string"
     ) {
       return [{ type: "tool_call", name: "Bash", args: obj.item.command }];
+    }
+
+    if (
+      obj.type === "item.completed" &&
+      obj.item?.type === "command_execution" &&
+      typeof obj.item.command === "string"
+    ) {
+      const exitCode =
+        typeof obj.item.exit_code === "number"
+          ? obj.item.exit_code
+          : typeof obj.item.exitCode === "number"
+            ? obj.item.exitCode
+            : undefined;
+      const stdout =
+        typeof obj.item.stdout === "string"
+          ? truncateForLog(obj.item.stdout)
+          : "";
+      const stderr =
+        typeof obj.item.stderr === "string"
+          ? truncateForLog(obj.item.stderr)
+          : "";
+      const details = [
+        `$ ${obj.item.command}${typeof exitCode === "number" ? ` (exit ${exitCode})` : ""}`,
+        stdout ? `stdout: ${stdout}` : "",
+        stderr ? `stderr: ${stderr}` : "",
+      ].filter(Boolean);
+
+      if (details.length > 0) {
+        return [{ type: "text", text: details.join("\n") }];
+      }
     }
 
     // turn.completed → skip

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -2424,16 +2424,21 @@ const toCodexStreamJson = (output: string): string => {
  */
 const makeMockCodexAgentLayer = (
   sandboxDir: string,
-  mockAgentBehavior: (sandboxRepoDir: string) => Promise<string>,
+  mockAgentBehavior: (
+    sandboxRepoDir: string,
+    command: string,
+  ) => Promise<string>,
 ): Layer.Layer<Sandbox> => {
   const fsLayer = makeLocalSandboxLayer(sandboxDir);
 
   return Layer.succeed(Sandbox, {
     exec: (command, options) => {
-      if (command.startsWith("codex ")) {
+      if (command.includes("codex exec")) {
         return Effect.gen(function* () {
           const cwd = options?.cwd ?? sandboxDir;
-          const output = yield* Effect.promise(() => mockAgentBehavior(cwd));
+          const output = yield* Effect.promise(() =>
+            mockAgentBehavior(cwd, command),
+          );
           return { stdout: output, stderr: "", exitCode: 0 };
         });
       }
@@ -2442,10 +2447,12 @@ const makeMockCodexAgentLayer = (
       ).pipe(Effect.provide(fsLayer));
     },
     execStreaming: (command, onStdoutLine, options) => {
-      if (command.startsWith("codex ")) {
+      if (command.includes("codex exec")) {
         return Effect.gen(function* () {
           const cwd = options?.cwd ?? sandboxDir;
-          const output = yield* Effect.promise(() => mockAgentBehavior(cwd));
+          const output = yield* Effect.promise(() =>
+            mockAgentBehavior(cwd, command),
+          );
           const streamOutput = toCodexStreamJson(output);
           for (const line of streamOutput.split("\n")) {
             onStdoutLine(line);
@@ -2531,5 +2538,43 @@ describe("Orchestrator with codex provider", () => {
 
     expect(result.iterationsRun).toBe(1);
     expect(result.completionSignal).toBe("<promise>COMPLETE</promise>");
+  });
+
+  it("feeds the codex prompt via stdin file instead of argv", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-codex-host-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    let seenCommand = "";
+    let seenPrompt = "";
+
+    const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
+      hostDir,
+      (dir) =>
+        makeMockCodexAgentLayer(dir, async (repoDir, command) => {
+          seenCommand = command;
+          seenPrompt = await readFile(
+            "/tmp/sandcastle-prompt.txt",
+            "utf-8",
+          ).catch(() => "");
+          return "All done. <promise>COMPLETE</promise>";
+        }),
+    );
+
+    const result = await Effect.runPromise(
+      orchestrate({
+        provider: codexTestProvider,
+        hostRepoDir: hostDir,
+        sandboxRepoDir,
+        iterations: 1,
+        prompt: "large prompt body",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(result.iterationsRun).toBe(1);
+    expect(seenCommand).toContain(
+      "cat '/tmp/sandcastle-prompt.txt' | codex exec",
+    );
+    expect(seenPrompt).toBe("large prompt body");
   });
 });

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -1,4 +1,7 @@
 import { Deferred, Effect } from "effect";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Display } from "./Display.js";
 import { preprocessPrompt } from "./PromptPreprocessor.js";
 import { AgentError, TimeoutError } from "./errors.js";
@@ -11,6 +14,7 @@ import type { AgentProvider } from "./AgentProvider.js";
 export type { ParsedStreamEvent } from "./AgentProvider.js";
 
 const IDLE_WARNING_INTERVAL_MS = 60_000;
+const shellEscape = (s: string): string => "'" + s.replace(/'/g, "'\\''") + "'";
 
 const invokeAgent = (
   sandbox: SandboxService,
@@ -64,8 +68,22 @@ const invokeAgent = (
     resetIdleTimer();
 
     const execEffect = Effect.gen(function* () {
+      let command = provider.buildPrintCommand(prompt);
+      let tempDir: string | null = null;
+
+      if (provider.buildPrintCommandFromStdin) {
+        tempDir = mkdtempSync(join(tmpdir(), "sandcastle-prompt-"));
+        const hostPromptPath = join(tempDir, "prompt.txt");
+        const sandboxPromptPath = "/tmp/sandcastle-prompt.txt";
+
+        writeFileSync(hostPromptPath, prompt, "utf8");
+        yield* sandbox.copyIn(hostPromptPath, sandboxPromptPath);
+
+        command = `cat ${shellEscape(sandboxPromptPath)} | ${provider.buildPrintCommandFromStdin()}`;
+      }
+
       const execResult = yield* sandbox.execStreaming(
-        provider.buildPrintCommand(prompt),
+        command,
         (line) => {
           for (const parsed of provider.parseStreamLine(line)) {
             if (parsed.type === "text") {
@@ -82,10 +100,17 @@ const invokeAgent = (
         { cwd: sandboxRepoDir },
       );
 
+      if (tempDir !== null) {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+
       if (execResult.exitCode !== 0) {
+        const stdout = execResult.stdout.trim();
+        const stderr = execResult.stderr.trim();
+        const details = [stderr, stdout].filter(Boolean).join("\n");
         return yield* Effect.fail(
           new AgentError({
-            message: `${provider.name} exited with code ${execResult.exitCode}:\n${execResult.stderr}`,
+            message: `${provider.name} exited with code ${execResult.exitCode}${details ? `:\n${details}` : ""}`,
           }),
         );
       }

--- a/src/WorktreeManager.test.ts
+++ b/src/WorktreeManager.test.ts
@@ -263,7 +263,7 @@ describe("WorktreeManager.create", () => {
       repoDir,
       ".sandcastle",
       "worktrees",
-      "sandcastle-issue-17-relatorios-csv-pdf-historico",
+      "sandcastle-issue-17-report-export-history",
     );
 
     await mkdir(orphanPath, { recursive: true });
@@ -271,11 +271,11 @@ describe("WorktreeManager.create", () => {
 
     const { path, branch } = await run(
       create(repoDir, {
-        branch: "sandcastle/issue-17-relatorios-csv-pdf-historico",
+        branch: "sandcastle/issue-17-report-export-history",
       }),
     );
 
-    expect(branch).toBe("sandcastle/issue-17-relatorios-csv-pdf-historico");
+    expect(branch).toBe("sandcastle/issue-17-report-export-history");
     expect(path).toBe(orphanPath);
     await expect(stat(join(path, "junk.txt"))).rejects.toThrow();
 

--- a/src/WorktreeManager.test.ts
+++ b/src/WorktreeManager.test.ts
@@ -256,6 +256,31 @@ describe("WorktreeManager.create", () => {
     const err = await runFail(create(repoDir, { branch: "main" }));
     expect(err.message).toMatch(/already checked out/i);
   });
+
+  it("removes an orphaned target directory before creating the worktree", async () => {
+    const repoDir = await setupRepo();
+    const orphanPath = join(
+      repoDir,
+      ".sandcastle",
+      "worktrees",
+      "sandcastle-issue-17-relatorios-csv-pdf-historico",
+    );
+
+    await mkdir(orphanPath, { recursive: true });
+    await writeFile(join(orphanPath, "junk.txt"), "orphan");
+
+    const { path, branch } = await run(
+      create(repoDir, {
+        branch: "sandcastle/issue-17-relatorios-csv-pdf-historico",
+      }),
+    );
+
+    expect(branch).toBe("sandcastle/issue-17-relatorios-csv-pdf-historico");
+    expect(path).toBe(orphanPath);
+    await expect(stat(join(path, "junk.txt"))).rejects.toThrow();
+
+    await run(remove(path));
+  });
 });
 
 describe("WorktreeManager.remove", () => {
@@ -275,6 +300,26 @@ describe("WorktreeManager.remove", () => {
     await run(remove(path));
 
     // After removal, the worktree should not appear in git worktree list
+    const { stdout } = await execAsync("git worktree list --porcelain", {
+      cwd: repoDir,
+    });
+    expect(stdout).not.toContain(path);
+  });
+
+  it("cleans ignored files before removing the worktree", async () => {
+    const repoDir = await setupRepo();
+    await writeFile(join(repoDir, ".gitignore"), "node_modules/\n");
+    await execAsync('git add .gitignore && git commit -m "add gitignore"', {
+      cwd: repoDir,
+    });
+
+    const { path } = await run(create(repoDir));
+    await mkdir(join(path, "node_modules"), { recursive: true });
+    await writeFile(join(path, "node_modules", "junk.txt"), "junk");
+
+    await run(remove(path));
+
+    await expect(stat(path)).rejects.toThrow();
     const { stdout } = await execAsync("git worktree list --porcelain", {
       cwd: repoDir,
     });

--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -137,10 +137,28 @@ export const create = (
     }
 
     const worktreePath = join(worktreesDir, worktreeName);
+    const existing = yield* listWorktrees(repoDir);
+    const activeWorktreePaths = new Set(existing.map((wt) => wt.path));
+    const hasOrphanedDir =
+      (yield* fs
+        .exists(worktreePath)
+        .pipe(
+          Effect.mapError((e) => new WorktreeError({ message: e.message })),
+        )) && !activeWorktreePaths.has(worktreePath);
+
+    if (hasOrphanedDir) {
+      yield* fs.remove(worktreePath, { recursive: true, force: true }).pipe(
+        Effect.mapError(
+          (e) =>
+            new WorktreeError({
+              message: `Failed to remove orphaned worktree dir '${worktreePath}': ${e.message}`,
+            }),
+        ),
+      );
+    }
 
     if (opts?.branch) {
       // Proactively detect collision before git produces a confusing error
-      const existing = yield* listWorktrees(repoDir);
       const collision = existing.find((wt) => wt.branch === branch);
       if (collision) {
         yield* Effect.fail(
@@ -210,8 +228,21 @@ export const remove = (
 ): Effect.Effect<void, WorktreeError> => {
   // Derive the main repo dir: worktreePath = <repoDir>/.sandcastle/worktrees/<name>
   const repoDir = join(worktreePath, "..", "..", "..");
-  return execGit(["worktree", "remove", "--force", worktreePath], repoDir).pipe(
-    Effect.asVoid,
+  const removeOnce = () =>
+    execGit(["worktree", "remove", "--force", worktreePath], repoDir).pipe(
+      Effect.asVoid,
+    );
+
+  return removeOnce().pipe(
+    Effect.catchAll((error) => {
+      if (!error.message.includes("Directory not empty")) {
+        return Effect.fail(error);
+      }
+
+      return execGit(["clean", "-fdx"], worktreePath).pipe(
+        Effect.andThen(removeOnce()),
+      );
+    }),
   );
 };
 

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -1,5 +1,62 @@
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
 import { docker } from "./docker.js";
+import { execFile, spawn } from "node:child_process";
+
+const mockExecFile = vi.mocked(execFile);
+const mockSpawn = vi.mocked(spawn);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExecFile.mockImplementation((_cmd, args, _opts, callback) => {
+    const subcommand = Array.isArray(args) ? args[0] : undefined;
+    if (subcommand === "ps") {
+      (callback as Function)(null, "", "");
+      return {} as any;
+    }
+    (callback as Function)(null, "ok", "");
+    return {} as any;
+  });
+});
+
+const mockDockerSpawnSuccess = (
+  stdout: string,
+  stderr = "",
+  onInput?: (input: string) => void,
+) => {
+  mockSpawn.mockImplementation((_cmd, _args, _opts) => {
+    const proc = new EventEmitter() as any;
+    const stdin = new PassThrough();
+    const stdoutStream = new PassThrough();
+    const stderrStream = new PassThrough();
+    let input = "";
+
+    stdin.on("data", (chunk: Buffer) => {
+      input += chunk.toString();
+    });
+
+    stdin.on("end", () => {
+      onInput?.(input);
+      stdoutStream.end(stdout);
+      stderrStream.end(stderr);
+      proc.emit("close", 0);
+    });
+
+    proc.stdin = stdin;
+    proc.stdout = stdoutStream;
+    proc.stderr = stderrStream;
+
+    return proc;
+  });
+};
 
 describe("docker()", () => {
   it("returns a SandboxProvider with tag 'bind-mount' and name 'docker'", () => {
@@ -35,5 +92,75 @@ describe("docker()", () => {
     if (provider.tag === "bind-mount") {
       expect(provider.branchStrategy).toEqual({ type: "merge-to-head" });
     }
+  });
+
+  it("exec sends commands to sh via stdin instead of argv", async () => {
+    let seenInput = "";
+    mockDockerSpawnSuccess("ok", "", (input) => {
+      seenInput = input;
+    });
+
+    const provider = docker();
+    if (provider.tag !== "bind-mount") throw new Error("unreachable");
+
+    const handle = await provider.create({
+      worktreePath: "/host/worktree",
+      hostRepoPath: "/host/repo",
+      mounts: [
+        {
+          hostPath: "/host/worktree",
+          sandboxPath: "/sandbox/workspace",
+        },
+      ],
+      env: {},
+    });
+
+    const result = await handle.exec("printf ok", { cwd: "/repo" });
+
+    expect(result.stdout).toBe("ok");
+    expect(seenInput).toBe("printf ok");
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["exec", "-i", "-w", "/repo", "sh"]),
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+    const args = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(args).not.toContain("-c");
+    expect(args).not.toContain("printf ok");
+  });
+
+  it("execStreaming streams lines while still sending stdin", async () => {
+    let seenInput = "";
+    mockDockerSpawnSuccess("line 1\nline 2\n", "", (input) => {
+      seenInput = input;
+    });
+
+    const provider = docker();
+    if (provider.tag !== "bind-mount") throw new Error("unreachable");
+
+    const handle = await provider.create({
+      worktreePath: "/host/worktree",
+      hostRepoPath: "/host/repo",
+      mounts: [
+        {
+          hostPath: "/host/worktree",
+          sandboxPath: "/sandbox/workspace",
+        },
+      ],
+      env: {},
+    });
+
+    const lines: string[] = [];
+    const result = await handle.execStreaming(
+      "printf 'line 1\\nline 2\\n'",
+      (line) => lines.push(line),
+      { cwd: "/repo" },
+    );
+
+    expect(result.stdout).toBe("line 1\nline 2\n");
+    expect(lines).toEqual(["line 1", "line 2"]);
+    expect(seenInput).toBe("printf 'line 1\\nline 2\\n'");
+    const args = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(args).not.toContain("-c");
   });
 });

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -113,70 +113,14 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
         workspacePath,
 
         exec: (command: string, opts?: { cwd?: string }): Promise<ExecResult> =>
-          new Promise((resolve, reject) => {
-            const args = ["exec"];
-            if (opts?.cwd) args.push("-w", opts.cwd);
-            args.push(containerName, "sh", "-c", command);
-
-            execFile(
-              "docker",
-              args,
-              { maxBuffer: 10 * 1024 * 1024 },
-              (error, stdout, stderr) => {
-                if (error && error.code === undefined) {
-                  reject(new Error(`docker exec failed: ${error.message}`));
-                } else {
-                  resolve({
-                    stdout: stdout.toString(),
-                    stderr: stderr.toString(),
-                    exitCode: typeof error?.code === "number" ? error.code : 0,
-                  });
-                }
-              },
-            );
-          }),
+          execViaStdin(containerName, command, opts),
 
         execStreaming: (
           command: string,
           onLine: (line: string) => void,
           opts?: { cwd?: string },
         ): Promise<ExecResult> =>
-          new Promise((resolve, reject) => {
-            const args = ["exec"];
-            if (opts?.cwd) args.push("-w", opts.cwd);
-            args.push(containerName, "sh", "-c", command);
-
-            const proc = spawn("docker", args, {
-              stdio: ["ignore", "pipe", "pipe"],
-            });
-
-            const stdoutChunks: string[] = [];
-            const stderrChunks: string[] = [];
-
-            const rl = createInterface({ input: proc.stdout! });
-            rl.on("line", (line) => {
-              stdoutChunks.push(line);
-              onLine(line);
-            });
-
-            proc.stderr!.on("data", (chunk: Buffer) => {
-              stderrChunks.push(chunk.toString());
-            });
-
-            proc.on("error", (error) => {
-              reject(
-                new Error(`docker exec streaming failed: ${error.message}`),
-              );
-            });
-
-            proc.on("close", (code) => {
-              resolve({
-                stdout: stdoutChunks.join("\n"),
-                stderr: stderrChunks.join(""),
-                exitCode: code ?? 0,
-              });
-            });
-          }),
+          execViaStdin(containerName, command, opts, onLine),
 
         close: async (): Promise<void> => {
           process.removeListener("exit", onExit);
@@ -190,6 +134,53 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
     },
   });
 };
+
+const execViaStdin = (
+  containerName: string,
+  command: string,
+  opts?: { cwd?: string },
+  onLine?: (line: string) => void,
+): Promise<ExecResult> =>
+  new Promise((resolve, reject) => {
+    const args = ["exec", "-i"];
+    if (opts?.cwd) args.push("-w", opts.cwd);
+    args.push(containerName, "sh");
+
+    const proc = spawn("docker", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    const rl = createInterface({ input: proc.stdout! });
+    rl.on("line", (line) => {
+      onLine?.(line);
+    });
+
+    proc.stdout!.on("data", (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+    });
+
+    proc.stderr!.on("data", (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+    });
+
+    proc.on("error", (error) => {
+      reject(new Error(`docker exec failed: ${error.message}`));
+    });
+
+    proc.on("close", (code) => {
+      rl.close();
+      resolve({
+        stdout: Buffer.concat(stdoutChunks).toString(),
+        stderr: Buffer.concat(stderrChunks).toString(),
+        exitCode: code ?? 0,
+      });
+    });
+
+    proc.stdin!.end(command);
+  });
 
 /**
  * Derive the default Docker image name from the repo directory.

--- a/src/templates/parallel-planner/implement-prompt.md
+++ b/src/templates/parallel-planner/implement-prompt.md
@@ -37,6 +37,18 @@ If applicable, use RGR to complete the task.
 
 Before committing, run `npm run typecheck` and `npm run test` to ensure the tests pass.
 
+# VALIDATION EVIDENCE
+
+If the task touches runtime/bootstrap/dev server/build/deployment/server entry/auth/routing, collect explicit runtime evidence and record the exact commands plus outcomes. Do not treat passing unit tests as sufficient evidence for runtime-sensitive work.
+
+Examples of acceptable evidence:
+
+- build command passed
+- dev server started and a real probe succeeded
+- CLI/task runner command produced the expected observable output
+
+Do not declare success from a timeout alone. Evidence beats assertion.
+
 # COMMIT
 
 Make a git commit. The commit message must:
@@ -52,6 +64,8 @@ Keep it concise.
 # THE ISSUE
 
 If the task is not complete, leave a comment on the GitHub issue with what was done.
+
+If you leave an issue comment, include a short `Validation` section listing the commands you actually ran and whether they passed, failed, or were skipped.
 
 Do not close the issue - this will be done later.
 

--- a/src/templates/parallel-planner/main.mts
+++ b/src/templates/parallel-planner/main.mts
@@ -8,6 +8,9 @@
 //                      each working a single issue on its own branch.
 //   Phase 3 (Merge):   A sonnet agent merges all branches that produced commits.
 //
+// Runtime-sensitive work still needs explicit validation evidence in the
+// prompts. Passing unit tests alone is not enough for server/bootstrap tasks.
+//
 // The outer loop repeats up to MAX_ITERATIONS times so that newly unblocked
 // issues are picked up after each round of merges.
 //


### PR DESCRIPTION
## Summary

This PR improves how runtime-sensitive codex work is executed, validated, and surfaced.

## What changed

- route codex prompts through stdin instead of argv
- add stdin-based codex execution support in the provider interface
- run docker exec via stdin instead of `sh -c <command>`
- make worktree creation/removal more resilient around orphaned directories and ignored-file residue
- improve non-zero agent error reporting with both `stderr` and trimmed `stdout`
- clarify that `<promise>COMPLETE</promise>` is only an early-stop signal, not proof of semantic success
- require explicit runtime validation evidence in public prompts/templates for runtime-sensitive work
- surface summarized codex command completion details in the parsed stream output

## Why

These changes address one problem from three angles:

- execution should be less fragile
- runtime-sensitive work should require observable validation
- command outcomes should be visible in the stream/log output

Together, this makes it harder for runtime work to look done based only on a stop signal, a timeout, or unit tests that do not validate the actual runtime path.

## Transparency

Co-developed by Caio Guimarães and GPT-5.4 Codex.

This branch was force-pushed before PR creation to replace a flawed local rewrite and preserve the intended scope with cleaner, signed commits. No new feature scope was added.
