### PR TITLE
Fix log files overwriting between runs (#296)

### DIFF
--- a/.changeset/log-append-between-runs.md
+++ b/.changeset/log-append-between-runs.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Log files now append between runs instead of overwriting. Each run writes a `--- Run started: <ISO timestamp> ---` delimiter header, preserving logs from previous runs of the same branch+agent combination.

--- a/src/Display.test.ts
+++ b/src/Display.test.ts
@@ -194,7 +194,7 @@ describe("FileDisplay", () => {
 
   const readLog = (logPath: string) => readFileSync(logPath, "utf-8");
 
-  it("intro is a no-op", async () => {
+  it("intro is a no-op (only delimiter in log)", async () => {
     const { logPath, layer } = setup();
 
     await Effect.runPromise(
@@ -205,7 +205,7 @@ describe("FileDisplay", () => {
     );
 
     const log = readLog(logPath);
-    expect(log).toBe("");
+    expect(log).toMatch(/^\n--- Run started: .+ ---\n$/);
   });
 
   it("writes status messages to file", async () => {
@@ -328,7 +328,7 @@ describe("FileDisplay", () => {
     expect(log).toContain("Some agent output here");
   });
 
-  it("creates an empty log file on initialization", async () => {
+  it("creates log file with run delimiter on initialization", async () => {
     const { logPath, layer } = setup();
 
     await Effect.runPromise(
@@ -339,7 +339,7 @@ describe("FileDisplay", () => {
     );
 
     const log = readLog(logPath);
-    expect(log).toBe("");
+    expect(log).toMatch(/^\n--- Run started: .+ ---\n$/);
   });
 
   it("strips [Name] prefix from status messages", async () => {
@@ -374,6 +374,61 @@ describe("FileDisplay", () => {
 
     const log = readLog(logPath);
     expect(log).not.toContain("\u001b[");
+  });
+
+  it("appends a run delimiter on initialization instead of truncating", async () => {
+    const { logPath, layer } = setup();
+
+    // First run: write some content
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* Display;
+        yield* d.text("first run output");
+      }).pipe(Effect.provide(layer)),
+    );
+
+    const logAfterFirstRun = readLog(logPath);
+    expect(logAfterFirstRun).toContain("--- Run started:");
+    expect(logAfterFirstRun).toContain("first run output");
+
+    // Second run: create a new layer on the same path
+    const layer2 = Layer.provide(
+      FileDisplay.layer(logPath),
+      NodeFileSystem.layer,
+    );
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* Display;
+        yield* d.text("second run output");
+      }).pipe(Effect.provide(layer2)),
+    );
+
+    const logAfterSecondRun = readLog(logPath);
+    // Previous content must be preserved
+    expect(logAfterSecondRun).toContain("first run output");
+    expect(logAfterSecondRun).toContain("second run output");
+    // Two run delimiters
+    const delimiterMatches = logAfterSecondRun.match(
+      /--- Run started: .+ ---/g,
+    );
+    expect(delimiterMatches).toHaveLength(2);
+  });
+
+  it("writes run delimiter with ISO 8601 UTC timestamp", async () => {
+    const { logPath, layer } = setup();
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* Display;
+        yield* d.intro("sandcastle");
+      }).pipe(Effect.provide(layer)),
+    );
+
+    const log = readLog(logPath);
+    expect(log).toMatch(
+      /--- Run started: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z ---/,
+    );
   });
 
   it("writes summary without ANSI escape codes", async () => {

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -138,7 +138,10 @@ export const FileDisplay = {
         yield* fs
           .makeDirectory(dirname(filePath), { recursive: true })
           .pipe(Effect.orDie);
-        yield* fs.writeFileString(filePath, "").pipe(Effect.orDie);
+        const delimiter = `\n--- Run started: ${new Date().toISOString()} ---\n`;
+        yield* fs
+          .writeFileString(filePath, delimiter, { flag: "a" })
+          .pipe(Effect.orDie);
 
         const appendToLog = (line: string): Effect.Effect<void> =>
           fs


### PR DESCRIPTION
## Summary
- `FileDisplay.layer()` now appends a timestamped `--- Run started: <ISO 8601> ---` delimiter instead of truncating the log file on each run
- Previous log content is preserved when the same branch+agent log path is reused
- Updated 2 existing tests and added 2 new tests for append behavior and timestamp format

Closes #296

## Test plan
- [x] New test verifies second run on same path preserves first run's content and adds two delimiters
- [x] New test verifies delimiter contains ISO 8601 UTC timestamp
- [x] Existing tests updated to expect delimiter header instead of empty file
- [x] All 564 tests pass, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)