### PR TITLE
Add sudo option to hook commands (#295)

### DIFF
--- a/.changeset/add-sudo-hook-option.md
+++ b/.changeset/add-sudo-hook-option.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add `sudo` option to hook commands and `exec()` interface for running commands with elevated privileges inside sandboxes

--- a/README.md
+++ b/README.md
@@ -823,7 +823,7 @@ Add your project-specific dependencies (e.g., language runtimes, build tools) to
 
 ### Hooks
 
-Hooks are arrays of `{ "command": "..." }` objects executed sequentially inside the sandbox. If any command exits with a non-zero code, execution stops immediately with an error.
+Hooks are arrays of `{ command, sudo? }` objects executed sequentially inside the sandbox. If any command exits with a non-zero code, execution stops immediately with an error.
 
 | Hook             | When it runs               | Working directory      |
 | ---------------- | -------------------------- | ---------------------- |
@@ -831,12 +831,15 @@ Hooks are arrays of `{ "command": "..." }` objects executed sequentially inside 
 
 **`onSandboxReady`** runs after the sandbox is ready. Use it for dependency installation or build steps (e.g., `npm install`).
 
-Pass hooks programmatically via `run()`:
+Set `sudo: true` to run a command with elevated privileges inside the sandbox:
 
 ```ts
 await run({
   hooks: {
-    onSandboxReady: [{ command: "npm install" }],
+    onSandboxReady: [
+      { command: "apt-get install -y ffmpeg", sudo: true },
+      { command: "npm install" },
+    ],
   },
   // ...
 });

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -35,7 +35,7 @@ export interface ExecResult {
 export interface SandboxService {
   readonly exec: (
     command: string,
-    options?: { onLine?: (line: string) => void; cwd?: string },
+    options?: { onLine?: (line: string) => void; cwd?: string; sudo?: boolean },
   ) => Effect.Effect<ExecResult, ExecError>;
 
   /** Copy a file or directory from the host into the sandbox. */

--- a/src/SandboxLifecycle.test.ts
+++ b/src/SandboxLifecycle.test.ts
@@ -179,6 +179,58 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     );
   });
 
+  it("onSandboxReady hooks pass sudo option through to exec", async () => {
+    const { hostDir, worktreeDir } = await setupWorktree();
+
+    const execCalls: Array<{
+      command: string;
+      options?: { sudo?: boolean; cwd?: string };
+    }> = [];
+
+    // Custom sandbox layer that records exec calls
+    const spySandboxLayer = Layer.succeed(Sandbox, {
+      exec: (command, options) => {
+        execCalls.push({ command, options });
+        return Effect.succeed({ stdout: "", stderr: "", exitCode: 0 });
+      },
+      copyIn: () => Effect.succeed(undefined as never),
+      copyFileOut: () => Effect.succeed(undefined as never),
+    });
+
+    await Effect.runPromise(
+      withSandboxLifecycle(
+        {
+          hostRepoDir: hostDir,
+          sandboxRepoDir: worktreeDir,
+          branch: "sandcastle/test",
+          hooks: {
+            onSandboxReady: [
+              { command: "npm install" },
+              { command: "apt-get install -y ffmpeg", sudo: true },
+            ],
+          },
+        },
+        () => Effect.succeed("ok"),
+      ).pipe(Effect.provide(Layer.merge(spySandboxLayer, testDisplayLayer))),
+    );
+
+    // Find the hook exec calls (after git config calls)
+    const hookCalls = execCalls.filter(
+      (c) =>
+        c.command === "npm install" ||
+        c.command === "apt-get install -y ffmpeg",
+    );
+    expect(hookCalls).toHaveLength(2);
+    expect(hookCalls[0]).toEqual(
+      expect.objectContaining({ command: "npm install" }),
+    );
+    expect(hookCalls[0]!.options?.sudo).toBeUndefined();
+    expect(hookCalls[1]).toEqual(
+      expect.objectContaining({ command: "apt-get install -y ffmpeg" }),
+    );
+    expect(hookCalls[1]!.options?.sudo).toBe(true);
+  });
+
   it("returns commits made in the worktree", async () => {
     const { hostDir, worktreeDir, layer } = await setupWorktree();
 

--- a/src/SandboxLifecycle.ts
+++ b/src/SandboxLifecycle.ts
@@ -12,7 +12,7 @@ import {
 const execOk = (
   sandbox: SandboxService,
   command: string,
-  options?: { cwd?: string },
+  options?: { cwd?: string; sudo?: boolean },
 ): Effect.Effect<ExecResult, ExecError> =>
   Effect.flatMap(sandbox.exec(command, options), (result) =>
     result.exitCode !== 0
@@ -28,7 +28,10 @@ const execOk = (
 const execAsync = promisify(exec);
 
 export type SandboxHooks = {
-  readonly onSandboxReady?: ReadonlyArray<{ readonly command: string }>;
+  readonly onSandboxReady?: ReadonlyArray<{
+    readonly command: string;
+    readonly sudo?: boolean;
+  }>;
 };
 
 export interface SandboxLifecycleOptions {
@@ -126,7 +129,10 @@ export const withSandboxLifecycle = <A>(
         if (hooks?.onSandboxReady?.length) {
           for (const hook of hooks.onSandboxReady) {
             message(hook.command);
-            yield* execOk(sandbox, hook.command, { cwd: sandboxRepoDir });
+            yield* execOk(sandbox, hook.command, {
+              cwd: sandboxRepoDir,
+              sudo: hook.sudo,
+            });
           }
         }
       }),

--- a/src/SandboxProvider.ts
+++ b/src/SandboxProvider.ts
@@ -27,7 +27,7 @@ export interface BindMountSandboxHandle {
    */
   exec(
     command: string,
-    options?: { onLine?: (line: string) => void; cwd?: string },
+    options?: { onLine?: (line: string) => void; cwd?: string; sudo?: boolean },
   ): Promise<ExecResult>;
   /** Tear down the sandbox. */
   close(): Promise<void>;
@@ -76,7 +76,7 @@ export interface IsolatedSandboxHandle {
    */
   exec(
     command: string,
-    options?: { onLine?: (line: string) => void; cwd?: string },
+    options?: { onLine?: (line: string) => void; cwd?: string; sudo?: boolean },
   ): Promise<ExecResult>;
   /** Copy a file or directory from the host into the sandbox. */
   copyIn(hostPath: string, sandboxPath: string): Promise<void>;

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -41,7 +41,10 @@ export interface CreateSandboxOptions {
   readonly sandbox: SandboxProvider;
   /** One-time setup hooks to run when the sandbox is first created. */
   readonly hooks?: {
-    readonly onSandboxReady?: ReadonlyArray<{ command: string }>;
+    readonly onSandboxReady?: ReadonlyArray<{
+      command: string;
+      sudo?: boolean;
+    }>;
   };
   /** Paths relative to the host repo root to copy into the worktree at creation time. */
   readonly copyToSandbox?: string[];
@@ -193,7 +196,10 @@ export const createSandbox = async (
           `git config --global --add safe.directory "${sandboxRepoDir}"`,
         );
         for (const hook of options.hooks!.onSandboxReady!) {
-          yield* sandbox.exec(hook.command, { cwd: sandboxRepoDir });
+          yield* sandbox.exec(hook.command, {
+            cwd: sandboxRepoDir,
+            sudo: hook.sudo,
+          });
         }
       }).pipe(Effect.provide(sandboxLayer)),
     );

--- a/src/run.ts
+++ b/src/run.ts
@@ -143,7 +143,10 @@ export interface RunOptions {
   readonly maxIterations?: number;
   /** Hooks to run during sandbox lifecycle */
   readonly hooks?: {
-    readonly onSandboxReady?: ReadonlyArray<{ command: string }>;
+    readonly onSandboxReady?: ReadonlyArray<{
+      command: string;
+      sudo?: boolean;
+    }>;
   };
   /** Key-value map for {{KEY}} placeholder substitution in prompts */
   readonly promptArgs?: PromptArgs;

--- a/src/sandboxes/daytona.ts
+++ b/src/sandboxes/daytona.ts
@@ -92,8 +92,13 @@ export const daytona = (options?: DaytonaOptions): IsolatedSandboxProvider =>
 
         exec: async (
           command: string,
-          opts?: { onLine?: (line: string) => void; cwd?: string },
+          opts?: {
+            onLine?: (line: string) => void;
+            cwd?: string;
+            sudo?: boolean;
+          },
         ): Promise<ExecResult> => {
+          const effectiveCommand = opts?.sudo ? `sudo ${command}` : command;
           if (opts?.onLine) {
             const onLine = opts.onLine;
             const sessionId = `sandcastle-${crypto.randomUUID()}`;
@@ -103,7 +108,7 @@ export const daytona = (options?: DaytonaOptions): IsolatedSandboxProvider =>
               const execResponse = await sandbox.process.executeSessionCommand(
                 sessionId,
                 {
-                  command: `cd ${opts?.cwd ?? workspacePath} && ${command}`,
+                  command: `cd ${opts?.cwd ?? workspacePath} && ${effectiveCommand}`,
                   async: true,
                 },
               );
@@ -152,7 +157,7 @@ export const daytona = (options?: DaytonaOptions): IsolatedSandboxProvider =>
           }
 
           const response = await sandbox.process.executeCommand(
-            command,
+            effectiveCommand,
             opts?.cwd ?? workspacePath,
           );
           return {

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -125,11 +125,16 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
 
         exec: (
           command: string,
-          opts?: { onLine?: (line: string) => void; cwd?: string },
+          opts?: {
+            onLine?: (line: string) => void;
+            cwd?: string;
+            sudo?: boolean;
+          },
         ): Promise<ExecResult> => {
+          const effectiveCommand = opts?.sudo ? `sudo ${command}` : command;
           const args = ["exec"];
           if (opts?.cwd) args.push("-w", opts.cwd);
-          args.push(containerName, "sh", "-c", command);
+          args.push(containerName, "sh", "-c", effectiveCommand);
 
           if (opts?.onLine) {
             const onLine = opts.onLine;

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -143,11 +143,16 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
 
         exec: (
           command: string,
-          opts?: { onLine?: (line: string) => void; cwd?: string },
+          opts?: {
+            onLine?: (line: string) => void;
+            cwd?: string;
+            sudo?: boolean;
+          },
         ): Promise<ExecResult> => {
+          const effectiveCommand = opts?.sudo ? `sudo ${command}` : command;
           const args = ["exec"];
           if (opts?.cwd) args.push("-w", opts.cwd);
-          args.push(containerName, "sh", "-c", command);
+          args.push(containerName, "sh", "-c", effectiveCommand);
 
           if (opts?.onLine) {
             const onLine = opts.onLine;

--- a/src/sandboxes/test-isolated.ts
+++ b/src/sandboxes/test-isolated.ts
@@ -38,7 +38,11 @@ export const testIsolated = (): IsolatedSandboxProvider =>
 
         exec: (
           command: string,
-          options?: { onLine?: (line: string) => void; cwd?: string },
+          options?: {
+            onLine?: (line: string) => void;
+            cwd?: string;
+            sudo?: boolean;
+          },
         ): Promise<ExecResult> => {
           if (options?.onLine) {
             const onLine = options.onLine;

--- a/src/sandboxes/vercel.ts
+++ b/src/sandboxes/vercel.ts
@@ -164,7 +164,11 @@ export const vercel = (options?: VercelOptions): IsolatedSandboxProvider =>
 
         exec: async (
           command: string,
-          opts?: { onLine?: (line: string) => void; cwd?: string },
+          opts?: {
+            onLine?: (line: string) => void;
+            cwd?: string;
+            sudo?: boolean;
+          },
         ): Promise<ExecResult> => {
           if (opts?.onLine) {
             const onLine = opts.onLine;
@@ -206,6 +210,7 @@ export const vercel = (options?: VercelOptions): IsolatedSandboxProvider =>
               cwd: opts?.cwd ?? VERCEL_WORKSPACE_PATH,
               stdout: stdoutWritable,
               stderr: stderrWritable,
+              ...(opts?.sudo ? { sudo: true } : {}),
             });
 
             return {
@@ -219,6 +224,7 @@ export const vercel = (options?: VercelOptions): IsolatedSandboxProvider =>
             cmd: "sh",
             args: ["-c", command],
             cwd: opts?.cwd ?? VERCEL_WORKSPACE_PATH,
+            ...(opts?.sudo ? { sudo: true } : {}),
           });
 
           const stdout = await result.stdout();


### PR DESCRIPTION
## Summary
- Add `sudo?: boolean` option to hook commands and `exec()` interface so commands can run with elevated privileges inside sandboxes
- Docker, Podman, Daytona providers prefix `sudo ` to the command string; Vercel uses native `sudo` on `runCommand()`
- Threaded through all layers: `SandboxHooks` → `execOk` → `SandboxService` → provider handle

## Test plan
- [x] New test: `onSandboxReady hooks pass sudo option through to exec` verifies sudo flag is threaded from hook config to exec calls
- [x] All 563 existing tests pass
- [x] TypeScript type checking passes

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)