### PR TITLE
Add Codex effort option via model_reasoning_effort

### DIFF
--- a/.changeset/codex-reasoning-effort.md
+++ b/.changeset/codex-reasoning-effort.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add a Codex `effort` option that forwards `model_reasoning_effort` to Codex for exec and interactive runs.

--- a/README.md
+++ b/README.md
@@ -519,6 +519,19 @@ agent: claudeCode("claude-opus-4-6", { effort: "high" });
 | `effort` | `"low"` \| `"medium"` \| `"high"` \| `"max"` | —       | Claude Code reasoning effort level (`max` is Opus only) |
 | `env`    | `Record<string, string>`                     | `{}`    | Environment variables injected by this agent provider   |
 
+### `CodexOptions`
+
+The `codex()` factory accepts an optional second argument for provider-specific options:
+
+```typescript
+agent: codex("gpt-5.4", { effort: "high" });
+```
+
+| Option   | Type                                           | Default | Description                                               |
+| -------- | ---------------------------------------------- | ------- | --------------------------------------------------------- |
+| `effort` | `"low"` \| `"medium"` \| `"high"` \| `"xhigh"` | —       | Codex reasoning effort level via `model_reasoning_effort` |
+| `env`    | `Record<string, string>`                       | `{}`    | Environment variables injected by this agent provider     |
+
 ### Provider `env`
 
 Both **agent providers** and **sandbox providers** accept an optional `env: Record<string, string>` in their options. These environment variables are merged with the `.sandcastle/.env` resolver output at launch time:

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -339,12 +339,40 @@ describe("codex factory", () => {
     expect(command).toContain("-m 'gpt-5.4-mini'");
   });
 
+  it("buildPrintCommand includes model reasoning effort config when specified", () => {
+    const provider = codex("gpt-5.4-mini", { effort: "high" });
+    const command = provider.buildPrintCommand("do something");
+    expect(command).toContain(`-c 'model_reasoning_effort="high"'`);
+  });
+
+  it("buildPrintCommand omits model reasoning effort config when not specified", () => {
+    const provider = codex("gpt-5.4-mini");
+    const command = provider.buildPrintCommand("do something");
+    expect(command).not.toContain("model_reasoning_effort");
+  });
+
   it("buildInteractiveArgs includes the binary and model", () => {
     const provider = codex("gpt-5.4-mini");
     const args = provider.buildInteractiveArgs("");
     expect(args[0]).toBe("codex");
     expect(args).toContain("gpt-5.4-mini");
     expect(args).toContain("--model");
+  });
+
+  it("buildInteractiveArgs includes model reasoning effort config when specified", () => {
+    const provider = codex("gpt-5.4-mini", { effort: "xhigh" });
+    const args = provider.buildInteractiveArgs("");
+    expect(args).toContain("-c");
+    expect(args).toContain('model_reasoning_effort="xhigh"');
+  });
+
+  it("supports all codex effort levels", () => {
+    for (const effort of ["low", "medium", "high", "xhigh"] as const) {
+      const provider = codex("gpt-5.4-mini", { effort });
+      expect(provider.buildPrintCommand("test")).toContain(
+        `model_reasoning_effort="${effort}"`,
+      );
+    }
   });
 
   it("parseStreamLine extracts text and result from item.completed agent_message", () => {

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -193,6 +193,7 @@ const parseCodexStreamLine = (line: string): ParsedStreamEvent[] => {
 
 /** Options for the codex agent provider. */
 export interface CodexOptions {
+  readonly effort?: "low" | "medium" | "high" | "xhigh";
   /** Environment variables injected by this agent provider. */
   readonly env?: Record<string, string>;
 }
@@ -205,11 +206,18 @@ export const codex = (
   env: options?.env ?? {},
 
   buildPrintCommand(prompt: string): string {
-    return `codex exec --json --dangerously-bypass-approvals-and-sandbox -m ${shellEscape(model)} ${shellEscape(prompt)}`;
+    const effortFlag = options?.effort
+      ? ` -c ${shellEscape(`model_reasoning_effort="${options.effort}"`)}`
+      : "";
+    return `codex exec --json --dangerously-bypass-approvals-and-sandbox -m ${shellEscape(model)}${effortFlag} ${shellEscape(prompt)}`;
   },
 
   buildInteractiveArgs(_prompt: string): string[] {
-    return ["codex", "--model", model];
+    const args = ["codex", "--model", model];
+    if (options?.effort) {
+      args.push("-c", `model_reasoning_effort="${options.effort}"`);
+    }
+    return args;
   },
 
   parseStreamLine(line: string): ParsedStreamEvent[] {


### PR DESCRIPTION
## Summary
- add an `effort` option to `codex()` and forward it through Codex's `model_reasoning_effort` config override
- cover the new behavior in `AgentProvider` tests for both exec and interactive invocation paths
- document `CodexOptions` in the README so Sandcastle users can discover the option

## Testing
- `npm test -- src/AgentProvider.test.ts`
- `npm test` (fails on existing unrelated repo issues in this checkout, including missing `dist/main.js` for CLI tests and several pre-existing path-sensitive/time-sensitive test failures)
- `npm run typecheck` (fails on existing missing optional `@daytona/sdk` types)