### PR TITLE
Harden codex stdin execution and worktree cleanup

### DIFF
--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -314,6 +314,20 @@ describe("codex factory", () => {
     expect(provider.name).toBe("codex");
   });
 
+  it("buildPrintCommand includes model and shell-escaped prompt", () => {
+    const provider = codex("gpt-5.4-mini");
+    const command = provider.buildPrintCommand("it's a test");
+    expect(command).toContain("-m 'gpt-5.4-mini'");
+    expect(command).toContain("'it'\\''s a test'");
+  });
+
+  it("buildPrintCommandFromStdin omits the prompt arg", () => {
+    const provider = codex("gpt-5.4-mini");
+    expect(provider.buildPrintCommandFromStdin?.()).toBe(
+      "codex exec --json --dangerously-bypass-approvals-and-sandbox -m 'gpt-5.4-mini' -",
+    );
+  });
+
   it("does not expose envManifest or dockerfileTemplate", () => {
     const provider = codex("gpt-5.4-mini");
     expect(provider).not.toHaveProperty("envManifest");

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -67,6 +67,7 @@ export interface AgentProvider {
   /** Environment variables injected by this agent provider. Merged at launch time with env resolver and sandbox provider env. */
   readonly env: Record<string, string>;
   buildPrintCommand(prompt: string): string;
+  buildPrintCommandFromStdin?(): string;
   buildInteractiveArgs(prompt: string): string[];
   parseStreamLine(line: string): ParsedStreamEvent[];
 }
@@ -206,6 +207,10 @@ export const codex = (
 
   buildPrintCommand(prompt: string): string {
     return `codex exec --json --dangerously-bypass-approvals-and-sandbox -m ${shellEscape(model)} ${shellEscape(prompt)}`;
+  },
+
+  buildPrintCommandFromStdin(): string {
+    return `codex exec --json --dangerously-bypass-approvals-and-sandbox -m ${shellEscape(model)} -`;
   },
 
   buildInteractiveArgs(_prompt: string): string[] {

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -2626,18 +2626,23 @@ const toCodexStreamJson = (output: string): string => {
  */
 const makeMockCodexAgentLayer = (
   sandboxDir: string,
-  mockAgentBehavior: (sandboxRepoDir: string) => Promise<string>,
+  mockAgentBehavior: (
+    sandboxRepoDir: string,
+    command: string,
+  ) => Promise<string>,
 ): Layer.Layer<Sandbox> => {
   const fsLayer = makeLocalSandboxLayer(sandboxDir);
 
   return Layer.succeed(Sandbox, {
     exec: (command, options) => {
-      if (command.startsWith("codex ")) {
+      if (command.includes("codex exec")) {
         if (options?.onLine) {
           const onLine = options.onLine;
           return Effect.gen(function* () {
             const cwd = options?.cwd ?? sandboxDir;
-            const output = yield* Effect.promise(() => mockAgentBehavior(cwd));
+            const output = yield* Effect.promise(() =>
+              mockAgentBehavior(cwd, command),
+            );
             const streamOutput = toCodexStreamJson(output);
             for (const line of streamOutput.split("\n")) {
               onLine(line);
@@ -2647,7 +2652,9 @@ const makeMockCodexAgentLayer = (
         }
         return Effect.gen(function* () {
           const cwd = options?.cwd ?? sandboxDir;
-          const output = yield* Effect.promise(() => mockAgentBehavior(cwd));
+          const output = yield* Effect.promise(() =>
+            mockAgentBehavior(cwd, command),
+          );
           return { stdout: output, stderr: "", exitCode: 0 };
         });
       }
@@ -2729,5 +2736,43 @@ describe("Orchestrator with codex provider", () => {
 
     expect(result.iterationsRun).toBe(1);
     expect(result.completionSignal).toBe("<promise>COMPLETE</promise>");
+  });
+
+  it("feeds the codex prompt via stdin file instead of argv", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-codex-host-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    let seenCommand = "";
+    let seenPrompt = "";
+
+    const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
+      hostDir,
+      (dir) =>
+        makeMockCodexAgentLayer(dir, async (repoDir, command) => {
+          seenCommand = command;
+          seenPrompt = await readFile(
+            "/tmp/sandcastle-prompt.txt",
+            "utf-8",
+          ).catch(() => "");
+          return "All done. <promise>COMPLETE</promise>";
+        }),
+    );
+
+    const result = await Effect.runPromise(
+      orchestrate({
+        provider: codexTestProvider,
+        hostRepoDir: hostDir,
+        sandboxRepoDir,
+        iterations: 1,
+        prompt: "large prompt body",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(result.iterationsRun).toBe(1);
+    expect(seenCommand).toContain(
+      "cat '/tmp/sandcastle-prompt.txt' | codex exec",
+    );
+    expect(seenPrompt).toBe("large prompt body");
   });
 });

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -1,4 +1,7 @@
 import { Deferred, Effect } from "effect";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Display } from "./Display.js";
 import { preprocessPrompt } from "./PromptPreprocessor.js";
 import { AgentError, TimeoutError } from "./errors.js";
@@ -12,6 +15,7 @@ import { TextDeltaBuffer } from "./TextDeltaBuffer.js";
 export type { ParsedStreamEvent } from "./AgentProvider.js";
 
 const IDLE_WARNING_INTERVAL_MS = 60_000;
+const shellEscape = (s: string): string => "'" + s.replace(/'/g, "'\\''") + "'";
 
 const invokeAgent = (
   sandbox: SandboxService,
@@ -63,31 +67,45 @@ const invokeAgent = (
     };
 
     resetIdleTimer();
+    let tempDir: string | null = null;
 
     const execEffect = Effect.gen(function* () {
-      const execResult = yield* sandbox.exec(
-        provider.buildPrintCommand(prompt),
-        {
-          onLine: (line) => {
-            resetIdleTimer();
-            for (const parsed of provider.parseStreamLine(line)) {
-              if (parsed.type === "text") {
-                onText(parsed.text);
-              } else if (parsed.type === "result") {
-                resultText = parsed.result;
-              } else if (parsed.type === "tool_call") {
-                onToolCall(parsed.name, parsed.args);
-              }
+      let command = provider.buildPrintCommand(prompt);
+
+      if (provider.buildPrintCommandFromStdin) {
+        tempDir = mkdtempSync(join(tmpdir(), "sandcastle-prompt-"));
+        const hostPromptPath = join(tempDir, "prompt.txt");
+        const sandboxPromptPath = "/tmp/sandcastle-prompt.txt";
+
+        writeFileSync(hostPromptPath, prompt, "utf8");
+        yield* sandbox.copyIn(hostPromptPath, sandboxPromptPath);
+
+        command = `cat ${shellEscape(sandboxPromptPath)} | ${provider.buildPrintCommandFromStdin()}`;
+      }
+
+      const execResult = yield* sandbox.exec(command, {
+        onLine: (line) => {
+          resetIdleTimer();
+          for (const parsed of provider.parseStreamLine(line)) {
+            if (parsed.type === "text") {
+              onText(parsed.text);
+            } else if (parsed.type === "result") {
+              resultText = parsed.result;
+            } else if (parsed.type === "tool_call") {
+              onToolCall(parsed.name, parsed.args);
             }
-          },
-          cwd: sandboxRepoDir,
+          }
         },
-      );
+        cwd: sandboxRepoDir,
+      });
 
       if (execResult.exitCode !== 0) {
+        const stdout = execResult.stdout.trim();
+        const stderr = execResult.stderr.trim();
+        const details = [stderr, stdout].filter(Boolean).join("\n");
         return yield* Effect.fail(
           new AgentError({
-            message: `${provider.name} exited with code ${execResult.exitCode}:\n${execResult.stderr}`,
+            message: `${provider.name} exited with code ${execResult.exitCode}${details ? `:\n${details}` : ""}`,
           }),
         );
       }
@@ -103,6 +121,10 @@ const invokeAgent = (
           if (warningHandle !== null) {
             clearInterval(warningHandle);
             warningHandle = null;
+          }
+          if (tempDir !== null) {
+            rmSync(tempDir, { recursive: true, force: true });
+            tempDir = null;
           }
         }),
       ),

--- a/src/WorktreeManager.test.ts
+++ b/src/WorktreeManager.test.ts
@@ -294,6 +294,31 @@ describe("WorktreeManager.create", () => {
     const err = await runFail(create(repoDir, { branch: "main" }));
     expect(err.message).toMatch(/already checked out/i);
   });
+
+  it("removes an orphaned target directory before creating the worktree", async () => {
+    const repoDir = await setupRepo();
+    const orphanPath = join(
+      repoDir,
+      ".sandcastle",
+      "worktrees",
+      "sandcastle-issue-17-example-worktree",
+    );
+
+    await mkdir(orphanPath, { recursive: true });
+    await writeFile(join(orphanPath, "junk.txt"), "orphan");
+
+    const { path, branch } = await run(
+      create(repoDir, {
+        branch: "sandcastle/issue-17-example-worktree",
+      }),
+    );
+
+    expect(branch).toBe("sandcastle/issue-17-example-worktree");
+    expect(path).toBe(orphanPath);
+    await expect(stat(join(path, "junk.txt"))).rejects.toThrow();
+
+    await run(remove(path));
+  });
 });
 
 describe("WorktreeManager.remove", () => {
@@ -313,6 +338,26 @@ describe("WorktreeManager.remove", () => {
     await run(remove(path));
 
     // After removal, the worktree should not appear in git worktree list
+    const { stdout } = await execAsync("git worktree list --porcelain", {
+      cwd: repoDir,
+    });
+    expect(stdout).not.toContain(path);
+  });
+
+  it("cleans ignored files before removing the worktree", async () => {
+    const repoDir = await setupRepo();
+    await writeFile(join(repoDir, ".gitignore"), "node_modules/\n");
+    await execAsync('git add .gitignore && git commit -m "add gitignore"', {
+      cwd: repoDir,
+    });
+
+    const { path } = await run(create(repoDir));
+    await mkdir(join(path, "node_modules"), { recursive: true });
+    await writeFile(join(path, "node_modules", "junk.txt"), "junk");
+
+    await run(remove(path));
+
+    await expect(stat(path)).rejects.toThrow();
     const { stdout } = await execAsync("git worktree list --porcelain", {
       cwd: repoDir,
     });

--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -142,10 +142,28 @@ export const create = (
     }
 
     const worktreePath = join(worktreesDir, worktreeName);
+    const existing = yield* listWorktrees(repoDir);
+    const activeWorktreePaths = new Set(existing.map((wt) => wt.path));
+    const hasOrphanedDir =
+      (yield* fs
+        .exists(worktreePath)
+        .pipe(
+          Effect.mapError((e) => new WorktreeError({ message: e.message })),
+        )) && !activeWorktreePaths.has(worktreePath);
+
+    if (hasOrphanedDir) {
+      yield* fs.remove(worktreePath, { recursive: true, force: true }).pipe(
+        Effect.mapError(
+          (e) =>
+            new WorktreeError({
+              message: `Failed to remove orphaned worktree dir '${worktreePath}': ${e.message}`,
+            }),
+        ),
+      );
+    }
 
     if (opts?.branch) {
       // Proactively detect collision before git produces a confusing error
-      const existing = yield* listWorktrees(repoDir);
       const collision = existing.find((wt) => wt.branch === branch);
       if (collision) {
         if (opts.throwOnDuplicateWorktree === false) {
@@ -218,8 +236,21 @@ export const remove = (
 ): Effect.Effect<void, WorktreeError> => {
   // Derive the main repo dir: worktreePath = <repoDir>/.sandcastle/worktrees/<name>
   const repoDir = join(worktreePath, "..", "..", "..");
-  return execGit(["worktree", "remove", "--force", worktreePath], repoDir).pipe(
-    Effect.asVoid,
+  const removeOnce = () =>
+    execGit(["worktree", "remove", "--force", worktreePath], repoDir).pipe(
+      Effect.asVoid,
+    );
+
+  return removeOnce().pipe(
+    Effect.catchAll((error) => {
+      if (!error.message.includes("Directory not empty")) {
+        return Effect.fail(error);
+      }
+
+      return execGit(["clean", "-fdx"], worktreePath).pipe(
+        Effect.andThen(removeOnce()),
+      );
+    }),
   );
 };
 

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -1,5 +1,62 @@
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
 import { docker } from "./docker.js";
+import { execFile, spawn } from "node:child_process";
+
+const mockExecFile = vi.mocked(execFile);
+const mockSpawn = vi.mocked(spawn);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExecFile.mockImplementation((_cmd, args, _opts, callback) => {
+    const subcommand = Array.isArray(args) ? args[0] : undefined;
+    if (subcommand === "ps") {
+      (callback as Function)(null, "", "");
+      return {} as any;
+    }
+    (callback as Function)(null, "ok", "");
+    return {} as any;
+  });
+});
+
+const mockDockerSpawnSuccess = (
+  stdout: string,
+  stderr = "",
+  onInput?: (input: string) => void,
+) => {
+  mockSpawn.mockImplementation((_cmd, _args, _opts) => {
+    const proc = new EventEmitter() as any;
+    const stdin = new PassThrough();
+    const stdoutStream = new PassThrough();
+    const stderrStream = new PassThrough();
+    let input = "";
+
+    stdin.on("data", (chunk: Buffer) => {
+      input += chunk.toString();
+    });
+
+    stdin.on("end", () => {
+      onInput?.(input);
+      stdoutStream.end(stdout);
+      stderrStream.end(stderr);
+      proc.emit("close", 0);
+    });
+
+    proc.stdin = stdin;
+    proc.stdout = stdoutStream;
+    proc.stderr = stderrStream;
+
+    return proc;
+  });
+};
 
 describe("docker()", () => {
   it("returns a SandboxProvider with tag 'bind-mount' and name 'docker'", () => {
@@ -61,5 +118,74 @@ describe("docker()", () => {
   it("defaults env to empty object when not provided", () => {
     const provider = docker();
     expect(provider.env).toEqual({});
+  });
+
+  it("exec sends commands to sh via stdin instead of argv", async () => {
+    let seenInput = "";
+    mockDockerSpawnSuccess("ok", "", (input) => {
+      seenInput = input;
+    });
+
+    const provider = docker();
+    if (provider.tag !== "bind-mount") throw new Error("unreachable");
+
+    const handle = await provider.create({
+      worktreePath: "/host/worktree",
+      hostRepoPath: "/host/repo",
+      mounts: [
+        {
+          hostPath: "/host/worktree",
+          sandboxPath: "/sandbox/workspace",
+        },
+      ],
+      env: {},
+    });
+
+    const result = await handle.exec("printf ok", { cwd: "/repo" });
+
+    expect(result.stdout).toBe("ok");
+    expect(seenInput).toBe("printf ok");
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["exec", "-i", "-w", "/repo", "sh"]),
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+    const args = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(args).not.toContain("-c");
+    expect(args).not.toContain("printf ok");
+  });
+
+  it("exec streams lines while still sending stdin", async () => {
+    let seenInput = "";
+    mockDockerSpawnSuccess("line 1\nline 2\n", "", (input) => {
+      seenInput = input;
+    });
+
+    const provider = docker();
+    if (provider.tag !== "bind-mount") throw new Error("unreachable");
+
+    const handle = await provider.create({
+      worktreePath: "/host/worktree",
+      hostRepoPath: "/host/repo",
+      mounts: [
+        {
+          hostPath: "/host/worktree",
+          sandboxPath: "/sandbox/workspace",
+        },
+      ],
+      env: {},
+    });
+
+    const lines: string[] = [];
+    const result = await handle.exec("printf 'line 1\\nline 2\\n'", {
+      cwd: "/repo",
+      onLine: (line) => lines.push(line),
+    });
+
+    expect(result.stdout).toBe("line 1\nline 2\n");
+    expect(lines).toEqual(["line 1", "line 2"]);
+    expect(seenInput).toBe("printf 'line 1\\nline 2\\n'");
+    const args = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(args).not.toContain("-c");
   });
 });

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -6,7 +6,7 @@
  *   await run({ agent: claudeCode("claude-opus-4-6"), sandbox: docker() });
  */
 
-import { execFile, execFileSync, spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline";
 import { Effect } from "effect";
@@ -130,65 +130,8 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
             cwd?: string;
             sudo?: boolean;
           },
-        ): Promise<ExecResult> => {
-          const effectiveCommand = opts?.sudo ? `sudo ${command}` : command;
-          const args = ["exec"];
-          if (opts?.cwd) args.push("-w", opts.cwd);
-          args.push(containerName, "sh", "-c", effectiveCommand);
-
-          if (opts?.onLine) {
-            const onLine = opts.onLine;
-            return new Promise((resolve, reject) => {
-              const proc = spawn("docker", args, {
-                stdio: ["ignore", "pipe", "pipe"],
-              });
-
-              const stdoutChunks: string[] = [];
-              const stderrChunks: string[] = [];
-
-              const rl = createInterface({ input: proc.stdout! });
-              rl.on("line", (line) => {
-                stdoutChunks.push(line);
-                onLine(line);
-              });
-
-              proc.stderr!.on("data", (chunk: Buffer) => {
-                stderrChunks.push(chunk.toString());
-              });
-
-              proc.on("error", (error) => {
-                reject(new Error(`docker exec failed: ${error.message}`));
-              });
-
-              proc.on("close", (code) => {
-                resolve({
-                  stdout: stdoutChunks.join("\n"),
-                  stderr: stderrChunks.join(""),
-                  exitCode: code ?? 0,
-                });
-              });
-            });
-          }
-
-          return new Promise((resolve, reject) => {
-            execFile(
-              "docker",
-              args,
-              { maxBuffer: 10 * 1024 * 1024 },
-              (error, stdout, stderr) => {
-                if (error && error.code === undefined) {
-                  reject(new Error(`docker exec failed: ${error.message}`));
-                } else {
-                  resolve({
-                    stdout: stdout.toString(),
-                    stderr: stderr.toString(),
-                    exitCode: typeof error?.code === "number" ? error.code : 0,
-                  });
-                }
-              },
-            );
-          });
-        },
+        ): Promise<ExecResult> =>
+          execViaStdin(containerName, command, opts),
 
         close: async (): Promise<void> => {
           process.removeListener("exit", onExit);
@@ -202,6 +145,53 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
     },
   });
 };
+
+const execViaStdin = (
+  containerName: string,
+  command: string,
+  opts?: { onLine?: (line: string) => void; cwd?: string; sudo?: boolean },
+): Promise<ExecResult> =>
+  new Promise((resolve, reject) => {
+    const effectiveCommand = opts?.sudo ? `sudo ${command}` : command;
+    const args = ["exec", "-i"];
+    if (opts?.cwd) args.push("-w", opts.cwd);
+    args.push(containerName, "sh");
+
+    const proc = spawn("docker", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    const rl = createInterface({ input: proc.stdout! });
+    rl.on("line", (line) => {
+      opts?.onLine?.(line);
+    });
+
+    proc.stdout!.on("data", (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+    });
+
+    proc.stderr!.on("data", (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+    });
+
+    proc.on("error", (error) => {
+      reject(new Error(`docker exec failed: ${error.message}`));
+    });
+
+    proc.on("close", (code) => {
+      rl.close();
+      resolve({
+        stdout: Buffer.concat(stdoutChunks).toString(),
+        stderr: Buffer.concat(stderrChunks).toString(),
+        exitCode: code ?? 0,
+      });
+    });
+
+    proc.stdin!.end(effectiveCommand);
+  });
 
 /**
  * Derive the default Docker image name from the repo directory.


### PR DESCRIPTION
## Summary

This PR fixes a few operational failure modes in Sandcastle's codex execution path and worktree lifecycle.

## Problem

Sandcastle currently relies on argv-heavy command execution in places where stdin is a safer transport. That makes codex execution more fragile for large prompts and makes the execution path harder to reason about consistently across orchestrator and docker sandbox layers.

Separately, worktree setup and teardown can fail in real-world scenarios involving orphaned directories or ignored-file residue.

## What changed

- route codex prompt delivery through stdin instead of argv in the orchestrator
- add provider support for stdin-based codex execution
- run docker exec via stdin instead of `sh -c <command>`
- remove orphaned worktree target directories before creation
- retry worktree removal after `git clean -fdx` when ignored files keep the directory non-empty
- improve non-zero agent error reporting with both `stderr` and trimmed `stdout`

## Why this belongs together

These changes all harden the same operational path:
- how codex commands are launched
- how sandboxed command execution is transported
- how temporary worktrees are created and cleaned up around those runs

## Context

This PR follows up on #279 with a narrower scope focused only on codex execution and worktree robustness.

## Transparency

Co-developed by Caio Guimarães and GPT-5.4 Codex.