### PR TITLE
Fix Podman readonly volume syntax

### DIFF
--- a/.changeset/podman-readonly-volume-syntax.md
+++ b/.changeset/podman-readonly-volume-syntax.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix Podman readonly bind mounts so SELinux-labeled volumes use `:ro,z` syntax that `podman run -v` accepts.

--- a/src/sandboxes/podman.test.ts
+++ b/src/sandboxes/podman.test.ts
@@ -1,5 +1,28 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:child_process")>(
+      "node:child_process",
+    );
+
+  return {
+    ...actual,
+    execFile: vi.fn(),
+    execFileSync: vi.fn(),
+    spawn: vi.fn(),
+  };
+});
+
+import { execFile } from "node:child_process";
+import { homedir } from "node:os";
 import { podman, defaultImageName } from "./podman.js";
+
+const mockExecFile = vi.mocked(execFile);
+
+afterEach(() => {
+  mockExecFile.mockReset();
+});
 
 describe("podman()", () => {
   it("returns a SandboxProvider with tag 'bind-mount' and name 'podman'", () => {
@@ -58,6 +81,36 @@ describe("podman()", () => {
   it("defaults env to empty object when not provided", () => {
     const provider = podman();
     expect(provider.env).toEqual({});
+  });
+
+  it("formats readonly SELinux mounts using podman volume syntax", async () => {
+    mockExecFile.mockImplementation((_command, args, callback: any) => {
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({
+      selinuxLabel: "z",
+      mounts: [{ hostPath: "~", sandboxPath: "/mnt/home", readonly: true }],
+    });
+
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1];
+
+    expect(runArgs).toContain("-v");
+    expect(runArgs).toContain(`${homedir()}:/mnt/home:ro,z`);
+
+    await handle.close();
   });
 });
 

--- a/src/sandboxes/podman.test.ts
+++ b/src/sandboxes/podman.test.ts
@@ -83,7 +83,7 @@ describe("podman()", () => {
     expect(provider.env).toEqual({});
   });
 
-  it("formats readonly SELinux mounts using podman volume syntax", async () => {
+  it("formats readonly SELinux mounts as :ro,z", async () => {
     mockExecFile.mockImplementation((_command, args, callback: any) => {
       callback(null, "", "");
       return undefined as any;
@@ -107,8 +107,96 @@ describe("podman()", () => {
       ([, args]) => Array.isArray(args) && args[0] === "run",
     )?.[1];
 
-    expect(runArgs).toContain("-v");
     expect(runArgs).toContain(`${homedir()}:/mnt/home:ro,z`);
+
+    await handle.close();
+  });
+
+  it("formats writable SELinux mounts as :z", async () => {
+    mockExecFile.mockImplementation((_command, _args, callback: any) => {
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({
+      selinuxLabel: "z",
+      mounts: [{ hostPath: "~", sandboxPath: "/mnt/home" }],
+    });
+
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1];
+
+    expect(runArgs).toContain(`${homedir()}:/mnt/home:z`);
+
+    await handle.close();
+  });
+
+  it("formats readonly mounts without SELinux as :ro", async () => {
+    mockExecFile.mockImplementation((_command, _args, callback: any) => {
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({
+      selinuxLabel: false,
+      mounts: [{ hostPath: "~", sandboxPath: "/mnt/home", readonly: true }],
+    });
+
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1];
+
+    expect(runArgs).toContain(`${homedir()}:/mnt/home:ro`);
+
+    await handle.close();
+  });
+
+  it("formats mounts with no options when writable and no SELinux", async () => {
+    mockExecFile.mockImplementation((_command, _args, callback: any) => {
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({
+      selinuxLabel: false,
+      mounts: [{ hostPath: "~", sandboxPath: "/mnt/home" }],
+    });
+
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1];
+
+    expect(runArgs).toContain(`${homedir()}:/mnt/home`);
+    // Should NOT have any trailing options
+    expect(runArgs).not.toContain(`${homedir()}:/mnt/home:`);
 
     await handle.close();
   });

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -69,13 +69,10 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
         )?.sandboxPath ?? "/home/agent/workspace";
 
       // Build volume mount strings with optional SELinux label (internal + user mounts)
-      const labelSuffix = selinuxLabel ? `:${selinuxLabel}` : "";
       const allMounts = [...createOptions.mounts, ...userMounts];
-      const volumeMounts = allMounts.map((m) => {
-        const base = `${m.hostPath}:${m.sandboxPath}`;
-        if (m.readonly) return `${base}:ro${labelSuffix}`;
-        return `${base}${labelSuffix}`;
-      });
+      const volumeMounts = allMounts.map((m) =>
+        formatVolumeMount(m, selinuxLabel),
+      );
 
       // Resolve image name
       const imageName =
@@ -267,3 +264,15 @@ const resolveUserMounts = (
       ...(m.readonly ? { readonly: true } : {}),
     };
   });
+
+const formatVolumeMount = (
+  mount: { hostPath: string; sandboxPath: string; readonly?: boolean },
+  selinuxLabel: PodmanOptions["selinuxLabel"],
+): string => {
+  const base = `${mount.hostPath}:${mount.sandboxPath}`;
+  const options = [mount.readonly ? "ro" : undefined, selinuxLabel || undefined]
+    .filter((option): option is string => option !== undefined)
+    .join(",");
+
+  return options ? `${base}:${options}` : base;
+};


### PR DESCRIPTION
## Summary
- format Podman bind mounts with comma-separated options so readonly SELinux mounts render as `:ro,z` instead of the invalid `:ro:z`
- keep the existing SELinux label behavior for read-write mounts while making readonly mounts compatible with `podman run -v`
- add a regression test that inspects the generated `podman run` arguments for a readonly user mount

## Testing
- `npm test -- src/sandboxes/podman.test.ts`
- `npm run typecheck` *(fails in the current repo because the optional `@daytona/sdk` peer dependency is not installed locally)*