### PR TITLE
Add JSON stream parsing for the opencode provider

### DIFF
--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -499,11 +499,10 @@ describe("opencode factory", () => {
     expect(command).toContain("opencode/big-pickle");
   });
 
-  it("buildPrintCommand does not include --format json", () => {
+  it("buildPrintCommand includes --format json", () => {
     const provider = opencode("opencode/big-pickle");
     const command = provider.buildPrintCommand(opts("do something"));
-    expect(command).not.toContain("--format json");
-    expect(command).not.toContain("--format");
+    expect(command).toContain("--format json");
   });
 
   it("buildPrintCommand shell-escapes the prompt", () => {

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -199,6 +199,64 @@ const parseCodexStreamLine = (line: string): ParsedStreamEvent[] => {
   return [];
 };
 
+const parseOpenCodeStreamLine = (
+  line: string,
+  accumulatedText: string,
+): { events: ParsedStreamEvent[]; accumulatedText: string } => {
+  if (!line.startsWith("{")) return { accumulatedText, events: [] };
+  try {
+    const obj = JSON.parse(line);
+
+    if (obj.type === "text" && typeof obj.part?.text === "string") {
+      const nextAccumulatedText = accumulatedText + obj.part.text;
+      return {
+        accumulatedText: nextAccumulatedText,
+        events: [
+          { type: "text", text: obj.part.text },
+          { type: "result", result: nextAccumulatedText },
+        ],
+      };
+    }
+
+    if (obj.type === "tool_use" && typeof obj.part?.tool === "string") {
+      let displayName: keyof typeof TOOL_ARG_FIELDS | undefined;
+      switch (obj.part.tool) {
+        case "bash":
+          displayName = "Bash";
+          break;
+        case "webfetch":
+          displayName = "WebFetch";
+          break;
+        case "websearch":
+          displayName = "WebSearch";
+          break;
+        case "agent":
+          displayName = "Agent";
+          break;
+      }
+      if (displayName === undefined) return { accumulatedText, events: [] };
+
+      const argField = TOOL_ARG_FIELDS[displayName];
+      if (argField === undefined) return { accumulatedText, events: [] };
+      const input = obj.part?.state?.input as
+        | Record<string, unknown>
+        | undefined;
+      if (!input) return { accumulatedText, events: [] };
+
+      const argValue = input[argField];
+      if (typeof argValue !== "string") return { accumulatedText, events: [] };
+
+      return {
+        accumulatedText,
+        events: [{ type: "tool_call", name: displayName, args: argValue }],
+      };
+    }
+  } catch {
+    // Not valid JSON — skip
+  }
+  return { accumulatedText, events: [] };
+};
+
 /** Options for the codex agent provider. */
 export interface CodexOptions {
   readonly effort?: "low" | "medium" | "high" | "xhigh";
@@ -244,24 +302,31 @@ export interface OpenCodeOptions {
 export const opencode = (
   model: string,
   options?: OpenCodeOptions,
-): AgentProvider => ({
-  name: "opencode",
-  env: options?.env ?? {},
+): AgentProvider => {
+  let accumulatedText = "";
 
-  buildPrintCommand({ prompt }: AgentCommandOptions): string {
-    return `opencode run --model ${shellEscape(model)} ${shellEscape(prompt)}`;
-  },
+  return {
+    name: "opencode",
+    env: options?.env ?? {},
 
-  buildInteractiveArgs({ prompt }: AgentCommandOptions): string[] {
-    const args = ["opencode", "--model", model];
-    if (prompt) args.push("-p", prompt);
-    return args;
-  },
+    buildPrintCommand({ prompt }: AgentCommandOptions): string {
+      accumulatedText = "";
+      return `opencode run --format json --model ${shellEscape(model)} ${shellEscape(prompt)}`;
+    },
 
-  parseStreamLine(_line: string): ParsedStreamEvent[] {
-    return [];
-  },
-});
+    buildInteractiveArgs({ prompt }: AgentCommandOptions): string[] {
+      const args = ["opencode", "--model", model];
+      if (prompt) args.push("-p", prompt);
+      return args;
+    },
+
+    parseStreamLine(line: string): ParsedStreamEvent[] {
+      const parsed = parseOpenCodeStreamLine(line, accumulatedText);
+      accumulatedText = parsed.accumulatedText;
+      return parsed.events;
+    },
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Claude Code agent provider

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -203,18 +203,21 @@ const parseOpenCodeStreamLine = (
   line: string,
   accumulatedText: string,
 ): { events: ParsedStreamEvent[]; accumulatedText: string } => {
-  if (!line.startsWith("{")) return { accumulatedText, events: [] };
+  if (!line.startsWith("{")) return { events: [], accumulatedText };
   try {
     const obj = JSON.parse(line);
 
     if (obj.type === "text" && typeof obj.part?.text === "string") {
-      const nextAccumulatedText = accumulatedText + obj.part.text;
       return {
-        accumulatedText: nextAccumulatedText,
-        events: [
-          { type: "text", text: obj.part.text },
-          { type: "result", result: nextAccumulatedText },
-        ],
+        events: [{ type: "text", text: obj.part.text }],
+        accumulatedText: accumulatedText + obj.part.text,
+      };
+    }
+
+    if (obj.type === "step_finish" && accumulatedText.length > 0) {
+      return {
+        events: [{ type: "result", result: accumulatedText }],
+        accumulatedText,
       };
     }
 
@@ -234,27 +237,33 @@ const parseOpenCodeStreamLine = (
           displayName = "Agent";
           break;
       }
-      if (displayName === undefined) return { accumulatedText, events: [] };
+      if (displayName === undefined) {
+        return { events: [], accumulatedText };
+      }
 
       const argField = TOOL_ARG_FIELDS[displayName];
-      if (argField === undefined) return { accumulatedText, events: [] };
+      if (argField === undefined) {
+        return { events: [], accumulatedText };
+      }
       const input = obj.part?.state?.input as
         | Record<string, unknown>
         | undefined;
-      if (!input) return { accumulatedText, events: [] };
+      if (!input) return { events: [], accumulatedText };
 
       const argValue = input[argField];
-      if (typeof argValue !== "string") return { accumulatedText, events: [] };
+      if (typeof argValue !== "string") {
+        return { events: [], accumulatedText };
+      }
 
       return {
-        accumulatedText,
         events: [{ type: "tool_call", name: displayName, args: argValue }],
+        accumulatedText,
       };
     }
   } catch {
     // Not valid JSON — skip
   }
-  return { accumulatedText, events: [] };
+  return { events: [], accumulatedText };
 };
 
 /** Options for the codex agent provider. */


### PR DESCRIPTION
## Summary

Switch the `opencode` provider to JSON stream parsing.

This replaces raw stdout passthrough with structured parsing so Sandcastle can surface streamed text,
supported tool calls, and a final result from `step_finish`.

## Validation

- `npm run build`
- `npm test -- src/AgentProvider.test.ts src/Orchestrator.test.ts`
- real `opencode run --format json ...` smoke test