### PR TITLE
Route agent prompt through stdin to avoid MAX_ARG_STRLEN E2BIG (fixes #387)

### DIFF
--- a/.changeset/stdin-prompt-transport.md
+++ b/.changeset/stdin-prompt-transport.md
@@ -1,0 +1,11 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix `spawn E2BIG` when the Claude Code prompt exceeds Linux's per-argv-string limit (`MAX_ARG_STRLEN`, 128 KB). Adds an opt-in stdin transport for the agent prompt so large prompts no longer fail at the kernel `execve` boundary.
+
+- `AgentProvider` gains an optional `buildPrintInvocation(options)` method returning `{ command, stdin? }`. When set, the orchestrator pipes `stdin` into the child process instead of inlining the prompt in argv. `claudeCode()` implements it (Claude Code's `--print` mode reads the prompt from stdin when no prompt argument is supplied).
+- Sandbox handles gain an optional `supportsStdinExec` flag. Docker, Podman, and the no-sandbox provider set it to `true` and forward the `stdin` option to the spawned child (via `docker exec -i` / `podman exec -i` / a piped stdin). Remote providers (Vercel, Daytona) leave it unset and behaviour is unchanged.
+- The orchestrator selects the stdin path only when both the agent provider implements `buildPrintInvocation` **and** the sandbox reports `supportsStdinExec`. Otherwise it falls back to the existing argv-based `buildPrintCommand`, so behaviour for non-Claude agents and non-local sandboxes is unchanged.
+
+Closes the failure mode where a sufficiently large prompt (e.g. a `plan-prompt.md` that inlines every open GitHub issue via `!\`gh issue list ...\``) causes the orchestrator's `sandbox.exec(...)` to reject with `ExecError: exec failed: spawn E2BIG`.

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -204,6 +204,42 @@ describe("claudeCode factory", () => {
     expect(command).not.toContain("--dangerously-skip-permissions");
   });
 
+  // --- buildPrintInvocation (stdin-based prompt transport) ---
+
+  it("buildPrintInvocation returns command without -p and prompt in stdin", () => {
+    const provider = claudeCode("claude-opus-4-6");
+    const invocation = provider.buildPrintInvocation!(opts("prompt text"));
+    expect(invocation.command).toContain("--print");
+    expect(invocation.command).toContain("--output-format stream-json");
+    expect(invocation.command).toContain("claude-opus-4-6");
+    expect(invocation.command).not.toMatch(/\s-p\s/);
+    expect(invocation.command).not.toContain("prompt text");
+    expect(invocation.stdin).toBe("prompt text");
+  });
+
+  it("buildPrintInvocation keeps flags aligned with buildPrintCommand", () => {
+    const provider = claudeCode("claude-opus-4-6");
+    const common: AgentCommandOptions = {
+      prompt: "hello",
+      dangerouslySkipPermissions: true,
+      resumeSession: "abc-123",
+    };
+    const invocation = provider.buildPrintInvocation!(common);
+    expect(invocation.command).toContain("--dangerously-skip-permissions");
+    expect(invocation.command).toContain("--resume 'abc-123'");
+  });
+
+  it("buildPrintInvocation keeps large prompts entirely out of argv", () => {
+    const provider = claudeCode("claude-opus-4-6");
+    const bigPrompt = "x".repeat(200_000);
+    const invocation = provider.buildPrintInvocation!({
+      prompt: bigPrompt,
+      dangerouslySkipPermissions: true,
+    });
+    expect(invocation.command.length).toBeLessThan(1_000);
+    expect(invocation.stdin).toBe(bigPrompt);
+  });
+
   it("buildInteractiveArgs includes --dangerously-skip-permissions when true", () => {
     const provider = claudeCode("claude-opus-4-6");
     const args = provider.buildInteractiveArgs!({

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -78,6 +78,17 @@ export interface AgentCommandOptions {
   readonly resumeSession?: string;
 }
 
+/**
+ * Shell command plus an optional stdin payload, returned by `buildPrintInvocation`.
+ * When `stdin` is set, the caller should pipe it into the child process's stdin
+ * instead of inlining it in argv. Used to keep the prompt out of argv so it does
+ * not hit the per-argv-string kernel limit (`MAX_ARG_STRLEN`, 128 KB on Linux).
+ */
+export interface AgentInvocation {
+  readonly command: string;
+  readonly stdin?: string;
+}
+
 export interface AgentProvider {
   readonly name: string;
   /** Environment variables injected by this agent provider. Merged at launch time with env resolver and sandbox provider env. */
@@ -85,6 +96,14 @@ export interface AgentProvider {
   /** When true, session capture is enabled for this provider. Default: true for Claude Code, false for others. */
   readonly captureSessions: boolean;
   buildPrintCommand(options: AgentCommandOptions): string;
+  /**
+   * Optional: return `{ command, stdin }` where `stdin` carries the prompt.
+   * When present and the sandbox reports `supportsStdinExec`, the orchestrator
+   * routes the prompt through stdin instead of inlining it in argv. This avoids
+   * the per-argv-string limit (`MAX_ARG_STRLEN`, 128 KB on Linux) for large
+   * prompts. Falls back to `buildPrintCommand` when either side is missing.
+   */
+  buildPrintInvocation?(options: AgentCommandOptions): AgentInvocation;
   buildInteractiveArgs?(options: AgentCommandOptions): string[];
   parseStreamLine(line: string): ParsedStreamEvent[];
 }
@@ -311,6 +330,27 @@ export const claudeCode = (
       ? ` --resume ${shellEscape(resumeSession)}`
       : "";
     return `claude --print --verbose${skipPerms} --output-format stream-json --model ${shellEscape(model)}${effortFlag}${resumeFlag} -p ${shellEscape(prompt)}`;
+  },
+
+  // Claude Code's `--print` mode reads the prompt from stdin when no prompt
+  // argument is supplied. Routing the prompt through stdin keeps it out of
+  // argv entirely, so it is not subject to MAX_ARG_STRLEN (128 KB on Linux).
+  buildPrintInvocation({
+    prompt,
+    dangerouslySkipPermissions,
+    resumeSession,
+  }: AgentCommandOptions): AgentInvocation {
+    const skipPerms = dangerouslySkipPermissions
+      ? " --dangerously-skip-permissions"
+      : "";
+    const effortFlag = options?.effort ? ` --effort ${options.effort}` : "";
+    const resumeFlag = resumeSession
+      ? ` --resume ${shellEscape(resumeSession)}`
+      : "";
+    return {
+      command: `claude --print --verbose${skipPerms} --output-format stream-json --model ${shellEscape(model)}${effortFlag}${resumeFlag}`,
+      stdin: prompt,
+    };
   },
 
   buildInteractiveArgs({

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -1602,6 +1602,122 @@ describe("Orchestrator streaming", () => {
     expect(capturedCommand).toContain("--model 'claude-sonnet-4-6'");
     expect(capturedCommand).not.toContain(DEFAULT_MODEL);
   });
+
+  it("routes prompt through stdin when sandbox reports supportsStdinExec", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-stdin-host-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    let capturedCommand = "";
+    let capturedStdin: string | undefined;
+
+    const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
+      const fsLayer = makeLocalSandboxLayer(dir);
+      return Layer.succeed(Sandbox, {
+        supportsStdinExec: true,
+        exec: (command, options) => {
+          if (command.startsWith("claude ") && options?.onLine) {
+            capturedCommand = command;
+            capturedStdin = options.stdin;
+            const onLine = options.onLine;
+            const streamOutput = toStreamJson("Done.");
+            for (const line of streamOutput.split("\n")) {
+              onLine(line);
+            }
+            return Effect.succeed({
+              stdout: streamOutput,
+              stderr: "",
+              exitCode: 0,
+            });
+          }
+          return Effect.flatMap(Sandbox, (real) =>
+            real.exec(command, options),
+          ).pipe(Effect.provide(fsLayer));
+        },
+        copyIn: (hostPath, sandboxPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyIn(hostPath, sandboxPath),
+          ).pipe(Effect.provide(fsLayer)),
+        copyFileOut: (sandboxPath, hostPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyFileOut(sandboxPath, hostPath),
+          ).pipe(Effect.provide(fsLayer)),
+      });
+    });
+
+    const bigPrompt = "the real work\n" + "x".repeat(200_000);
+    await Effect.runPromise(
+      orchestrate({
+        provider: testProvider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: bigPrompt,
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    // Prompt must arrive via stdin, not argv
+    expect(capturedStdin).toBe(bigPrompt);
+    expect(capturedCommand).not.toContain(bigPrompt);
+    expect(capturedCommand).not.toMatch(/\s-p\s/);
+  });
+
+  it("keeps prompt in argv when sandbox does not report supportsStdinExec", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-noexec-host-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    let capturedCommand = "";
+    let capturedStdin: string | undefined = "unset";
+
+    const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
+      const fsLayer = makeLocalSandboxLayer(dir);
+      return Layer.succeed(Sandbox, {
+        // supportsStdinExec intentionally omitted — falls back to argv
+        exec: (command, options) => {
+          if (command.startsWith("claude ") && options?.onLine) {
+            capturedCommand = command;
+            capturedStdin = options.stdin;
+            const onLine = options.onLine;
+            const streamOutput = toStreamJson("Done.");
+            for (const line of streamOutput.split("\n")) {
+              onLine(line);
+            }
+            return Effect.succeed({
+              stdout: streamOutput,
+              stderr: "",
+              exitCode: 0,
+            });
+          }
+          return Effect.flatMap(Sandbox, (real) =>
+            real.exec(command, options),
+          ).pipe(Effect.provide(fsLayer));
+        },
+        copyIn: (hostPath, sandboxPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyIn(hostPath, sandboxPath),
+          ).pipe(Effect.provide(fsLayer)),
+        copyFileOut: (sandboxPath, hostPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyFileOut(sandboxPath, hostPath),
+          ).pipe(Effect.provide(fsLayer)),
+      });
+    });
+
+    await Effect.runPromise(
+      orchestrate({
+        provider: testProvider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: "small prompt",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    // Argv fallback: prompt is inlined in the command
+    expect(capturedCommand).toMatch(/\s-p\s+'small prompt'/);
+    expect(capturedStdin).toBeUndefined();
+  });
 });
 
 describe("Orchestrator prompt preprocessing", () => {

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -75,31 +75,46 @@ const invokeAgent = (
 
     resetIdleTimer();
 
-    const execEffect = Effect.gen(function* () {
-      const execResult = yield* sandbox.exec(
-        provider.buildPrintCommand({
+    // Prefer stdin-based invocation when both the agent provider and the
+    // sandbox support it — this keeps the prompt out of argv and avoids the
+    // per-argv-string kernel limit (`MAX_ARG_STRLEN`, 128 KB on Linux) that
+    // otherwise caps how large a prompt can be.
+    const useStdinPath =
+      sandbox.supportsStdinExec && provider.buildPrintInvocation !== undefined;
+    const invocation = useStdinPath
+      ? provider.buildPrintInvocation!({
           prompt,
           dangerouslySkipPermissions: true,
           resumeSession,
-        }),
-        {
-          onLine: (line) => {
-            resetIdleTimer();
-            for (const parsed of provider.parseStreamLine(line)) {
-              if (parsed.type === "text") {
-                onText(parsed.text);
-              } else if (parsed.type === "result") {
-                resultText = parsed.result;
-              } else if (parsed.type === "tool_call") {
-                onToolCall(parsed.name, parsed.args);
-              } else if (parsed.type === "session_id") {
-                sessionId = parsed.sessionId;
-              }
+        })
+      : {
+          command: provider.buildPrintCommand({
+            prompt,
+            dangerouslySkipPermissions: true,
+            resumeSession,
+          }),
+          stdin: undefined as string | undefined,
+        };
+
+    const execEffect = Effect.gen(function* () {
+      const execResult = yield* sandbox.exec(invocation.command, {
+        onLine: (line) => {
+          resetIdleTimer();
+          for (const parsed of provider.parseStreamLine(line)) {
+            if (parsed.type === "text") {
+              onText(parsed.text);
+            } else if (parsed.type === "result") {
+              resultText = parsed.result;
+            } else if (parsed.type === "tool_call") {
+              onToolCall(parsed.name, parsed.args);
+            } else if (parsed.type === "session_id") {
+              sessionId = parsed.sessionId;
             }
-          },
-          cwd: sandboxRepoDir,
+          }
         },
-      );
+        cwd: sandboxRepoDir,
+        stdin: invocation.stdin,
+      });
 
       if (execResult.exitCode !== 0) {
         return yield* Effect.fail(

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -36,8 +36,26 @@ export interface ExecResult {
 export interface SandboxService {
   readonly exec: (
     command: string,
-    options?: { onLine?: (line: string) => void; cwd?: string; sudo?: boolean },
+    options?: {
+      onLine?: (line: string) => void;
+      cwd?: string;
+      sudo?: boolean;
+      /**
+       * When set, the value is written to the child process's stdin and stdin
+       * is then closed. Only respected when `supportsStdinExec` is true; on
+       * other sandboxes this option is silently ignored.
+       */
+      stdin?: string;
+    },
   ) => Effect.Effect<ExecResult, ExecError>;
+
+  /**
+   * Whether the underlying sandbox forwards the `stdin` option in `exec()` to
+   * the spawned child process. Callers wanting to deliver a large payload (for
+   * example a prompt exceeding `MAX_ARG_STRLEN`) MUST check this flag before
+   * relying on `stdin`. Unset is treated as `false`.
+   */
+  readonly supportsStdinExec?: boolean;
 
   /** Copy a file or directory from the host into the sandbox. */
   readonly copyIn: (
@@ -107,6 +125,7 @@ export const makeSandboxLayerFromHandle = (
             message: `exec failed: ${e instanceof Error ? e.message : String(e)}`,
           }),
       }),
+    supportsStdinExec: handle.supportsStdinExec === true,
     copyIn: getCopyIn(handle),
     copyFileOut:
       "copyFileOut" in handle

--- a/src/SandboxProvider.ts
+++ b/src/SandboxProvider.ts
@@ -25,6 +25,13 @@ export interface BindMountSandboxHandle {
   /** Absolute path to the worktree inside the sandbox. */
   readonly worktreePath: string;
   /**
+   * Whether `exec()` forwards the `stdin` option to the underlying child process.
+   * When true, callers may deliver large payloads (e.g. prompts larger than
+   * `MAX_ARG_STRLEN`) via stdin. When false or unset, the `stdin` option is
+   * silently ignored.
+   */
+  readonly supportsStdinExec?: boolean;
+  /**
    * Execute a command in the sandbox.
    *
    * Implementations MUST support line-by-line streaming via `onLine`. This is
@@ -35,7 +42,19 @@ export interface BindMountSandboxHandle {
    */
   exec(
     command: string,
-    options?: { onLine?: (line: string) => void; cwd?: string; sudo?: boolean },
+    options?: {
+      onLine?: (line: string) => void;
+      cwd?: string;
+      sudo?: boolean;
+      /**
+       * When set, the value is written to the child process's stdin and stdin is
+       * then closed. Providers that forward stdin to the underlying process MUST
+       * set `supportsStdinExec: true`; providers that ignore this option MUST
+       * leave `supportsStdinExec` unset/false. Callers should check the flag on
+       * the handle before relying on this behaviour.
+       */
+      stdin?: string;
+    },
   ): Promise<ExecResult>;
   /**
    * Launch an interactive process inside the sandbox.
@@ -88,6 +107,11 @@ export interface IsolatedSandboxHandle {
   /** Absolute path to the worktree inside the sandbox. */
   readonly worktreePath: string;
   /**
+   * Whether `exec()` forwards the `stdin` option to the underlying child process.
+   * See `BindMountSandboxHandle.supportsStdinExec` for semantics.
+   */
+  readonly supportsStdinExec?: boolean;
+  /**
    * Execute a command in the sandbox.
    *
    * Implementations MUST support line-by-line streaming via `onLine`. This is
@@ -98,7 +122,19 @@ export interface IsolatedSandboxHandle {
    */
   exec(
     command: string,
-    options?: { onLine?: (line: string) => void; cwd?: string; sudo?: boolean },
+    options?: {
+      onLine?: (line: string) => void;
+      cwd?: string;
+      sudo?: boolean;
+      /**
+       * When set, the value is written to the child process's stdin and stdin is
+       * then closed. Providers that forward stdin to the underlying process MUST
+       * set `supportsStdinExec: true`; providers that ignore this option MUST
+       * leave `supportsStdinExec` unset/false. Callers should check the flag on
+       * the handle before relying on this behaviour.
+       */
+      stdin?: string;
+    },
   ): Promise<ExecResult>;
   /**
    * Launch an interactive process inside the sandbox.
@@ -169,6 +205,11 @@ export interface NoSandboxHandle {
   /** Absolute path to the worktree on the host. */
   readonly worktreePath: string;
   /**
+   * Whether `exec()` forwards the `stdin` option to the underlying child process.
+   * See `BindMountSandboxHandle.supportsStdinExec` for semantics.
+   */
+  readonly supportsStdinExec?: boolean;
+  /**
    * Execute a command on the host.
    *
    * Implementations MUST support line-by-line streaming via `onLine`. This is
@@ -177,7 +218,19 @@ export interface NoSandboxHandle {
    */
   exec(
     command: string,
-    options?: { onLine?: (line: string) => void; cwd?: string; sudo?: boolean },
+    options?: {
+      onLine?: (line: string) => void;
+      cwd?: string;
+      sudo?: boolean;
+      /**
+       * When set, the value is written to the child process's stdin and stdin is
+       * then closed. Providers that forward stdin to the underlying process MUST
+       * set `supportsStdinExec: true`; providers that ignore this option MUST
+       * leave `supportsStdinExec` unset/false. Callers should check the flag on
+       * the handle before relying on this behaviour.
+       */
+      stdin?: string;
+    },
   ): Promise<ExecResult>;
   /**
    * Launch an interactive process on the host with inherited stdio.

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -140,6 +140,7 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
 
       const handle: BindMountSandboxHandle = {
         worktreePath,
+        supportsStdinExec: true,
 
         exec: (
           command: string,
@@ -147,28 +148,50 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
             onLine?: (line: string) => void;
             cwd?: string;
             sudo?: boolean;
+            stdin?: string;
           },
         ): Promise<ExecResult> => {
           const effectiveCommand = opts?.sudo ? `sudo ${command}` : command;
           const args = ["exec"];
+          // `-i` keeps stdin open so we can pipe opts.stdin into the container process
+          if (opts?.stdin !== undefined) args.push("-i");
           if (opts?.cwd) args.push("-w", opts.cwd);
           args.push(containerName, "sh", "-c", effectiveCommand);
 
-          if (opts?.onLine) {
-            const onLine = opts.onLine;
+          const stdinPayload = opts?.stdin;
+          const stdinMode: "pipe" | "ignore" =
+            stdinPayload !== undefined ? "pipe" : "ignore";
+
+          if (opts?.onLine || stdinPayload !== undefined) {
+            const onLine = opts?.onLine;
             return new Promise((resolve, reject) => {
               const proc = spawn("docker", args, {
-                stdio: ["ignore", "pipe", "pipe"],
+                stdio: [stdinMode, "pipe", "pipe"],
               });
+
+              if (stdinPayload !== undefined && proc.stdin) {
+                proc.stdin.on("error", (error: Error) => {
+                  reject(
+                    new Error(`docker exec stdin failed: ${error.message}`),
+                  );
+                });
+                proc.stdin.end(stdinPayload);
+              }
 
               const stdoutChunks: string[] = [];
               const stderrChunks: string[] = [];
 
-              const rl = createInterface({ input: proc.stdout! });
-              rl.on("line", (line) => {
-                stdoutChunks.push(line);
-                onLine(line);
-              });
+              if (onLine) {
+                const rl = createInterface({ input: proc.stdout! });
+                rl.on("line", (line) => {
+                  stdoutChunks.push(line);
+                  onLine(line);
+                });
+              } else {
+                proc.stdout!.on("data", (chunk: Buffer) => {
+                  stdoutChunks.push(chunk.toString());
+                });
+              }
 
               proc.stderr!.on("data", (chunk: Buffer) => {
                 stderrChunks.push(chunk.toString());
@@ -180,7 +203,7 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
 
               proc.on("close", (code) => {
                 resolve({
-                  stdout: stdoutChunks.join("\n"),
+                  stdout: stdoutChunks.join(onLine ? "\n" : ""),
                   stderr: stderrChunks.join(""),
                   exitCode: code ?? 0,
                 });

--- a/src/sandboxes/no-sandbox.test.ts
+++ b/src/sandboxes/no-sandbox.test.ts
@@ -90,6 +90,41 @@ describe("noSandbox", () => {
       expect(result.stdout.trim()).toBe("sandcastle_test_value");
     });
 
+    it("handle declares supportsStdinExec: true", async () => {
+      const provider = noSandbox();
+      const handle = await provider.create({
+        worktreePath: process.cwd(),
+        env: {},
+      });
+      expect(handle.supportsStdinExec).toBe(true);
+    });
+
+    it("exec forwards the stdin option to the spawned process", async () => {
+      const provider = noSandbox();
+      const handle = await provider.create({
+        worktreePath: process.cwd(),
+        env: {},
+      });
+
+      const result = await handle.exec("cat", { stdin: "piped-input-data" });
+      expect(result.stdout).toBe("piped-input-data");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("exec delivers stdin payloads larger than MAX_ARG_STRLEN (128 KB)", async () => {
+      const provider = noSandbox();
+      const handle = await provider.create({
+        worktreePath: process.cwd(),
+        env: {},
+      });
+
+      // 256 KB — double the per-argv-string kernel cap. Would hit E2BIG via argv.
+      const largePayload = "x".repeat(256 * 1024);
+      const result = await handle.exec("wc -c", { stdin: largePayload });
+      expect(result.stdout.trim()).toBe(String(largePayload.length));
+      expect(result.exitCode).toBe(0);
+    });
+
     it("interactiveExec spawns process and returns exit code", async () => {
       const provider = noSandbox();
       const handle = await provider.create({

--- a/src/sandboxes/no-sandbox.ts
+++ b/src/sandboxes/no-sandbox.ts
@@ -41,6 +41,7 @@ export const noSandbox = (options?: NoSandboxOptions): NoSandboxProvider => ({
 
     const handle: NoSandboxHandle = {
       worktreePath,
+      supportsStdinExec: true,
 
       exec: (
         command: string,
@@ -48,17 +49,28 @@ export const noSandbox = (options?: NoSandboxOptions): NoSandboxProvider => ({
           onLine?: (line: string) => void;
           cwd?: string;
           sudo?: boolean;
+          stdin?: string;
         },
       ): Promise<ExecResult> => {
         // sudo is a no-op for no-sandbox — the user is already on the host
         const cwd = opts?.cwd ?? worktreePath;
+        const stdinPayload = opts?.stdin;
+        const stdinMode: "pipe" | "ignore" =
+          stdinPayload !== undefined ? "pipe" : "ignore";
 
         return new Promise((resolve, reject) => {
           const proc = spawn("sh", ["-c", command], {
             cwd,
             env: processEnv,
-            stdio: ["ignore", "pipe", "pipe"],
+            stdio: [stdinMode, "pipe", "pipe"],
           });
+
+          if (stdinPayload !== undefined && proc.stdin) {
+            proc.stdin.on("error", (error: Error) => {
+              reject(new Error(`exec stdin failed: ${error.message}`));
+            });
+            proc.stdin.end(stdinPayload);
+          }
 
           const stdoutChunks: string[] = [];
           const stderrChunks: string[] = [];

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -191,6 +191,7 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
 
       const handle: BindMountSandboxHandle = {
         worktreePath,
+        supportsStdinExec: true,
 
         exec: (
           command: string,
@@ -198,28 +199,50 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
             onLine?: (line: string) => void;
             cwd?: string;
             sudo?: boolean;
+            stdin?: string;
           },
         ): Promise<ExecResult> => {
           const effectiveCommand = opts?.sudo ? `sudo ${command}` : command;
           const args = ["exec"];
+          // `-i` keeps stdin open so we can pipe opts.stdin into the container process
+          if (opts?.stdin !== undefined) args.push("-i");
           if (opts?.cwd) args.push("-w", opts.cwd);
           args.push(containerName, "sh", "-c", effectiveCommand);
 
-          if (opts?.onLine) {
-            const onLine = opts.onLine;
+          const stdinPayload = opts?.stdin;
+          const stdinMode: "pipe" | "ignore" =
+            stdinPayload !== undefined ? "pipe" : "ignore";
+
+          if (opts?.onLine || stdinPayload !== undefined) {
+            const onLine = opts?.onLine;
             return new Promise((resolve, reject) => {
               const proc = spawn("podman", args, {
-                stdio: ["ignore", "pipe", "pipe"],
+                stdio: [stdinMode, "pipe", "pipe"],
               });
+
+              if (stdinPayload !== undefined && proc.stdin) {
+                proc.stdin.on("error", (error: Error) => {
+                  reject(
+                    new Error(`podman exec stdin failed: ${error.message}`),
+                  );
+                });
+                proc.stdin.end(stdinPayload);
+              }
 
               const stdoutChunks: string[] = [];
               const stderrChunks: string[] = [];
 
-              const rl = createInterface({ input: proc.stdout! });
-              rl.on("line", (line) => {
-                stdoutChunks.push(line);
-                onLine(line);
-              });
+              if (onLine) {
+                const rl = createInterface({ input: proc.stdout! });
+                rl.on("line", (line) => {
+                  stdoutChunks.push(line);
+                  onLine(line);
+                });
+              } else {
+                proc.stdout!.on("data", (chunk: Buffer) => {
+                  stdoutChunks.push(chunk.toString());
+                });
+              }
 
               proc.stderr!.on("data", (chunk: Buffer) => {
                 stderrChunks.push(chunk.toString());
@@ -231,7 +254,7 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
 
               proc.on("close", (code) => {
                 resolve({
-                  stdout: stdoutChunks.join("\n"),
+                  stdout: stdoutChunks.join(onLine ? "\n" : ""),
                   stderr: stderrChunks.join(""),
                   exitCode: code ?? 0,
                 });


### PR DESCRIPTION
## Summary

Fixes #387 — the orchestrator currently inlines the full prompt into argv via `sandbox.exec(provider.buildPrintCommand({ prompt, ... }))`, so docker/podman spawn the container's `sh -c '<command-with-inlined-prompt>'` with the prompt living in a single argv entry. Linux's `MAX_ARG_STRLEN` (32 × PAGE_SIZE = 128 KB per argv string) is independent of `ARG_MAX`, so any prompt past that cliff fails at `execve` with `E2BIG`.

This PR adds an opt-in stdin transport so the prompt doesn't live in argv:

- `AgentProvider` gains an optional `buildPrintInvocation(options)` returning `{ command, stdin? }`. `claudeCode()` implements it — Claude Code's `--print` mode reads the prompt from stdin when no prompt argument is supplied.
- Sandbox handles gain an optional `supportsStdinExec` flag. `docker`, `podman`, and `no-sandbox` set it `true` and forward the `stdin` option to the spawned child (via `docker exec -i` / `podman exec -i` / piped stdin).
- The orchestrator uses the stdin path only when both sides opt in; otherwise it falls back to the existing `buildPrintCommand` argv path. No behaviour change for non-Claude agents, remote sandboxes, or existing callers.

Draft because I'm happy to rework if you'd prefer a different transport (e.g. a prompt file `copyFileIn`-ed into the sandbox and fed to the agent via `< /tmp/prompt`). Both are equivalent in outcome and this one felt smaller.

## Scope

Deliberately narrow. Not included:

- **Other agents** — `pi`, `codex`, `opencode` are unchanged. Their stdin behaviour varies and the failure mode I hit is specifically on the Claude Code path; they can be ported individually later.
- **Remote isolated providers** — `vercel`, `daytona` do not forward `stdin` and leave `supportsStdinExec` unset. They don't go through `execve` so the limit doesn't apply; a follow-up can add `stdin` routing through their APIs if wanted.
- **Worktree cleanup / error reporting** — not touched.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 848 passing (the 3 pre-existing failures in `Session capture integration` and `propagates error when getSandboxHead fails (empty repo)` reproduce on `main` without this diff on my host; unrelated to this change)
- [x] Unit tests for `claudeCode.buildPrintInvocation`: command excludes `-p`, prompt lands in `stdin`, 200 KB prompt keeps argv under 1 KB.
- [x] Orchestrator tests: stdin path fires when sandbox reports the capability; argv fallback fires when it does not.
- [x] `no-sandbox` exec test with a 256 KB stdin payload piped through `wc -c`, proving payloads past `MAX_ARG_STRLEN` flow through stdin correctly.

## Why stdin and not a file

Because it's the smallest change surface. Writing the prompt to a sandbox file via `copyFileIn` would also work, but it requires a tempfile lifecycle (create/remove around each agent run) and an agent CLI that reads from a file path. `claude --print` already reads from stdin when the prompt argument is absent, so this just uses that.

## Changeset

Added `.changeset/stdin-prompt-transport.md` (patch).