### PR TITLE
Remove chown -R, use Podman userns UID mapping

### DIFF
--- a/.changeset/remove-chown-uid-alignment.md
+++ b/.changeset/remove-chown-uid-alignment.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Remove recursive chown from Docker and Podman sandbox startup. For Podman, use `--userns=keep-id:uid=N,gid=N` to align bind-mount and image ownership via namespace mapping instead. For Docker, rely on `--user` alone without post-start chown. Add `containerUid`/`containerGid` options to Podman provider.

--- a/docs/adr/0005-remove-chown-uid-alignment.md
+++ b/docs/adr/0005-remove-chown-uid-alignment.md
@@ -1,0 +1,20 @@
+# Remove runtime chown, align UIDs via namespace mapping and build-time convention
+
+Both sandbox providers used `chown -R /home/agent` at container startup to fix ownership mismatches between bind-mounted files (host UID) and image-built files (UID 1000). This was slow, produced log spam from walking into bind mounts, and hit permission errors on read-only mounts (VirtioFS `.git/objects`, custom read-only mounts). We removed it entirely.
+
+**Podman** now uses `--userns=keep-id:uid=N,gid=N` (Podman 4.1+), which maps the host user to a fixed UID inside the container at the namespace level. Both bind-mounted and image-built files appear owned by the same UID with no file mutation. The `containerUid`/`containerGid` options (default 1000) must match the Containerfile's agent user UID.
+
+**Docker** drops the chown and keeps only `--user ${hostUid}:${hostGid}`. This relies on the host UID matching the image UID (common on Linux where both are 1000) or on Docker Desktop's VirtioFS layer handling permission translation (macOS/Windows). If image-file permission errors resurface, the planned fix is a build-time UID injection via `build-image` (passing `--build-arg AGENT_UID=$(id -u)`) rather than runtime chown.
+
+## Considered options
+
+- **Targeted non-recursive chown** (chown specific dirs, skip bind mounts) — still requires knowing which paths are mounts vs image-local, still has startup cost, still produces warnings on read-only mounts.
+- **Build-time UID injection** (pass host UID as build-arg, create agent user with that UID) — eliminates chown but requires Dockerfile changes for existing users. Reserved as a future escape hatch for Docker if `--user` alone proves insufficient.
+- **fixuid / entrypoint script** (runtime `/etc/passwd` mutation + chown) — industry-standard approach (used by devcontainers, fixuid) but still chowns at startup. Solves the identity problem but not the performance/log-spam problem.
+- **User namespace remapping** (Docker daemon-level `--userns-remap`) — not per-container, requires daemon config changes. Not practical.
+
+## Consequences
+
+- Requires Podman 4.1+ (for `--userns=keep-id:uid=N,gid=N` syntax).
+- If a user's Containerfile creates the agent user at a UID other than 1000, they must pass `containerUid`/`containerGid` to `podman()` — otherwise ownership breaks silently.
+- Docker users on Linux with a non-1000 host UID may hit image-file permission errors. This is a rare edge case; if it surfaces, the build-time UID injection fix can be added without changing the runtime path.

--- a/src/DockerLifecycle.test.ts
+++ b/src/DockerLifecycle.test.ts
@@ -7,7 +7,7 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { execFile } from "node:child_process";
-import { chownInContainer, startContainer } from "./DockerLifecycle.js";
+import { startContainer } from "./DockerLifecycle.js";
 
 const mockExecFile = vi.mocked(execFile);
 
@@ -71,53 +71,5 @@ describe("startContainer", () => {
     );
     const runArgs = runCall![1] as string[];
     expect(runArgs).not.toContain("--network");
-  });
-});
-
-describe("chownInContainer", () => {
-  it("succeeds silently when chown succeeds", async () => {
-    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
-      cb(null, "", "");
-      return undefined as any;
-    });
-
-    await Effect.runPromise(
-      chownInContainer("ctr", "1000:1000", "/home/agent"),
-    );
-  });
-
-  it("does not propagate error when chown fails", async () => {
-    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
-      const err = new Error(
-        "chown: changing ownership of '/workspace/.git/objects/pack': Read-only file system",
-      );
-      (err as any).code = 1;
-      cb(err, "", "chown: Read-only file system");
-      return undefined as any;
-    });
-
-    // Should NOT throw — chown failure is non-fatal
-    await Effect.runPromise(
-      chownInContainer("ctr", "1000:1000", "/home/agent"),
-    );
-  });
-
-  it("logs a warning when chown fails", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
-      const err = new Error("chown failed");
-      (err as any).code = 1;
-      cb(err, "", "chown: Read-only file system");
-      return undefined as any;
-    });
-
-    await Effect.runPromise(
-      chownInContainer("ctr", "1000:1000", "/home/agent"),
-    );
-
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("chown"));
-
-    warnSpy.mockRestore();
   });
 });

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -123,40 +123,6 @@ export const startContainer = (
   });
 
 /**
- * Fix ownership of a directory inside the container.
- * Runs as root so the target owner can write to the path.
- *
- * Non-fatal: if chown fails (e.g. read-only .git/objects on macOS VirtioFS),
- * a warning is logged but the error is not propagated.
- *
- * @param owner - chown-compatible owner spec, e.g. "1000:1000" or "agent"
- */
-export const chownInContainer = (
-  containerName: string,
-  owner: string,
-  path: string,
-): Effect.Effect<void> =>
-  Effect.asVoid(
-    dockerExec([
-      "exec",
-      "-u",
-      "root",
-      containerName,
-      "chown",
-      "-R",
-      owner,
-      path,
-    ]),
-  ).pipe(
-    Effect.catchAll((error) => {
-      console.warn(
-        `chown -R ${owner} ${path} in container ${containerName} failed (non-fatal): ${error.message}`,
-      );
-      return Effect.void;
-    }),
-  );
-
-/**
  * Stop and remove a container without removing the image.
  */
 export const removeContainer = (

--- a/src/PodmanLifecycle.test.ts
+++ b/src/PodmanLifecycle.test.ts
@@ -10,7 +10,6 @@ import { execFile } from "node:child_process";
 import {
   buildImage,
   removeImage,
-  chownInContainer,
 } from "./PodmanLifecycle.js";
 
 const mockExecFile = vi.mocked(execFile);
@@ -97,79 +96,6 @@ describe("PodmanLifecycle", () => {
       const result = await Effect.runPromiseExit(removeImage("my-image"));
 
       expect(result._tag).toBe("Failure");
-    });
-  });
-
-  describe("chownInContainer", () => {
-    it("runs podman exec -u root chown -R with the given owner and path", async () => {
-      mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
-        cb(null, "", "");
-        return undefined as any;
-      });
-
-      await Effect.runPromise(
-        chownInContainer("my-ctr", "501:20", "/home/agent"),
-      );
-
-      expect(mockExecFile).toHaveBeenCalledWith(
-        "podman",
-        [
-          "exec",
-          "-u",
-          "root",
-          "my-ctr",
-          "chown",
-          "-R",
-          "501:20",
-          "/home/agent",
-        ],
-        expect.any(Object),
-        expect.any(Function),
-      );
-    });
-
-    it("succeeds silently when chown succeeds", async () => {
-      mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
-        cb(null, "", "");
-        return undefined as any;
-      });
-
-      await Effect.runPromise(
-        chownInContainer("ctr", "1000:1000", "/home/agent"),
-      );
-    });
-
-    it("does not propagate error when chown fails", async () => {
-      mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
-        const err = new Error("chown: Read-only file system");
-        (err as any).code = 1;
-        cb(err, "", "chown: Read-only file system");
-        return undefined as any;
-      });
-
-      // Should NOT throw — chown failure is non-fatal
-      await Effect.runPromise(
-        chownInContainer("ctr", "1000:1000", "/home/agent"),
-      );
-    });
-
-    it("logs a warning when chown fails", async () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-      mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
-        const err = new Error("chown failed");
-        (err as any).code = 1;
-        cb(err, "", "chown: Read-only file system");
-        return undefined as any;
-      });
-
-      await Effect.runPromise(
-        chownInContainer("ctr", "1000:1000", "/home/agent"),
-      );
-
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("chown"));
-
-      warnSpy.mockRestore();
     });
   });
 });

--- a/src/PodmanLifecycle.ts
+++ b/src/PodmanLifecycle.ts
@@ -53,40 +53,6 @@ export const buildImage = (
   });
 
 /**
- * Fix ownership of a directory inside the container.
- * Runs as root so the target owner can write to the path.
- *
- * Non-fatal: if chown fails (e.g. read-only mount), a warning is logged
- * but the error is not propagated. Matches Docker provider semantics.
- *
- * @param owner - chown-compatible owner spec, e.g. "1000:1000"
- */
-export const chownInContainer = (
-  containerName: string,
-  owner: string,
-  path: string,
-): Effect.Effect<void> =>
-  Effect.asVoid(
-    podmanExec([
-      "exec",
-      "-u",
-      "root",
-      containerName,
-      "chown",
-      "-R",
-      owner,
-      path,
-    ]),
-  ).pipe(
-    Effect.catchAll((error) => {
-      console.warn(
-        `chown -R ${owner} ${path} in container ${containerName} failed (non-fatal): ${error.message}`,
-      );
-      return Effect.void;
-    }),
-  );
-
-/**
  * Remove a Podman image.
  */
 export const removeImage = (

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -18,7 +18,6 @@ import { Effect } from "effect";
 import {
   startContainer,
   removeContainer,
-  chownInContainer,
 } from "../DockerLifecycle.js";
 import {
   createBindMountSandboxProvider,
@@ -109,14 +108,6 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
             user: `${hostUid}:${hostGid}`,
             network: options?.network,
           },
-        ).pipe(
-          Effect.andThen(
-            chownInContainer(
-              containerName,
-              `${hostUid}:${hostGid}`,
-              "/home/agent",
-            ),
-          ),
         ),
       );
 

--- a/src/sandboxes/podman.test.ts
+++ b/src/sandboxes/podman.test.ts
@@ -284,7 +284,35 @@ describe("podman()", () => {
       ([, args]) => Array.isArray(args) && args[0] === "run",
     )?.[1] as string[];
 
-    expect(runArgs).toContain("--userns=keep-id");
+    expect(runArgs).toContain("--userns=keep-id:uid=1000,gid=1000");
+
+    await handle.close();
+  });
+
+  it("passes custom containerUid/containerGid to --userns and --user", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({ containerUid: 500, containerGid: 500 });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1] as string[];
+
+    expect(runArgs).toContain("--userns=keep-id:uid=500,gid=500");
+    const userIdx = runArgs.indexOf("--user");
+    expect(runArgs[userIdx + 1]).toBe("500:500");
 
     await handle.close();
   });
@@ -310,7 +338,7 @@ describe("podman()", () => {
       ([, args]) => Array.isArray(args) && args[0] === "run",
     )?.[1] as string[];
 
-    expect(runArgs).not.toContain("--userns=keep-id");
+    expect(runArgs).not.toContain("--userns=keep-id:uid=1000,gid=1000");
 
     await handle.close();
   });
@@ -461,7 +489,7 @@ describe("podman()", () => {
     await handle.close();
   });
 
-  it("runs chown on /home/agent after container start", async () => {
+  it("does not run chown after container start", async () => {
     mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
       const callback = rest[rest.length - 1];
       callback(null, "", "");
@@ -478,55 +506,15 @@ describe("podman()", () => {
       env: {},
     });
 
-    // Find the chown exec call (podman exec -u root <name> chown -R ...)
+    // Verify no chown exec call was made
     const chownCall = mockExecFile.mock.calls.find(
       ([cmd, args]) =>
         cmd === "podman" &&
         Array.isArray(args) &&
-        args[0] === "exec" &&
-        args[1] === "-u" &&
-        args[2] === "root" &&
-        args[4] === "chown",
+        args.includes("chown"),
     );
-    expect(chownCall).toBeDefined();
-    const chownArgs = chownCall![1] as string[];
-    expect(chownArgs).toContain("-R");
-    expect(chownArgs[chownArgs.length - 1]).toBe("/home/agent");
+    expect(chownCall).toBeUndefined();
 
-    await handle.close();
-  });
-
-  it("does not fail sandbox creation when chown fails", async () => {
-    mockExecFile.mockImplementation((_command, args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-
-      // Fail the chown exec call
-      if (Array.isArray(args) && args[0] === "exec" && args.includes("chown")) {
-        const err = new Error("chown: Read-only file system");
-        (err as any).code = 1;
-        callback(err, "", "chown: Read-only file system");
-      } else {
-        callback(null, "", "");
-      }
-      return undefined as any;
-    });
-
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-    const provider = podman();
-    // Should NOT throw despite chown failing
-    const handle = await provider.create({
-      worktreePath: "/tmp/worktree",
-      hostRepoPath: "/tmp/repo",
-      mounts: [
-        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
-      ],
-      env: {},
-    });
-
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("chown"));
-
-    warnSpy.mockRestore();
     await handle.close();
   });
 

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -25,10 +25,8 @@ import {
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, resolve } from "node:path";
-import { Effect } from "effect";
 import type { MountConfig } from "../MountConfig.js";
 import { SANDBOX_REPO_DIR } from "../SandboxFactory.js";
-import { chownInContainer } from "../PodmanLifecycle.js";
 
 export interface PodmanOptions {
   /** Podman image name (default: derived from repo directory name). */
@@ -44,11 +42,26 @@ export interface PodmanOptions {
   /**
    * User namespace mode for rootless Podman.
    *
-   * - `"keep-id"` (default) — maps host UID 1:1 into the container,
-   *   so bind-mounted files have correct ownership. Required for rootless Podman.
+   * - `"keep-id"` (default) — maps host UID to `containerUid` inside the
+   *   container via `--userns=keep-id:uid=N,gid=N`, so both bind-mounted
+   *   files and image-built files have correct ownership without chown.
    * - `false` — disable; use for rootful Podman setups.
    */
   readonly userns?: "keep-id" | false;
+  /**
+   * The UID of the `agent` user inside the container image (default: 1000).
+   *
+   * Must match the UID set in the Containerfile. Used with `--userns=keep-id`
+   * to map the host user to this UID inside the container.
+   */
+  readonly containerUid?: number;
+  /**
+   * The GID of the `agent` user inside the container image (default: 1000).
+   *
+   * Must match the GID set in the Containerfile. Used with `--userns=keep-id`
+   * to map the host group to this GID inside the container.
+   */
+  readonly containerGid?: number;
   /**
    * Additional host directories to bind-mount into the sandbox.
    *
@@ -81,6 +94,8 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
   const configuredImageName = options?.imageName;
   const selinuxLabel = options?.selinuxLabel ?? "z";
   const userns = options?.userns ?? "keep-id";
+  const containerUid = options?.containerUid ?? 1000;
+  const containerGid = options?.containerGid ?? 1000;
   const userMounts = options?.mounts ? resolveUserMounts(options.mounts) : [];
 
   return createBindMountSandboxProvider({
@@ -114,16 +129,16 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
       // Pre-flight: verify image exists locally
       await checkImageExists(imageName);
 
-      const hostUid = process.getuid?.() ?? 1000;
-      const hostGid = process.getgid?.() ?? 1000;
-
       const env = { ...createOptions.env, HOME: "/home/agent" };
       const envArgs = Object.entries(env).flatMap(([key, value]) => [
         "-e",
         `${key}=${value}`,
       ]);
       const volumeArgs = volumeMounts.flatMap((v) => ["-v", v]);
-      const usernsArgs = userns ? [`--userns=${userns}`] : [];
+      const usernsArgs = userns
+        ? [`--userns=keep-id:uid=${containerUid},gid=${containerGid}`]
+        : [];
+      const userArgs = ["--user", `${containerUid}:${containerGid}`];
       const networks = options?.network
         ? Array.isArray(options.network)
           ? options.network
@@ -140,8 +155,7 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
             "-d",
             "--name",
             containerName,
-            "--user",
-            `${hostUid}:${hostGid}`,
+            ...userArgs,
             ...usernsArgs,
             ...networkArgs,
             "-w",
@@ -162,13 +176,6 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
           },
         );
       });
-
-      // Fix /home/agent ownership for the container user (parity with Docker provider).
-      // On macOS rootless Podman with --userns=keep-id, the host UID may differ
-      // from UID 1000 in the image, making /home/agent unwritable.
-      await Effect.runPromise(
-        chownInContainer(containerName, `${hostUid}:${hostGid}`, "/home/agent"),
-      );
 
       // Set up signal handlers for cleanup
       const onExit = () => {


### PR DESCRIPTION
## Summary
- **Podman**: Replace `--user ${hostUid}` + `chown -R /home/agent` with `--userns=keep-id:uid=N,gid=N`. Aligns bind-mount and image ownership via namespace mapping — no file mutation needed. Add `containerUid`/`containerGid` options (default 1000).
- **Docker**: Remove `chown -R /home/agent` entirely. Keep `--user ${hostUid}:${hostGid}` only.
- Delete `chownInContainer` from both lifecycle modules.
- ADR: `docs/adr/0005-remove-chown-uid-alignment.md`

Fixes #385, fixes #377

## Test plan
- [ ] QA on WSL with Docker provider — verify no permission errors on startup
- [ ] QA on macOS with Podman provider — verify bind-mounted and image files are both writable
- [ ] QA with custom mounts under `/home/agent` — verify no chown warnings
- [ ] Verify `containerUid`/`containerGid` option works with non-1000 image UIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)