### PR TITLE
Fix Codex agent provider not logging output

### DIFF
--- a/.changeset/fix-codex-logging.md
+++ b/.changeset/fix-codex-logging.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix Codex agent provider not logging output by reading `item.text` instead of `item.content` from stream events

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -439,7 +439,7 @@ describe("codex factory", () => {
     const provider = codex("gpt-5.4-mini");
     const line = JSON.stringify({
       type: "item.completed",
-      item: { type: "agent_message", content: "Hello world" },
+      item: { type: "agent_message", text: "Hello world" },
     });
     expect(provider.parseStreamLine(line)).toEqual([
       { type: "text", text: "Hello world" },
@@ -481,11 +481,23 @@ describe("codex factory", () => {
     expect(provider.parseStreamLine("{bad json")).toEqual([]);
   });
 
-  it("parseStreamLine handles item.completed with missing content", () => {
+  it("parseStreamLine handles item.completed with missing text", () => {
     const provider = codex("gpt-5.4-mini");
     const line = JSON.stringify({
       type: "item.completed",
       item: { type: "agent_message" },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([]);
+  });
+
+  it("parseStreamLine does not extract from item.content (array form), only item.text", () => {
+    const provider = codex("gpt-5.4-mini");
+    const line = JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        content: [{ type: "text", text: "from content array" }],
+      },
     });
     expect(provider.parseStreamLine(line)).toEqual([]);
   });

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -187,9 +187,9 @@ const parseCodexStreamLine = (line: string): ParsedStreamEvent[] => {
     if (
       obj.type === "item.completed" &&
       obj.item?.type === "agent_message" &&
-      typeof obj.item.content === "string"
+      typeof obj.item.text === "string"
     ) {
-      const text = obj.item.content;
+      const text = obj.item.text;
       return [
         { type: "text", text },
         { type: "result", result: text },

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -2668,7 +2668,7 @@ const toCodexStreamJson = (output: string): string => {
   lines.push(
     JSON.stringify({
       type: "item.completed",
-      item: { type: "agent_message", content: output },
+      item: { type: "agent_message", text: output },
     }),
   );
   return lines.join("\n");


### PR DESCRIPTION
## Summary
- Fixes #374: `parseCodexStreamLine` was checking `obj.item.content` (an array in Codex's API) instead of `obj.item.text` (the string field), so the type guard always failed and no `"text"` or `"result"` `ParsedStreamEvent` values were emitted
- Changed field access from `item.content` to `item.text` in the parser
- Updated all test fixtures to match real Codex stream format and added a regression test ensuring `item.content` (array form) is not extracted

## Test plan
- [x] Unit tests for `parseCodexStreamLine` pass (85/85 in AgentProvider.test.ts)
- [x] Codex integration tests in Orchestrator.test.ts pass (2/2)
- [x] Typecheck passes
- [x] Full test suite passes (pre-existing failures in session capture unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)