### PR TITLE
Enable Ctrl+Z (job control) in Podman interactive mode

### DIFF
--- a/.changeset/podman-interactive-ctrl-z.md
+++ b/.changeset/podman-interactive-ctrl-z.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Enable Ctrl+Z (job control) in Podman interactive mode by wrapping the agent in a bash session with `set -m`. Suspending with Ctrl+Z drops into the shell; `fg` resumes the agent. The terminal is reset via `PROMPT_COMMAND` on resume, and the shell exits cleanly when the agent finishes normally.

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -259,24 +259,53 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
           });
         },
 
-        interactiveExec: (
+        interactiveExec: async (
           args: string[],
           opts: InteractiveExecOptions,
         ): Promise<{ exitCode: number }> => {
-          return new Promise((resolve, reject) => {
-            const podmanArgs = ["exec"];
-            // Allocate a pseudo-terminal when stdin looks like a TTY
-            if (
-              "isTTY" in opts.stdin &&
-              (opts.stdin as { isTTY?: boolean }).isTTY
-            ) {
-              podmanArgs.push("-it");
-            } else {
-              podmanArgs.push("-i");
-            }
-            if (opts.cwd) podmanArgs.push("-w", opts.cwd);
-            podmanArgs.push(containerName, ...args);
+          // Wrap the agent in an interactive bash session so Ctrl+Z works:
+          // bash (with job control) runs the agent in a new process group, so
+          // SIGTSTP only suspends the agent while bash retains terminal control.
+          // PROMPT_COMMAND resets the terminal after suspend, and exits bash
+          // once the agent job is gone (normal exit) — but NOT when it's merely
+          // stopped, so `fg` correctly resumes it.
+          const shellQuote = (s: string) =>
+            "'" + s.replace(/'/g, "'\\''") + "'";
+          const cmd = args.map(shellQuote).join(" ");
+          const script =
+            [
+              "set -m",
+              "PROMPT_COMMAND='stty sane 2>/dev/null; jobs %1 &>/dev/null 2>&1 || exit'",
+              cmd,
+            ].join("\n") + "\n";
+          // Use base64 round-trip so the script survives any special characters.
+          const b64 = Buffer.from(script).toString("base64");
+          await handle.exec(
+            `printf '%s' '${b64}' | base64 -d > /tmp/.sc_init.sh`,
+          );
 
+          const podmanArgs = ["exec"];
+          if (
+            "isTTY" in opts.stdin &&
+            (opts.stdin as { isTTY?: boolean }).isTTY
+          ) {
+            podmanArgs.push("-it");
+          } else {
+            podmanArgs.push("-i");
+          }
+          if (opts.cwd) podmanArgs.push("-w", opts.cwd);
+          // Run bash interactively with our init script as the rcfile.
+          // The agent starts as a foreground job; Ctrl+Z suspends it and
+          // drops the user into the same shell, `fg` brings it back.
+          podmanArgs.push(
+            containerName,
+            "bash",
+            "--rcfile",
+            "/tmp/.sc_init.sh",
+            "-i",
+          );
+
+          return new Promise((resolve, reject) => {
             const proc = spawn("podman", podmanArgs, {
               stdio: [opts.stdin, opts.stdout, opts.stderr] as StdioOptions,
             });


### PR DESCRIPTION
--- Human note:

I wanted to be able to drop out of interactive sessions into the container, to run commands, see what's available in the container for Claude to use and essentially have a good starting point to debug the whole thing.
This isn't really beautiful, but works nicely for me. Still, please test it by going through the test plan before merging :)

--- AI PR:

## Summary

- Wraps the agent command in an interactive bash session with `set -m` (job control enabled), so Ctrl+Z suspends only the agent process while bash retains terminal control
- The init script is written to `/tmp/.sc_init.sh` via a base64 round-trip to survive any special characters in the command args
- `PROMPT_COMMAND` resets the terminal with `stty sane` on resume, and exits bash once the agent job is gone (normal exit) — but not when it's merely stopped, so `fg` correctly resumes it

## Test plan

- [ ] Run sandcastle in Podman interactive mode and press Ctrl+Z — agent should suspend and drop to a shell prompt
- [ ] Type `fg` to resume the agent — it should continue from where it left off
- [ ] Verify normal exit (no Ctrl+Z) still works: bash exits cleanly when the agent finishes
- [ ] Verify non-TTY mode (piped stdin) still works: init script is still written, bash runs non-interactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)