### PR TITLE
Remove duplicate command logging in shell expression expansion

### DIFF
--- a/.changeset/remove-duplicate-command-logging.md
+++ b/.changeset/remove-duplicate-command-logging.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Remove duplicate command logging in shell expression expansion. Each command now appears once in the task log (with its token count), instead of twice.

--- a/src/PromptPreprocessor.test.ts
+++ b/src/PromptPreprocessor.test.ts
@@ -136,20 +136,17 @@ describe("PromptPreprocessor", () => {
     const taskLogEntry = entries.find((e) => e._tag === "taskLog");
     expect(taskLogEntry).toBeDefined();
     if (taskLogEntry!._tag !== "taskLog") throw new Error("unreachable");
-    // First two messages are the command names (existing behavior)
-    expect(taskLogEntry!.messages[0]).toBe("echo hello");
-    expect(taskLogEntry!.messages[1]).toBe("echo world");
-    // Next two messages are per-command token counts
+    // Each command appears exactly once — with its token count
     const helloTokens = Math.ceil("hello".length / 4);
     const worldTokens = Math.ceil("world".length / 4);
-    expect(taskLogEntry!.messages[2]).toBe(
+    expect(taskLogEntry!.messages[0]).toBe(
       `echo hello \u2192 ~${helloTokens} tokens`,
     );
-    expect(taskLogEntry!.messages[3]).toBe(
+    expect(taskLogEntry!.messages[1]).toBe(
       `echo world \u2192 ~${worldTokens} tokens`,
     );
-    // No total line — exactly 4 messages
-    expect(taskLogEntry!.messages).toHaveLength(4);
+    // No upfront command names, no total line — exactly 2 messages
+    expect(taskLogEntry!.messages).toHaveLength(2);
   });
 
   it("does not show taskLog when prompt has no commands", async () => {

--- a/src/PromptPreprocessor.ts
+++ b/src/PromptPreprocessor.ts
@@ -30,11 +30,6 @@ export const preprocessPrompt = (
     const display = yield* Display;
     return yield* display.taskLog("Expanding shell expressions", (message) =>
       Effect.gen(function* () {
-        // Log all commands upfront in document order
-        for (const match of matches) {
-          message(match[1]!);
-        }
-
         // Execute all commands in parallel
         const results = yield* Effect.all(
           matches.map((match) => {


### PR DESCRIPTION
## Summary
- Removes the upfront command logging loop in `preprocessPrompt()` that logged each shell expression command name before execution
- Each command now appears exactly once in the `taskLog` — with its `→ ~N tokens` suffix after execution
- Updates test expectations from 4 messages to 2

Fixes #407

## Test plan
- [x] Updated test "logs per-command token counts after shell expressions resolve" to expect only token-count messages
- [x] `npm run typecheck` passes
- [x] All existing tests pass (4 pre-existing failures on main unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)