### PR TITLE
Expose token usage on IterationResult

### DIFF
--- a/.changeset/expose-iteration-usage.md
+++ b/.changeset/expose-iteration-usage.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Expose per-iteration token usage on `IterationResult` via a new `usage?: IterationUsage` field. Claude Code sessions are parsed after capture to extract raw token counts (`inputTokens`, `cacheCreationInputTokens`, `cacheReadInputTokens`, `outputTokens`) from the last assistant message. Non-Claude agent providers return `undefined`.

--- a/README.md
+++ b/README.md
@@ -672,10 +672,20 @@ Removes the Podman image.
 
 ### `IterationResult`
 
-| Field             | Type    | Description                                                                          |
-| ----------------- | ------- | ------------------------------------------------------------------------------------ |
-| `sessionId`       | string? | Claude Code session ID from the init line, or `undefined` for non-Claude agents      |
-| `sessionFilePath` | string? | Absolute host path to the captured session JSONL, or `undefined` when capture is off |
+| Field             | Type              | Description                                                                                                                         |
+| ----------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `sessionId`       | string?           | Claude Code session ID from the init line, or `undefined` for non-Claude agents                                                     |
+| `sessionFilePath` | string?           | Absolute host path to the captured session JSONL, or `undefined` when capture is off                                                |
+| `usage`           | `IterationUsage`? | Token usage snapshot from the last assistant message, or `undefined` when capture is off or provider does not support usage parsing |
+
+### `IterationUsage`
+
+| Field                      | Type   | Description                                |
+| -------------------------- | ------ | ------------------------------------------ |
+| `inputTokens`              | number | Input tokens consumed                      |
+| `cacheCreationInputTokens` | number | Tokens used to create prompt cache entries |
+| `cacheReadInputTokens`     | number | Tokens read from prompt cache              |
+| `outputTokens`             | number | Output tokens generated                    |
 
 ### Session capture
 

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -694,6 +694,111 @@ describe("resumeSession on non-Claude providers", () => {
   });
 });
 
+describe("parseSessionUsage (Claude Code)", () => {
+  const provider = claudeCode("claude-opus-4-6");
+
+  it("extracts usage from the last assistant message in a JSONL string", () => {
+    const content = [
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          model: "claude-opus-4-6",
+          usage: {
+            input_tokens: 100,
+            cache_creation_input_tokens: 200,
+            cache_read_input_tokens: 300,
+            output_tokens: 50,
+          },
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          model: "claude-opus-4-6",
+          usage: {
+            input_tokens: 3,
+            cache_creation_input_tokens: 9294,
+            cache_read_input_tokens: 8526,
+            output_tokens: 458,
+          },
+        },
+      }),
+    ].join("\n");
+
+    expect(provider.parseSessionUsage!(content)).toEqual({
+      inputTokens: 3,
+      cacheCreationInputTokens: 9294,
+      cacheReadInputTokens: 8526,
+      outputTokens: 458,
+    });
+  });
+
+  it("returns undefined for empty content", () => {
+    expect(provider.parseSessionUsage!("")).toBeUndefined();
+  });
+
+  it("returns undefined for content with no assistant messages", () => {
+    const content = [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "abc" }),
+      JSON.stringify({ type: "result", result: "done" }),
+    ].join("\n");
+    expect(provider.parseSessionUsage!(content)).toBeUndefined();
+  });
+
+  it("returns undefined when assistant message has no usage block", () => {
+    const content = JSON.stringify({
+      type: "assistant",
+      message: {
+        model: "claude-opus-4-6",
+        content: [{ type: "text", text: "hi" }],
+      },
+    });
+    expect(provider.parseSessionUsage!(content)).toBeUndefined();
+  });
+
+  it("returns undefined for malformed JSON lines", () => {
+    const content = "not json\n{bad json\n";
+    expect(provider.parseSessionUsage!(content)).toBeUndefined();
+  });
+
+  it("skips malformed lines and finds valid assistant message", () => {
+    const content = [
+      "not json",
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          model: "claude-opus-4-6",
+          usage: {
+            input_tokens: 10,
+            cache_creation_input_tokens: 20,
+            cache_read_input_tokens: 30,
+            output_tokens: 40,
+          },
+        },
+      }),
+    ].join("\n");
+
+    expect(provider.parseSessionUsage!(content)).toEqual({
+      inputTokens: 10,
+      cacheCreationInputTokens: 20,
+      cacheReadInputTokens: 30,
+      outputTokens: 40,
+    });
+  });
+
+  it("is not defined on pi provider", () => {
+    expect(pi("model").parseSessionUsage).toBeUndefined();
+  });
+
+  it("is not defined on codex provider", () => {
+    expect(codex("model").parseSessionUsage).toBeUndefined();
+  });
+
+  it("is not defined on opencode provider", () => {
+    expect(opencode("model").parseSessionUsage).toBeUndefined();
+  });
+});
+
 describe("captureSessions flag", () => {
   it("claudeCode defaults captureSessions to true", () => {
     expect(claudeCode("claude-opus-4-6").captureSessions).toBe(true);

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -86,6 +86,14 @@ export interface PrintCommand {
   readonly stdin?: string;
 }
 
+/** Per-iteration token usage snapshot extracted from the agent session. */
+export interface IterationUsage {
+  readonly inputTokens: number;
+  readonly cacheCreationInputTokens: number;
+  readonly cacheReadInputTokens: number;
+  readonly outputTokens: number;
+}
+
 export interface AgentProvider {
   readonly name: string;
   /** Environment variables injected by this agent provider. Merged at launch time with env resolver and sandbox provider env. */
@@ -95,6 +103,8 @@ export interface AgentProvider {
   buildPrintCommand(options: AgentCommandOptions): PrintCommand;
   buildInteractiveArgs?(options: AgentCommandOptions): string[];
   parseStreamLine(line: string): ParsedStreamEvent[];
+  /** Parse token usage from the captured session JSONL content. Only implemented by Claude Code. */
+  parseSessionUsage?(content: string): IterationUsage | undefined;
 }
 
 export const DEFAULT_MODEL = "claude-opus-4-6";
@@ -346,5 +356,35 @@ export const claudeCode = (
 
   parseStreamLine(line: string): ParsedStreamEvent[] {
     return parseStreamJsonLine(line);
+  },
+
+  parseSessionUsage(content: string): IterationUsage | undefined {
+    const lines = content.split("\n");
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i]!;
+      if (!line.startsWith("{")) continue;
+      try {
+        const obj = JSON.parse(line);
+        if (obj.type === "assistant" && obj.message?.usage) {
+          const u = obj.message.usage;
+          if (
+            typeof u.input_tokens === "number" &&
+            typeof u.cache_creation_input_tokens === "number" &&
+            typeof u.cache_read_input_tokens === "number" &&
+            typeof u.output_tokens === "number"
+          ) {
+            return {
+              inputTokens: u.input_tokens,
+              cacheCreationInputTokens: u.cache_creation_input_tokens,
+              cacheReadInputTokens: u.cache_read_input_tokens,
+              outputTokens: u.output_tokens,
+            };
+          }
+        }
+      } catch {
+        // Not valid JSON — skip
+      }
+    }
+    return undefined;
   },
 });

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -3105,6 +3105,103 @@ describe("Session capture integration", () => {
     const entry = JSON.parse(capturedLines[0]!) as { cwd: string };
     expect(entry.cwd).toBe(hostDir);
   });
+
+  it("populates usage on IterationResult when session has assistant usage", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-usage-host-"));
+    const hostProjectsDir = await mkdtemp(
+      join(tmpdir(), "orch-usage-projects-"),
+    );
+    const sandboxProjectsDir = await mkdtemp(
+      join(tmpdir(), "orch-usage-sb-projects-"),
+    );
+    const mockSessionId = "usage-session-123";
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const { factoryLayer } = makeSessionCaptureFactory(
+      hostDir,
+      async (repoDir) => {
+        const encoded = encodeProjectPath(repoDir);
+        const sessionsDir = join(sandboxProjectsDir, encoded);
+        await mkdir(sessionsDir, { recursive: true });
+        await writeFile(
+          join(sessionsDir, `${mockSessionId}.jsonl`),
+          [
+            JSON.stringify({
+              type: "system",
+              subtype: "init",
+              session_id: mockSessionId,
+            }),
+            JSON.stringify({
+              type: "assistant",
+              message: {
+                model: "claude-opus-4-6",
+                usage: {
+                  input_tokens: 3,
+                  cache_creation_input_tokens: 9294,
+                  cache_read_input_tokens: 8526,
+                  output_tokens: 458,
+                },
+              },
+            }),
+          ].join("\n"),
+        );
+        return "Done. <promise>COMPLETE</promise>";
+      },
+      mockSessionId,
+    );
+
+    const result = await Effect.runPromise(
+      orchestrate({
+        provider: testProvider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: "do some work",
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            factoryLayer,
+            testDisplayLayer,
+            sessionPathsLayer({ hostProjectsDir, sandboxProjectsDir }),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.iterations[0]!.usage).toEqual({
+      inputTokens: 3,
+      cacheCreationInputTokens: 9294,
+      cacheReadInputTokens: 8526,
+      outputTokens: 458,
+    });
+  });
+
+  it("usage is undefined when captureSessions is false", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-nousage-host-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const provider = claudeCode("test-model", { captureSessions: false });
+
+    const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) =>
+      makeMockAgentLayer(dir, async () => {
+        return "Done.";
+      }),
+    );
+
+    const result = await Effect.runPromise(
+      orchestrate({
+        provider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: "do some work",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(result.iterations[0]!.usage).toBeUndefined();
+  });
 });
 
 describe("Orchestrator signal (AbortSignal)", () => {

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { Deferred, Effect } from "effect";
 import { Display } from "./Display.js";
 import { preprocessPrompt } from "./PromptPreprocessor.js";
@@ -10,7 +11,7 @@ import type { SandboxError } from "./errors.js";
 import type { SandboxService } from "./SandboxFactory.js";
 import { SandboxFactory, SANDBOX_REPO_DIR } from "./SandboxFactory.js";
 import { withSandboxLifecycle, type SandboxHooks } from "./SandboxLifecycle.js";
-import type { AgentProvider } from "./AgentProvider.js";
+import type { AgentProvider, IterationUsage } from "./AgentProvider.js";
 import { TextDeltaBuffer } from "./TextDeltaBuffer.js";
 import {
   hostSessionStore,
@@ -22,7 +23,7 @@ import { SessionPaths } from "./SessionPaths.js";
 /** Sandbox-side Claude Code projects directory (fixed convention). */
 const SANDBOX_PROJECTS_DIR = "/home/agent/.claude/projects";
 
-export type { ParsedStreamEvent } from "./AgentProvider.js";
+export type { ParsedStreamEvent, IterationUsage } from "./AgentProvider.js";
 
 const IDLE_WARNING_INTERVAL_MS = 60_000;
 
@@ -191,6 +192,8 @@ export interface IterationResult {
   readonly sessionId?: string;
   /** Absolute host path to the captured session JSONL, or undefined when capture is disabled or provider is non-Claude. */
   readonly sessionFilePath?: string;
+  /** Token usage snapshot from the last assistant message in the session, or undefined when capture is disabled or provider does not support usage parsing. */
+  readonly usage?: IterationUsage;
 }
 
 export interface OrchestrateResult {
@@ -332,6 +335,7 @@ export const orchestrate = (
 
                 // Capture session while sandbox is still alive
                 let sessionFilePath: string | undefined;
+                let usage: IterationUsage | undefined;
                 if (provider.captureSessions && sessionId && bindMountHandle) {
                   yield* display.status(label("Capturing session"), "info");
                   const sbStore = sandboxSessionStore(
@@ -349,6 +353,18 @@ export const orchestrate = (
                       }),
                   });
                   sessionFilePath = hStore.sessionFilePath(sessionId);
+
+                  // Parse token usage from the captured session JSONL
+                  if (provider.parseSessionUsage) {
+                    const content = yield* Effect.promise(() =>
+                      readFile(sessionFilePath!, "utf-8").catch(
+                        () => undefined as string | undefined,
+                      ),
+                    );
+                    if (content) {
+                      usage = provider.parseSessionUsage(content);
+                    }
+                  }
                 }
 
                 // Check completion signal
@@ -360,6 +376,7 @@ export const orchestrate = (
                   stdout: agentOutput,
                   sessionId,
                   sessionFilePath,
+                  usage,
                 } as const;
               }),
           ),
@@ -375,6 +392,7 @@ export const orchestrate = (
       allIterations.push({
         sessionId: lifecycleResult.result.sessionId,
         sessionFilePath: lifecycleResult.result.sessionFilePath,
+        usage: lifecycleResult.result.usage,
       });
 
       if (lifecycleResult.result.completionSignal !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export type {
   RunResult,
   LoggingOption,
   IterationResult,
+  IterationUsage,
 } from "./run.js";
 export { interactive } from "./interactive.js";
 export type { InteractiveOptions, InteractiveResult } from "./interactive.js";

--- a/src/run.ts
+++ b/src/run.ts
@@ -210,7 +210,7 @@ export interface RunOptions {
   readonly signal?: AbortSignal;
 }
 
-export type { IterationResult } from "./Orchestrator.js";
+export type { IterationResult, IterationUsage } from "./Orchestrator.js";
 
 export interface RunResult {
   /** Per-iteration results (use `iterations.length` for the count). */


### PR DESCRIPTION
## Summary

Closes #406

- Adds `IterationUsage` type with raw token counts (`inputTokens`, `cacheCreationInputTokens`, `cacheReadInputTokens`, `outputTokens`)
- Adds optional `parseSessionUsage()` method to `AgentProvider` interface, implemented only on `claudeCode()`
- Wires usage parsing into the Orchestrator after session capture, populating `IterationResult.usage`
- Re-exports `IterationUsage` from the public API (`index.ts`)

## Design decisions

Per ADR 0005: raw token counts only, no context window size or percentage. Usage is parsed from the last `type: "assistant"` entry in the captured session JSONL. Only Claude Code is supported; other agent providers return `undefined`.

## Test plan

- [x] 8 unit tests for `parseSessionUsage` (valid JSONL, empty content, no assistant messages, no usage block, malformed JSON, mixed valid/invalid lines, not defined on pi/codex/opencode)
- [x] Integration test: `usage` is `undefined` when `captureSessions: false`
- [x] Integration test: `usage` is populated when session has assistant usage (depends on session capture infra — pre-existing failure, same as 2 existing session capture tests on main)
- [x] Typecheck passes
- [x] README updated with `IterationUsage` documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)