### PR TITLE
Pre-release: clean up changesets

### DIFF
--- a/.changeset/abort-signal-interactive.md
+++ b/.changeset/abort-signal-interactive.md
@@ -1,5 +1,0 @@
----
-"@ai-hero/sandcastle": patch
----
-
-Add `signal?: AbortSignal` to `InteractiveOptions` and `WorktreeInteractiveOptions` for cancelling an interactive session. Aborting mid-session kills the agent subprocess; the rejected promise surfaces `signal.reason` verbatim.

--- a/.changeset/abort-signal-lifecycle-hooks.md
+++ b/.changeset/abort-signal-lifecycle-hooks.md
@@ -1,5 +1,0 @@
----
-"@ai-hero/sandcastle": patch
----
-
-Thread AbortSignal to lifecycle hooks so aborting a run also cancels in-flight hook commands (host.onWorktreeReady, host.onSandboxReady, sandbox.onSandboxReady).

--- a/.changeset/abort-signal-run-core.md
+++ b/.changeset/abort-signal-run-core.md
@@ -1,5 +1,0 @@
----
-"@ai-hero/sandcastle": patch
----
-
-Add `signal?: AbortSignal` to `RunOptions` for cancelling a run. Aborting mid-iteration kills the in-flight agent subprocess; the worktree is preserved on disk. The rejected promise surfaces `signal.reason` verbatim.

--- a/.changeset/abort-signal-sandbox-run-interactive.md
+++ b/.changeset/abort-signal-sandbox-run-interactive.md
@@ -1,5 +1,0 @@
----
-"@ai-hero/sandcastle": patch
----
-
-Add `signal?: AbortSignal` to `Sandbox.run()` and `Sandbox.interactive()` options. Aborting cancels the in-flight operation but leaves the `Sandbox` handle usable — call `.run()` again with a fresh signal, or `.close()` to tear down normally.

--- a/.changeset/abort-signal-worktree-run-interactive.md
+++ b/.changeset/abort-signal-worktree-run-interactive.md
@@ -1,5 +1,0 @@
----
-"@ai-hero/sandcastle": patch
----
-
-Add `signal?: AbortSignal` to `WorktreeRunOptions` and `WorktreeInteractiveOptions` for cancelling operations on the Worktree handle. Aborting mid-operation kills the in-flight agent subprocess; the worktree is preserved on disk and the handle remains usable for subsequent calls.

--- a/.changeset/abort-signal.md
+++ b/.changeset/abort-signal.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add AbortSignal support for cancelling runs and interactive sessions. Pass `signal` to `run()`, `interactive()`, `Sandbox.run()`, `Sandbox.interactive()`, or any Worktree equivalent. Aborting kills the in-flight agent subprocess; handles remain usable for subsequent calls. Lifecycle hooks (`host.onWorktreeReady`, `host.onSandboxReady`, `sandbox.onSandboxReady`) are also cancelled when the signal fires.

--- a/.changeset/expose-iteration-usage.md
+++ b/.changeset/expose-iteration-usage.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": patch
 ---
 
-Expose per-iteration token usage on `IterationResult` via a new `usage?: IterationUsage` field. Claude Code sessions are parsed after capture to extract raw token counts (`inputTokens`, `cacheCreationInputTokens`, `cacheReadInputTokens`, `outputTokens`) from the last assistant message. Non-Claude agent providers return `undefined`.
+Expose per-iteration token usage on `IterationResult` via a new `usage?: IterationUsage` field. Returns raw token counts (`inputTokens`, `cacheCreationInputTokens`, `cacheReadInputTokens`, `outputTokens`) for Claude Code runs. Non-Claude agent providers return `undefined`.

--- a/.changeset/fix-codex-logging.md
+++ b/.changeset/fix-codex-logging.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": patch
 ---
 
-Fix Codex agent provider not logging output by reading `item.text` instead of `item.content` from stream events
+Fix Codex agent provider not logging output during runs.

--- a/.changeset/fix-session-resume-mkdir.md
+++ b/.changeset/fix-session-resume-mkdir.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": patch
 ---
 
-Fix session resume failing with `docker cp (in) failed` / `podman cp (in) failed` when the sandbox's `~/.claude/projects/<encoded>/` directory didn't yet exist. `sandboxSessionStore.writeSession` now creates the project directory inside the sandbox before copying the session JSONL in.
+Fix session resume failing with `docker cp (in) failed` / `podman cp (in) failed` when the sandbox's project directory didn't yet exist.

--- a/.changeset/fix-windows-docker-mount-paths.md
+++ b/.changeset/fix-windows-docker-mount-paths.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": patch
 ---
 
-Fix Windows paths breaking Docker/Podman volume mounts. Normalize backslashes to forward slashes in mount host paths and remap Windows-style sandbox paths to valid POSIX paths before they reach providers. Extract duplicated mount utilities (`defaultImageName`, `expandTilde`, `resolveHostPath`, `resolveSandboxPath`, `resolveUserMounts`) from Docker and Podman providers into a shared `mountUtils` module. `defaultImageName` now handles both `/` and `\` path separators. `expandTilde` now handles `~\` (Windows tilde paths).
+Fix Windows paths breaking Docker/Podman volume mounts. Backslashes in host paths and Windows-style sandbox paths are now normalized before reaching the container runtime.

--- a/.changeset/remove-chown-uid-alignment.md
+++ b/.changeset/remove-chown-uid-alignment.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": patch
 ---
 
-Remove recursive chown from Docker and Podman sandbox startup. For Podman, use `--userns=keep-id:uid=N,gid=N` to align bind-mount and image ownership via namespace mapping instead. For Docker, rely on `--user` alone without post-start chown. Add `containerUid`/`containerGid` options to Podman provider.
+Faster sandbox startup — remove the recursive `chown` that ran on every Docker and Podman container start. Add `containerUid`/`containerGid` options to the Podman provider for controlling in-container ownership.

--- a/.changeset/remove-duplicate-command-logging.md
+++ b/.changeset/remove-duplicate-command-logging.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": patch
 ---
 
-Remove duplicate command logging in shell expression expansion. Each command now appears once in the task log (with its token count), instead of twice.
+Fix duplicate command entries appearing in the task log. Each command now appears once (with its token count).

--- a/.changeset/stdin-prompt-delivery.md
+++ b/.changeset/stdin-prompt-delivery.md
@@ -2,11 +2,4 @@
 "@ai-hero/sandcastle": patch
 ---
 
-Deliver prompts via stdin instead of argv to avoid Linux E2BIG when prompts exceed 128 KB
-
-`AgentProvider.buildPrintCommand()` now returns `{ command, stdin? }` instead of a bare string. When `stdin` is set, the sandbox pipes the prompt to the child process's stdin rather than inlining it in the command-line arguments. This removes the 128 KB per-arg ceiling imposed by `execve(2)` on Linux.
-
-- `claudeCode()`, `pi()`, and `codex()` providers set `stdin` to the prompt and omit it from argv
-- `opencode()` provider keeps the prompt in argv (`stdin` undefined) — accepted limitation
-- Docker, Podman, and no-sandbox `exec()` implementations accept `stdin?: string` and pipe it when set
-- Orchestrator destructures `buildPrintCommand()` and forwards `stdin` to `sandbox.exec()`
+Fix runs failing when prompts exceed 128 KB on Linux. Prompts are now delivered via stdin instead of command-line arguments, avoiding the `execve(2)` argument size limit.

--- a/.changeset/worktree-run-resume-session.md
+++ b/.changeset/worktree-run-resume-session.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": patch
 ---
 
-`Worktree.run()` (returned from `createWorktree()`) now accepts `resumeSession` to resume a prior Claude Code session by ID. Mirrors the validation on top-level `run()`: the session file must exist on the host, and `resumeSession` cannot be combined with `maxIterations > 1`.
+`Worktree.run()` now accepts `resumeSession` to resume a prior Claude Code session by ID, matching the existing support on top-level `run()`.


### PR DESCRIPTION
## Summary
- Consolidate 5 separate abort signal changesets into a single changeset (one user-facing feature, not five implementation touch-points)
- Strip implementation details from 8 changesets — each now describes only the user-facing change, not internal refactors, code paths, or API shapes
- No code changes — only `.changeset/*.md` files modified

## Changes applied

| Changeset | What changed |
|---|---|
| `abort-signal-*.md` (5 files) | Merged into single `abort-signal.md` |
| `stdin-prompt-delivery.md` | Removed provider-by-provider implementation list |
| `fix-windows-docker-mount-paths.md` | Removed mountUtils refactoring details |
| `fix-codex-logging.md` | Removed `item.text`/`item.content` detail |
| `fix-session-resume-mkdir.md` | Removed internal store/path details |
| `expose-iteration-usage.md` | Removed session parsing internals |
| `remove-chown-uid-alignment.md` | Reframed as user-facing perf improvement + new options |
| `worktree-run-resume-session.md` | Removed validation mirroring detail |
| `remove-duplicate-command-logging.md` | Removed "shell expression expansion" implementation detail |

## Test plan
- [ ] Verify `npx changeset status` still reports all expected packages
- [ ] Review final changeset wording reads as a user-facing changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)