### PR TITLE
Show commit-aware sync logs only for isolated sandboxes

### DIFF
--- a/.changeset/commit-aware-sync-logs.md
+++ b/.changeset/commit-aware-sync-logs.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Show commit-aware sync logs only for isolated sandboxes. Displays "Syncing N commit(s) to host" when commits exist or "No commits to sync out" when there are none, instead of the generic "Syncing changes to host" message. Bind-mount providers no longer show sync logs since sync-out only applies to isolated sandboxes.

--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -992,7 +992,7 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
             );
             commitMade = true;
             // Caller (lifecycle) is responsible for calling applyToHost
-            yield* info.applyToHost();
+            yield* info.applyToHost!();
           }),
         );
       }).pipe(Effect.provide(makeIsolatedLayer(hostDir))),

--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -992,7 +992,8 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
             );
             commitMade = true;
             // Caller (lifecycle) is responsible for calling applyToHost
-            yield* info.applyToHost!();
+            if (!info.applyToHost) throw new Error("applyToHost not provided for isolated sandbox");
+            yield* info.applyToHost();
           }),
         );
       }).pipe(Effect.provide(makeIsolatedLayer(hostDir))),

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -143,9 +143,8 @@ export interface SandboxInfo {
   readonly hostWorktreePath?: string;
   /** Absolute path to the worktree inside the sandbox, as reported by the provider. */
   readonly sandboxRepoPath: string;
-  /** Sync changes from the sandbox to the host worktree.
-   *  For isolated providers, runs syncOut. For bind-mount providers, this is a no-op. */
-  readonly applyToHost: () => Effect.Effect<void, SyncError>;
+  /** Sync changes from the sandbox to the host worktree (isolated providers only). */
+  readonly applyToHost?: () => Effect.Effect<void, SyncError>;
   /** The bind-mount sandbox handle, available when the provider is a bind-mount provider. Used for session capture. */
   readonly bindMountHandle?: BindMountSandboxHandle;
 }
@@ -447,7 +446,6 @@ export const WorktreeDockerSandboxFactory = {
                     makeEffect({
                       hostWorktreePath: hostRepoDir,
                       sandboxRepoPath: worktreePath,
-                      applyToHost: () => Effect.void,
                       bindMountHandle: handle as BindMountSandboxHandle,
                     }).pipe(Effect.provide(sandboxLayer)) as Effect.Effect<
                       A,
@@ -538,7 +536,6 @@ export const WorktreeDockerSandboxFactory = {
               makeEffect({
                 hostWorktreePath: worktreeInfo.path,
                 sandboxRepoPath: worktreePath,
-                applyToHost: () => Effect.void,
                 bindMountHandle: handle as BindMountSandboxHandle,
               }).pipe(Effect.provide(sandboxLayer)) as Effect.Effect<
                 A,

--- a/src/SandboxLifecycle.test.ts
+++ b/src/SandboxLifecycle.test.ts
@@ -819,7 +819,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     ).rejects.toThrow("sync failed");
   });
 
-  it("logs 'Syncing changes to host' taskLog when applyToHost is provided", async () => {
+  it("logs 'No commits to sync out' when applyToHost is provided but no commits", async () => {
     const { hostDir, worktreeDir, layer } = await setupWorktree();
     const displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]);
     const displayLayer = SilentDisplay.layer(displayRef);
@@ -840,12 +840,44 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     );
 
     const syncLog = entries.find(
-      (e) => e._tag === "taskLog" && e.title === "Syncing changes to host",
+      (e) => e._tag === "taskLog" && e.title === "No commits to sync out",
     );
     expect(syncLog).toBeDefined();
   });
 
-  it("does not log 'Syncing changes to host' when applyToHost is not provided", async () => {
+  it("logs 'Syncing N commits to host' when applyToHost is provided with commits", async () => {
+    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]);
+    const displayLayer = SilentDisplay.layer(displayRef);
+
+    const entries = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* withSandboxLifecycle(
+          {
+            hostRepoDir: hostDir,
+            sandboxRepoDir: worktreeDir,
+            branch: "sandcastle/test",
+            applyToHost: () => Effect.void,
+          },
+          (ctx) =>
+            Effect.gen(function* () {
+              yield* ctx.sandbox.exec(
+                'sh -c "echo new > sync-file.txt && git add sync-file.txt && git commit -m \\"sync commit\\""',
+                { cwd: ctx.sandboxRepoDir },
+              );
+            }),
+        );
+        return yield* Ref.get(displayRef);
+      }).pipe(Effect.provide(Layer.merge(layer, displayLayer))),
+    );
+
+    const syncLog = entries.find(
+      (e) => e._tag === "taskLog" && e.title === "Syncing 1 commit to host",
+    );
+    expect(syncLog).toBeDefined();
+  });
+
+  it("does not log sync taskLog when applyToHost is not provided", async () => {
     const { hostDir, worktreeDir, layer } = await setupWorktree();
     const displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]);
     const displayLayer = SilentDisplay.layer(displayRef);
@@ -865,7 +897,10 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     );
 
     const syncLog = entries.find(
-      (e) => e._tag === "taskLog" && e.title === "Syncing changes to host",
+      (e) =>
+        e._tag === "taskLog" &&
+        (e.title === "No commits to sync out" ||
+          e.title.startsWith("Syncing")),
     );
     expect(syncLog).toBeUndefined();
   });

--- a/src/SandboxLifecycle.ts
+++ b/src/SandboxLifecycle.ts
@@ -332,10 +332,22 @@ export const withSandboxLifecycle = <A>(
     // Run the caller's work
     const result = yield* work({ sandbox, sandboxRepoDir, baseHead });
 
-    // Sync changes from sandbox to host worktree (no-op for bind-mount providers)
+    // Sync changes from sandbox to host worktree (isolated sandbox only)
     if (options.applyToHost) {
-      yield* display.taskLog("Syncing changes to host", () =>
-        options.applyToHost!(),
+      const countResult = yield* sandbox.exec(
+        `git rev-list "${baseHead}..HEAD" --count`,
+        { cwd: sandboxRepoDir },
+      );
+      const commitCount =
+        countResult.exitCode === 0
+          ? parseInt(countResult.stdout.trim(), 10)
+          : 0;
+
+      yield* display.taskLog(
+        commitCount > 0
+          ? `Syncing ${commitCount} commit${commitCount !== 1 ? "s" : ""} to host`
+          : "No commits to sync out",
+        () => options.applyToHost!(),
       );
     }
 


### PR DESCRIPTION
## Summary
- Replace generic "Syncing changes to host" taskLog with commit-count-aware messages: "Syncing N commit(s) to host" when commits exist, "No commits to sync out" when there are none
- Remove no-op `applyToHost` from bind-mount providers — sync-out only applies to isolated sandboxes
- Make `applyToHost` optional in `SandboxInfo` interface to reflect this

## Test plan
- [x] Existing test updated: verifies "No commits to sync out" taskLog when applyToHost provided with zero commits
- [x] New test: verifies "Syncing 1 commit to host" taskLog when commits exist
- [x] Existing test updated: verifies no sync taskLog when applyToHost is not provided
- [x] All 143 tests pass (SandboxLifecycle: 36, Orchestrator: 70, SandboxFactory: 37)
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)