### PR TITLE
Fix dirty-worktree test to match ADR 0003

### DIFF
--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -109,7 +109,7 @@ const listWorktrees = (
  *
  * When `branch` collides with an existing managed worktree:
  * - Clean → reuses the existing worktree.
- * - Dirty (uncommitted changes) → throws with actionable suggestions.
+ * - Dirty (uncommitted changes) → reuses with a console warning (ADR 0003).
  *
  * Collisions with the main working tree or external worktrees always throw.
  */

--- a/src/createSandbox.test.ts
+++ b/src/createSandbox.test.ts
@@ -344,7 +344,7 @@ describe("createSandbox", () => {
     }
   });
 
-  it("errors when branch worktree is dirty", async () => {
+  it("reuses dirty worktree with warning (ADR 0003)", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandbox-test-"));
     await initRepo(hostDir);
     await commitFile(hostDir, "init.txt", "init", "initial commit");
@@ -362,17 +362,21 @@ describe("createSandbox", () => {
     await writeFile(join(sandbox1.worktreePath, "dirty.txt"), "uncommitted");
 
     try {
-      await expect(
-        createSandbox({
-          branch: "dirty-collision",
-          sandbox: testSandbox,
-          cwd: hostDir,
-          _test: {
-            buildSandboxLayer: (sandboxDir) =>
-              makeLocalSandboxLayer(sandboxDir),
-          },
-        }),
-      ).rejects.toThrow(/uncommitted changes/);
+      const sandbox2 = await createSandbox({
+        branch: "dirty-collision",
+        sandbox: testSandbox,
+        cwd: hostDir,
+        _test: {
+          buildSandboxLayer: (sandboxDir) =>
+            makeLocalSandboxLayer(sandboxDir),
+        },
+      });
+
+      // Should reuse the same worktree path
+      expect(sandbox2.worktreePath).toBe(sandbox1.worktreePath);
+      expect(sandbox2.branch).toBe("dirty-collision");
+
+      await sandbox2.close();
     } finally {
       await rm(sandbox1.worktreePath, { recursive: true, force: true });
       await execAsync("git worktree prune", { cwd: hostDir });


### PR DESCRIPTION
## Summary
- Updated the `createSandbox` test "errors when branch worktree is dirty" to match ADR 0003's reuse-by-default behavior — dirty worktrees are now reused with a warning instead of throwing
- Fixed stale JSDoc in `WorktreeManager.create` that still said "throws with actionable suggestions" for dirty collisions

## Test plan
- [x] `createSandbox.test.ts` — all 32 tests pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)