### PR TITLE
Isolate test suite from host git config

### DIFF
--- a/src/globalSetup.ts
+++ b/src/globalSetup.ts
@@ -1,0 +1,19 @@
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tmpDir: string;
+
+export function setup() {
+  tmpDir = mkdtempSync(join(tmpdir(), "test-gitconfig-global-"));
+  const globalConfigPath = join(tmpDir, ".gitconfig");
+  writeFileSync(globalConfigPath, "");
+  process.env.GIT_CONFIG_GLOBAL = globalConfigPath;
+}
+
+export function teardown() {
+  delete process.env.GIT_CONFIG_GLOBAL;
+  try {
+    rmSync(tmpDir, { recursive: true });
+  } catch {}
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
+    globalSetup: ["src/globalSetup.ts"],
   },
 });


### PR DESCRIPTION
## Summary

- Adds a vitest `globalSetup` that sets `GIT_CONFIG_GLOBAL` to a temp file before any tests run, preventing `git config --global` writes from leaking into the developer's real `~/.gitconfig`
- This is a process-level safety net on top of the existing per-sandbox isolation in `makeLocalSandboxLayer` (`testSandbox.ts`)
- Fixes stale `safe.directory` entries and identity overwrites (`user.name "Test"`) accumulating in the host's global git config during test runs

## Test plan

- [x] All 35 `SandboxLifecycle.test.ts` tests pass
- [x] Full suite passes (failures are pre-existing/flaky, confirmed by running without this change)
- [x] Verified `globalSetup` teardown cleans up the temp file

🤖 Generated with [Claude Code](https://claude.com/claude-code)