### PR TITLE
Support baseBranch in branch strategy for worktree creation

### DIFF
--- a/.changeset/support-basebranch-in-branch-strategy.md
+++ b/.changeset/support-basebranch-in-branch-strategy.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Support `baseBranch` in named branch strategy for worktree creation

--- a/src/SandboxProvider.ts
+++ b/src/SandboxProvider.ts
@@ -245,6 +245,13 @@ export interface MergeToHeadBranchStrategy {
 export interface NamedBranchStrategy {
   readonly type: "branch";
   readonly branch: string;
+  /**
+   * Git ref to use as the starting point when creating a new branch.
+   * Only used when the branch doesn't already exist — ignored otherwise.
+   * Callers are responsible for ensuring the ref is current (e.g. `git fetch`).
+   * Defaults to `HEAD` when omitted.
+   */
+  readonly baseBranch?: string;
 }
 
 /** Branch strategy for bind-mount providers (all three variants). */

--- a/src/WorktreeManager.test.ts
+++ b/src/WorktreeManager.test.ts
@@ -243,6 +243,69 @@ describe("WorktreeManager.create", () => {
     await run(remove(path));
   });
 
+  it("creates a new branch from baseBranch when specified", async () => {
+    const repoDir = await setupRepo();
+
+    // Create a second commit on main so HEAD differs from the base
+    await commitFile(repoDir, "second.txt", "second", "second commit");
+
+    // Record the first commit's SHA (the one before "second commit")
+    const { stdout: baseSha } = await execAsync("git rev-parse HEAD~1", {
+      cwd: repoDir,
+    });
+
+    const { path, branch } = await run(
+      create(repoDir, {
+        branch: "feature/from-base",
+        baseBranch: baseSha.trim(),
+      }),
+    );
+
+    expect(branch).toBe("feature/from-base");
+    expect(await getBranch(path)).toBe("feature/from-base");
+
+    // The worktree should be at the base commit, not HEAD
+    const { stdout: worktreeHead } = await execAsync("git rev-parse HEAD", {
+      cwd: path,
+    });
+    expect(worktreeHead.trim()).toBe(baseSha.trim());
+
+    await run(remove(path));
+  });
+
+  it("ignores baseBranch when the branch already exists", async () => {
+    const repoDir = await setupRepo();
+
+    // Create a branch with a known commit
+    await execAsync("git checkout -b existing-branch", { cwd: repoDir });
+    await commitFile(repoDir, "on-branch.txt", "x", "branch commit");
+    const { stdout: branchHead } = await execAsync("git rev-parse HEAD", {
+      cwd: repoDir,
+    });
+    await execAsync("git checkout main", { cwd: repoDir });
+
+    // Add another commit on main to use as baseBranch
+    await commitFile(repoDir, "main2.txt", "y", "main commit 2");
+    const { stdout: mainHead } = await execAsync("git rev-parse HEAD", {
+      cwd: repoDir,
+    });
+
+    // baseBranch should be ignored since existing-branch already exists
+    const { path } = await run(
+      create(repoDir, {
+        branch: "existing-branch",
+        baseBranch: mainHead.trim(),
+      }),
+    );
+
+    const { stdout: worktreeHead } = await execAsync("git rev-parse HEAD", {
+      cwd: path,
+    });
+    expect(worktreeHead.trim()).toBe(branchHead.trim());
+
+    await run(remove(path));
+  });
+
   it("reuses worktree with unpushed commits (not considered dirty)", async () => {
     const repoDir = await setupRepo();
     await execAsync("git checkout -b my-branch", { cwd: repoDir });

--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -117,6 +117,7 @@ export const create = (
   repoDir: string,
   opts?: {
     branch?: string;
+    baseBranch?: string;
     name?: string;
   },
 ): Effect.Effect<
@@ -184,7 +185,7 @@ export const create = (
         Effect.catchAll((e) => {
           if (e.message.includes("invalid reference")) {
             return execGit(
-              ["worktree", "add", "-b", branch, worktreePath, "HEAD"],
+              ["worktree", "add", "-b", branch, worktreePath, opts?.baseBranch ?? "HEAD"],
               repoDir,
             );
           }

--- a/src/createWorktree.test.ts
+++ b/src/createWorktree.test.ts
@@ -82,6 +82,41 @@ describe("createWorktree", () => {
     }
   });
 
+  it("creates a worktree with baseBranch forking from specified ref", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "ws-test-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "init.txt", "init", "initial commit");
+
+    const { stdout: baseSha } = await execAsync("git rev-parse HEAD", {
+      cwd: hostDir,
+    });
+
+    // Add a second commit so HEAD moves forward
+    await commitFile(hostDir, "second.txt", "second", "second commit");
+
+    const ws = await createWorktree({
+      branchStrategy: {
+        type: "branch",
+        branch: "feature-from-base",
+        baseBranch: baseSha.trim(),
+      },
+      cwd: hostDir,
+    });
+
+    try {
+      expect(ws.branch).toBe("feature-from-base");
+
+      // The worktree should be at the base commit, not HEAD
+      const { stdout: worktreeHead } = await execAsync("git rev-parse HEAD", {
+        cwd: ws.worktreePath,
+      });
+      expect(worktreeHead.trim()).toBe(baseSha.trim());
+    } finally {
+      await ws.close();
+      await rm(hostDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects 'head' branch strategy at the type level", () => {
     const _options: CreateWorktreeOptions = {
       // @ts-expect-error - head strategy should be a compile-time error

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -206,12 +206,17 @@ export const createWorktree = async (
       ? options.branchStrategy.branch
       : undefined;
 
+  const baseBranch =
+    options.branchStrategy.type === "branch"
+      ? options.branchStrategy.baseBranch
+      : undefined;
+
   const { hostRepoDir, worktreeInfo } = await Effect.gen(function* () {
     const hostRepoDir = yield* resolveCwd(options.cwd);
     yield* WorktreeManager.pruneStale(hostRepoDir).pipe(
       Effect.catchAll(() => Effect.void),
     );
-    const info = yield* WorktreeManager.create(hostRepoDir, { branch });
+    const info = yield* WorktreeManager.create(hostRepoDir, { branch, baseBranch });
     if (options.copyToWorktree && options.copyToWorktree.length > 0) {
       yield* copyToWorktree(options.copyToWorktree, hostRepoDir, info.path);
     }


### PR DESCRIPTION
## Summary

- Adds optional `baseBranch` field to `NamedBranchStrategy`, allowing callers to specify the git starting point when creating a new branch worktree
- When `baseBranch` is set and the branch doesn't exist, `git worktree add -b <branch> <path> <baseBranch>` is used instead of forking from `HEAD`
- When omitted or when the branch already exists, behavior is unchanged

Closes #434

## Test plan

- [ ] New test: `WorktreeManager.create` — creates a new branch from `baseBranch` when specified
- [ ] New test: `WorktreeManager.create` — ignores `baseBranch` when the branch already exists
- [ ] New test: `createWorktree` — creates a worktree with `baseBranch` forking from specified ref
- [ ] All 64 existing tests continue to pass
- [ ] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)