### PR TITLE
Fix libicu symlink shim to work on arm64 hosts

### DIFF
--- a/.changeset/fix-dockerfile-arm64-libicu-multiarch.md
+++ b/.changeset/fix-dockerfile-arm64-libicu-multiarch.md
@@ -1,0 +1,7 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix Beads Dockerfile libicu symlink to use dynamic multiarch path
+
+Replace hardcoded `/usr/lib/x86_64-linux-gnu/` with `dpkg-architecture -qDEB_HOST_MULTIARCH` so the symlink loop works on both amd64 and arm64 hosts.

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -1118,6 +1118,12 @@ describe("InitService scaffold", () => {
         "corepack enable",
       );
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).not.toContain("gh");
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).not.toContain(
+        "x86_64-linux-gnu",
+      );
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(
+        "dpkg-architecture -qDEB_HOST_MULTIARCH",
+      );
     });
 
     it("getBacklogManager returns undefined for unknown manager", () => {
@@ -1607,6 +1613,8 @@ describe("InitService scaffold", () => {
       expect(dockerfile).toContain("corepack enable");
       expect(dockerfile).not.toContain("GitHub CLI");
       expect(dockerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
+      expect(dockerfile).not.toContain("x86_64-linux-gnu");
+      expect(dockerfile).toContain("dpkg-architecture -qDEB_HOST_MULTIARCH");
     });
 
     it("scaffold with beads + podman produces Containerfile with beads install", async () => {
@@ -1625,6 +1633,8 @@ describe("InitService scaffold", () => {
       expect(containerfile).toContain("libicu72");
       expect(containerfile).not.toContain("GitHub CLI");
       expect(containerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
+      expect(containerfile).not.toContain("x86_64-linux-gnu");
+      expect(containerfile).toContain("dpkg-architecture -qDEB_HOST_MULTIARCH");
     });
 
     it("scaffold with beads + pi agent produces Dockerfile with beads install and pi agent", async () => {

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -243,9 +243,11 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \\
 
 const BEADS_TOOLS = `# Install system dependencies for Beads
 RUN apt-get update && apt-get install -y \\
+  dpkg-dev \\
   libicu72 \\
   && rm -rf /var/lib/apt/lists/* \\
-  && for lib in /usr/lib/x86_64-linux-gnu/libicu*.so.72; do \\
+  && ARCH_DIR=$(dpkg-architecture -qDEB_HOST_MULTIARCH) \\
+  && for lib in /usr/lib/$ARCH_DIR/libicu*.so.72; do \\
        ln -s "$lib" "\${lib%.72}.74"; \\
      done
 


### PR DESCRIPTION
The BEADS_TOOLS Dockerfile snippet in InitService.ts (line 244-254) hardcodes `/usr/lib/x86_64-linux-gnu/` for the libicu symlink shim, which fails on arm64 (Apple Silicon). Replace with architecture-aware path detection using `dpkg-architecture -qDEB_HOST_MULTIARCH`.

Closes #425.

Closes #425