### PR TITLE
Surface Claude Code error text from stream-json stdout on non-zero exit

### DIFF
--- a/.changeset/prefer-resulttext-in-agent-error.md
+++ b/.changeset/prefer-resulttext-in-agent-error.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+When an agent exits with a non-zero exit code, prefer stderr in the error message but fall back to resultText when stderr is empty. Always include the exit code.

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -25,7 +25,7 @@ import {
 } from "./AgentProvider.js";
 import { Sandbox } from "./SandboxFactory.js";
 import type { DockerError, SandboxError } from "./errors.js";
-import { AgentIdleTimeoutError } from "./errors.js";
+import { AgentError, AgentIdleTimeoutError } from "./errors.js";
 import { SandboxFactory } from "./SandboxFactory.js";
 import { encodeProjectPath } from "./SessionStore.js";
 import { defaultSessionPathsLayer, sessionPathsLayer } from "./SessionPaths.js";
@@ -1402,6 +1402,171 @@ describe("Orchestrator error handling", () => {
     );
 
     expect(exit._tag).toBe("Failure");
+  });
+
+  it("uses resultText in error message when stderr is empty", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-err-resulttext-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
+      const fsLayer = makeLocalSandboxLayer(dir);
+      return Layer.succeed(Sandbox, {
+        exec: (command, options) => {
+          if (command.startsWith("claude ") && options?.onLine) {
+            const onLine = options.onLine;
+            // Emit a result line so resultText gets populated
+            onLine(
+              JSON.stringify({ type: "result", result: "agent output text" }),
+            );
+            return Effect.succeed({
+              stdout: "",
+              stderr: "",
+              exitCode: 1,
+            });
+          }
+          return Effect.flatMap(Sandbox, (real) =>
+            real.exec(command, options),
+          ).pipe(Effect.provide(fsLayer));
+        },
+        copyIn: (hostPath, sandboxPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyIn(hostPath, sandboxPath),
+          ).pipe(Effect.provide(fsLayer)),
+        copyFileOut: (sandboxPath, hostPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyFileOut(sandboxPath, hostPath),
+          ).pipe(Effect.provide(fsLayer)),
+      });
+    });
+
+    const exit = await Effect.runPromiseExit(
+      orchestrate({
+        provider: testProvider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: "do some work",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const err = Cause.squash(exit.cause);
+      expect(err).toBeInstanceOf(AgentError);
+      if (err instanceof AgentError) {
+        expect(err.message).toContain("agent output text");
+        expect(err.message).toContain("exited with code 1");
+      }
+    }
+  });
+
+  it("uses stderr in error message when stderr is non-empty", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-err-stderr-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
+      const fsLayer = makeLocalSandboxLayer(dir);
+      return Layer.succeed(Sandbox, {
+        exec: (command, options) => {
+          if (command.startsWith("claude ") && options?.onLine) {
+            const onLine = options.onLine;
+            onLine(
+              JSON.stringify({ type: "result", result: "agent output text" }),
+            );
+            return Effect.succeed({
+              stdout: "",
+              stderr: "fatal error from agent",
+              exitCode: 1,
+            });
+          }
+          return Effect.flatMap(Sandbox, (real) =>
+            real.exec(command, options),
+          ).pipe(Effect.provide(fsLayer));
+        },
+        copyIn: (hostPath, sandboxPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyIn(hostPath, sandboxPath),
+          ).pipe(Effect.provide(fsLayer)),
+        copyFileOut: (sandboxPath, hostPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyFileOut(sandboxPath, hostPath),
+          ).pipe(Effect.provide(fsLayer)),
+      });
+    });
+
+    const exit = await Effect.runPromiseExit(
+      orchestrate({
+        provider: testProvider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: "do some work",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const err = Cause.squash(exit.cause);
+      expect(err).toBeInstanceOf(AgentError);
+      if (err instanceof AgentError) {
+        expect(err.message).toContain("fatal error from agent");
+        expect(err.message).toContain("exited with code 1");
+      }
+    }
+  });
+
+  it("includes only exit code in error message when both stderr and resultText are empty", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-err-empty-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
+      const fsLayer = makeLocalSandboxLayer(dir);
+      return Layer.succeed(Sandbox, {
+        exec: (command, options) => {
+          if (command.startsWith("claude ") && options?.onLine) {
+            return Effect.succeed({
+              stdout: "",
+              stderr: "",
+              exitCode: 2,
+            });
+          }
+          return Effect.flatMap(Sandbox, (real) =>
+            real.exec(command, options),
+          ).pipe(Effect.provide(fsLayer));
+        },
+        copyIn: (hostPath, sandboxPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyIn(hostPath, sandboxPath),
+          ).pipe(Effect.provide(fsLayer)),
+        copyFileOut: (sandboxPath, hostPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyFileOut(sandboxPath, hostPath),
+          ).pipe(Effect.provide(fsLayer)),
+      });
+    });
+
+    const exit = await Effect.runPromiseExit(
+      orchestrate({
+        provider: testProvider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: "do some work",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const err = Cause.squash(exit.cause);
+      expect(err).toBeInstanceOf(AgentError);
+      if (err instanceof AgentError) {
+        expect(err.message).toContain("exited with code 2");
+        expect(err.message).not.toContain("\n");
+      }
+    }
   });
 });
 

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -119,11 +119,11 @@ const invokeAgent = (
       });
 
       if (execResult.exitCode !== 0) {
-        return yield* Effect.fail(
-          new AgentError({
-            message: `${provider.name} exited with code ${execResult.exitCode}:\n${execResult.stderr}`,
-          }),
-        );
+        const detail = execResult.stderr || resultText;
+        const message = detail
+          ? `${provider.name} exited with code ${execResult.exitCode}:\n${detail}`
+          : `${provider.name} exited with code ${execResult.exitCode}`;
+        return yield* Effect.fail(new AgentError({ message }));
       }
 
       return { result: resultText || execResult.stdout, sessionId };


### PR DESCRIPTION
When Claude Code exits non-zero, the error message (e.g. rate limit, auth failure) is on stdout in stream-json format, not stderr. The `invokeAgent` function in Orchestrator.ts already captures `resultText` from parsed stream events but discards it on the error path. Fall back to `resultText` when `stderr` is empty.

Closes #419.

Closes #419