### PR TITLE
Support tilde expansion in sandboxPath for custom mounts

### DIFF
--- a/.changeset/sandbox-path-tilde-expansion.md
+++ b/.changeset/sandbox-path-tilde-expansion.md
@@ -1,0 +1,7 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Support tilde expansion in `sandboxPath` for Docker and Podman mount configs.
+
+Users can now write `sandboxPath: "~/.npm"` and it expands to `/home/agent/.npm` inside the sandbox. The expansion uses the provider's declared `sandboxHomedir` (`"/home/agent"` for Docker and Podman). Using `~` in `sandboxPath` with a provider that has no `sandboxHomedir` throws a descriptive error at mount resolution time.

--- a/src/MountConfig.ts
+++ b/src/MountConfig.ts
@@ -16,9 +16,8 @@ export interface MountConfig {
   /**
    * Path inside the sandbox container. Supports:
    * - Absolute paths (`/mnt/data`)
+   * - Tilde-expanded paths (`~/.npm` → `/home/agent/.npm`) — expanded using the provider's sandbox home directory
    * - Relative paths (`data` or `./data`) — resolved from the worktree directory (`/home/agent/workspace`)
-   *
-   * Tilde is NOT expanded.
    */
   readonly sandboxPath: string;
   /** Mount as read-only. Defaults to `false`. */

--- a/src/SandboxProvider.ts
+++ b/src/SandboxProvider.ts
@@ -85,6 +85,12 @@ export interface BindMountSandboxProviderConfig {
   readonly name: string;
   /** Environment variables injected by this provider. Merged at launch time. */
   readonly env?: Record<string, string>;
+  /**
+   * Absolute path to the home directory inside the sandbox (e.g. `"/home/agent"`).
+   * Used to expand `~` in user-provided `sandboxPath` mount configs.
+   * Set to `undefined` for providers that do not have a fixed home directory.
+   */
+  readonly sandboxHomedir?: string;
   /** Create a sandbox handle from the given options. */
   readonly create: (
     options: BindMountCreateOptions,
@@ -160,6 +166,11 @@ export interface BindMountSandboxProvider {
   readonly name: string;
   /** Environment variables injected by this provider. */
   readonly env: Record<string, string>;
+  /**
+   * Absolute path to the home directory inside the sandbox (e.g. `"/home/agent"`).
+   * `undefined` when the provider does not declare a sandbox home directory.
+   */
+  readonly sandboxHomedir: string | undefined;
   /** @internal Create a sandbox handle. */
   readonly create: (
     options: BindMountCreateOptions,
@@ -305,6 +316,7 @@ export const createBindMountSandboxProvider = (
   tag: "bind-mount",
   name: config.name,
   env: config.env ?? {},
+  sandboxHomedir: config.sandboxHomedir,
   create: config.create,
 });
 

--- a/src/mountUtils.test.ts
+++ b/src/mountUtils.test.ts
@@ -95,6 +95,28 @@ describe("resolveSandboxPath", () => {
   it("resolves relative paths against SANDBOX_REPO_DIR", () => {
     expect(resolveSandboxPath("data")).toBe(`${SANDBOX_REPO_DIR}/data`);
   });
+
+  it("expands ~ to sandboxHomedir when provided", () => {
+    expect(resolveSandboxPath("~", "/home/agent")).toBe("/home/agent");
+  });
+
+  it("expands ~/.npm to sandboxHomedir/.npm", () => {
+    expect(resolveSandboxPath("~/.npm", "/home/agent")).toBe(
+      "/home/agent/.npm",
+    );
+  });
+
+  it("throws when ~ is used but sandboxHomedir is undefined", () => {
+    expect(() => resolveSandboxPath("~/.npm")).toThrow(
+      /sandboxPath.*tilde.*sandboxHomedir/i,
+    );
+  });
+
+  it("throws when ~ alone is used but sandboxHomedir is undefined", () => {
+    expect(() => resolveSandboxPath("~")).toThrow(
+      /sandboxPath.*tilde.*sandboxHomedir/i,
+    );
+  });
 });
 
 describe("resolveUserMounts", () => {
@@ -120,6 +142,38 @@ describe("resolveUserMounts", () => {
       { hostPath: "/existing/path", sandboxPath: "/mnt/data", readonly: true },
     ]);
     expect(result[0]!.readonly).toBe(true);
+  });
+
+  it("expands ~ in sandboxPath when sandboxHomedir is provided", () => {
+    const result = resolveUserMounts(
+      [{ hostPath: "/existing/path", sandboxPath: "~/.npm" }],
+      "/home/agent",
+    );
+    expect(result[0]!.sandboxPath).toBe("/home/agent/.npm");
+  });
+
+  it("expands ~ alone in sandboxPath when sandboxHomedir is provided", () => {
+    const result = resolveUserMounts(
+      [{ hostPath: "/existing/path", sandboxPath: "~" }],
+      "/home/agent",
+    );
+    expect(result[0]!.sandboxPath).toBe("/home/agent");
+  });
+
+  it("throws when ~ used in sandboxPath but sandboxHomedir is undefined", () => {
+    expect(() =>
+      resolveUserMounts([
+        { hostPath: "/existing/path", sandboxPath: "~/.npm" },
+      ]),
+    ).toThrow(/sandboxPath.*tilde.*sandboxHomedir/i);
+  });
+
+  it("resolves hostPath tilde via os.homedir() regardless of sandboxHomedir", () => {
+    const result = resolveUserMounts(
+      [{ hostPath: "~/data", sandboxPath: "/mnt/data" }],
+      undefined,
+    );
+    expect(result[0]!.hostPath).toBe("/home/testuser/data");
   });
 });
 
@@ -281,9 +335,7 @@ describe("parseGitdirPath", () => {
   });
 
   it("parses Windows gitdir path with backslashes", () => {
-    const result = parseGitdirPath(
-      "C:\\Users\\project\\.git\\worktrees\\abc",
-    );
+    const result = parseGitdirPath("C:\\Users\\project\\.git\\worktrees\\abc");
     expect(result.parentGitDir).toBe("C:/Users/project/.git");
     expect(result.worktreeName).toBe("abc");
   });
@@ -297,9 +349,7 @@ describe("parseGitdirPath", () => {
   });
 
   it("handles trailing slash", () => {
-    const result = parseGitdirPath(
-      "/home/user/repo/.git/worktrees/my-wt/",
-    );
+    const result = parseGitdirPath("/home/user/repo/.git/worktrees/my-wt/");
     expect(result.parentGitDir).toBe("/home/user/repo/.git");
     expect(result.worktreeName).toBe("my-wt");
   });
@@ -401,9 +451,7 @@ describe("patchGitMountsForWindows", () => {
         mounts,
         "/tmp/test-worktree",
         SANDBOX_REPO_DIR,
-        makeReadFile(
-          "gitdir: C:/Users/parent-repo/.git/worktrees/my-branch\n",
-        ),
+        makeReadFile("gitdir: C:/Users/parent-repo/.git/worktrees/my-branch\n"),
         makeStatFile("file"),
         "win32",
       );

--- a/src/mountUtils.ts
+++ b/src/mountUtils.ts
@@ -36,13 +36,13 @@ export const defaultImageName = (repoDir: string): string => {
 };
 
 /**
- * Expand tilde (`~`) to the user's home directory.
+ * Expand tilde (`~`) to the given home directory (or `os.homedir()` if omitted).
  * Handles both `~/path` (POSIX) and `~\path` (Windows).
  */
-export const expandTilde = (p: string): string => {
-  if (p === "~") return homedir();
-  if (p.startsWith("~/") || p.startsWith("~\\"))
-    return homedir() + "/" + p.slice(2);
+export const expandTilde = (p: string, homeDirPath?: string): string => {
+  const home = homeDirPath ?? homedir();
+  if (p === "~") return home;
+  if (p.startsWith("~/") || p.startsWith("~\\")) return home + "/" + p.slice(2);
   return p;
 };
 
@@ -55,19 +55,38 @@ export const resolveHostPath = (hostPath: string): string => {
 };
 
 /**
- * Resolve a sandbox path: relative paths are resolved from `SANDBOX_REPO_DIR`.
+ * Resolve a sandbox path: expands tilde using `sandboxHomedir`, then resolves
+ * relative paths from `SANDBOX_REPO_DIR`.
+ *
+ * Throws if `sandboxPath` starts with `~` but `sandboxHomedir` is `undefined`.
  */
-export const resolveSandboxPath = (sandboxPath: string): string =>
-  isAbsolute(sandboxPath)
-    ? sandboxPath
-    : resolve(SANDBOX_REPO_DIR, sandboxPath);
+export const resolveSandboxPath = (
+  sandboxPath: string,
+  sandboxHomedir?: string,
+): string => {
+  const hasTilde =
+    sandboxPath === "~" ||
+    sandboxPath.startsWith("~/") ||
+    sandboxPath.startsWith("~\\");
+  if (hasTilde && sandboxHomedir === undefined) {
+    throw new Error(
+      `sandboxPath "${sandboxPath}" contains a tilde but the provider has no sandboxHomedir set`,
+    );
+  }
+  const expanded = hasTilde
+    ? expandTilde(sandboxPath, sandboxHomedir)
+    : sandboxPath;
+  return isAbsolute(expanded) ? expanded : resolve(SANDBOX_REPO_DIR, expanded);
+};
 
 /**
  * Resolve and validate user-provided mount configurations.
  * Throws if a hostPath does not exist on the filesystem.
+ * Throws if a sandboxPath uses tilde but `sandboxHomedir` is `undefined`.
  */
 export const resolveUserMounts = (
   mounts: readonly MountConfig[],
+  sandboxHomedir?: string,
 ): Array<{ hostPath: string; sandboxPath: string; readonly?: boolean }> =>
   mounts.map((m) => {
     const resolvedHostPath = resolveHostPath(m.hostPath);
@@ -83,7 +102,7 @@ export const resolveUserMounts = (
 
     return {
       hostPath: resolvedHostPath,
-      sandboxPath: resolveSandboxPath(m.sandboxPath),
+      sandboxPath: resolveSandboxPath(m.sandboxPath, sandboxHomedir),
       ...(m.readonly ? { readonly: true } : {}),
     };
   });

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -58,11 +58,15 @@ export interface DockerOptions {
  */
 export const docker = (options?: DockerOptions): SandboxProvider => {
   const configuredImageName = options?.imageName;
-  const userMounts = options?.mounts ? resolveUserMounts(options.mounts) : [];
+  const sandboxHomedir = "/home/agent";
+  const userMounts = options?.mounts
+    ? resolveUserMounts(options.mounts, sandboxHomedir)
+    : [];
 
   return createBindMountSandboxProvider({
     name: "docker",
     env: options?.env,
+    sandboxHomedir,
     create: async (
       createOptions: BindMountCreateOptions,
     ): Promise<BindMountSandboxHandle> => {

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -93,11 +93,15 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
   const userns = options?.userns ?? "keep-id";
   const containerUid = options?.containerUid ?? 1000;
   const containerGid = options?.containerGid ?? 1000;
-  const userMounts = options?.mounts ? resolveUserMounts(options.mounts) : [];
+  const sandboxHomedir = "/home/agent";
+  const userMounts = options?.mounts
+    ? resolveUserMounts(options.mounts, sandboxHomedir)
+    : [];
 
   return createBindMountSandboxProvider({
     name: "podman",
     env: options?.env,
+    sandboxHomedir,
     create: async (
       createOptions: BindMountCreateOptions,
     ): Promise<BindMountSandboxHandle> => {


### PR DESCRIPTION
Add `sandboxHomedir` property to sandbox provider interfaces so that `~` in `sandboxPath` mount configs is expanded to the sandbox's home directory. Consolidate the duplicated `expandTilde` into a shared utility parameterized by home directory. Error if `~` is used on a provider with no `sandboxHomedir`.

Closes #336.

Closes #336