### PR TITLE
Fix worktree config.lock race condition

### DIFF
--- a/.changeset/fix-worktree-config-lock-race.md
+++ b/.changeset/fix-worktree-config-lock-race.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix transient worktree creation failure when `branch.autoSetupMerge` or `push.autoSetupRemote` is enabled globally

--- a/src/WorktreeManager.test.ts
+++ b/src/WorktreeManager.test.ts
@@ -331,6 +331,46 @@ describe("WorktreeManager.create", () => {
     const err = await runFail(create(repoDir, { branch: "main" }));
     expect(err.message).toMatch(/already checked out/i);
   });
+
+  it("does not write upstream tracking config even when autoSetupMerge is enabled", async () => {
+    const repoDir = await setupRepo();
+
+    // Enable the config that triggers .git/config writes during branch creation
+    await execAsync("git config branch.autoSetupMerge always", { cwd: repoDir });
+
+    const { path, branch } = await run(
+      create(repoDir, { branch: "sandcastle/no-tracking-test" }),
+    );
+
+    // If -c branch.autoSetupMerge=false is working, the new branch should
+    // have no upstream tracking config (no branch.<name>.remote or .merge)
+    const { stdout: trackingConfig } = await execAsync(
+      `git config --get-regexp "branch\\.sandcastle/no-tracking-test\\." || true`,
+      { cwd: repoDir },
+    );
+    expect(trackingConfig.trim()).toBe("");
+
+    await run(remove(path));
+  });
+
+  it("does not write upstream tracking config for temp branches when autoSetupMerge is enabled", async () => {
+    const repoDir = await setupRepo();
+
+    // Enable the config that triggers .git/config writes during branch creation
+    await execAsync("git config branch.autoSetupMerge always", { cwd: repoDir });
+
+    const { path, branch } = await run(create(repoDir));
+
+    // The temp branch should also have no upstream tracking config
+    const escapedBranch = branch.replace(/\//g, "\\/").replace(/\./g, "\\.");
+    const { stdout: trackingConfig } = await execAsync(
+      `git config --get-regexp "branch\\.${escapedBranch}\\." || true`,
+      { cwd: repoDir },
+    );
+    expect(trackingConfig.trim()).toBe("");
+
+    await run(remove(path));
+  });
 });
 
 describe("WorktreeManager.remove", () => {

--- a/src/WorktreeManager.test.ts
+++ b/src/WorktreeManager.test.ts
@@ -336,7 +336,9 @@ describe("WorktreeManager.create", () => {
     const repoDir = await setupRepo();
 
     // Enable the config that triggers .git/config writes during branch creation
-    await execAsync("git config branch.autoSetupMerge always", { cwd: repoDir });
+    await execAsync("git config branch.autoSetupMerge always", {
+      cwd: repoDir,
+    });
 
     const { path, branch } = await run(
       create(repoDir, { branch: "sandcastle/no-tracking-test" }),
@@ -357,7 +359,9 @@ describe("WorktreeManager.create", () => {
     const repoDir = await setupRepo();
 
     // Enable the config that triggers .git/config writes during branch creation
-    await execAsync("git config branch.autoSetupMerge always", { cwd: repoDir });
+    await execAsync("git config branch.autoSetupMerge always", {
+      cwd: repoDir,
+    });
 
     const { path, branch } = await run(create(repoDir));
 

--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -6,6 +6,19 @@ import { WorktreeError, WorktreeTimeoutError, withTimeout } from "./errors.js";
 
 const WORKTREE_TIMEOUT_MS = 30_000;
 
+/**
+ * Git global flags that prevent `git worktree add -b` from writing upstream
+ * tracking config to `.git/config`. Without these, a user's global
+ * `branch.autoSetupMerge` or `push.autoSetupRemote` can cause a config write
+ * that races with other processes holding `.git/config.lock`.
+ */
+const NO_CONFIG_LOCK_FLAGS = [
+  "-c",
+  "branch.autoSetupMerge=false",
+  "-c",
+  "push.autoSetupRemote=false",
+];
+
 /** Format a timestamp as YYYYMMDD-HHMMSS */
 const formatTimestamp = (date: Date): string => {
   const pad = (n: number) => String(n).padStart(2, "0");
@@ -181,11 +194,11 @@ export const create = (
           }),
         );
       }
-      yield* execGit(["worktree", "add", worktreePath, branch], repoDir).pipe(
+      yield* execGit([...NO_CONFIG_LOCK_FLAGS, "worktree", "add", worktreePath, branch], repoDir).pipe(
         Effect.catchAll((e) => {
           if (e.message.includes("invalid reference")) {
             return execGit(
-              ["worktree", "add", "-b", branch, worktreePath, opts?.baseBranch ?? "HEAD"],
+              [...NO_CONFIG_LOCK_FLAGS, "worktree", "add", "-b", branch, worktreePath, opts?.baseBranch ?? "HEAD"],
               repoDir,
             );
           }
@@ -194,7 +207,7 @@ export const create = (
       );
     } else {
       yield* execGit(
-        ["worktree", "add", "-b", branch, worktreePath, "HEAD"],
+        [...NO_CONFIG_LOCK_FLAGS, "worktree", "add", "-b", branch, worktreePath, "HEAD"],
         repoDir,
       ).pipe(
         Effect.catchAll((e) => {

--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -194,11 +194,22 @@ export const create = (
           }),
         );
       }
-      yield* execGit([...NO_CONFIG_LOCK_FLAGS, "worktree", "add", worktreePath, branch], repoDir).pipe(
+      yield* execGit(
+        [...NO_CONFIG_LOCK_FLAGS, "worktree", "add", worktreePath, branch],
+        repoDir,
+      ).pipe(
         Effect.catchAll((e) => {
           if (e.message.includes("invalid reference")) {
             return execGit(
-              [...NO_CONFIG_LOCK_FLAGS, "worktree", "add", "-b", branch, worktreePath, opts?.baseBranch ?? "HEAD"],
+              [
+                ...NO_CONFIG_LOCK_FLAGS,
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                worktreePath,
+                opts?.baseBranch ?? "HEAD",
+              ],
               repoDir,
             );
           }
@@ -207,7 +218,15 @@ export const create = (
       );
     } else {
       yield* execGit(
-        [...NO_CONFIG_LOCK_FLAGS, "worktree", "add", "-b", branch, worktreePath, "HEAD"],
+        [
+          ...NO_CONFIG_LOCK_FLAGS,
+          "worktree",
+          "add",
+          "-b",
+          branch,
+          worktreePath,
+          "HEAD",
+        ],
         repoDir,
       ).pipe(
         Effect.catchAll((e) => {


### PR DESCRIPTION
## Summary
- Pass `-c branch.autoSetupMerge=false -c push.autoSetupRemote=false` as git global flags to all three `git worktree add` invocations in `WorktreeManager.ts`
- Prevents git from writing upstream tracking config to `.git/config`, eliminating the transient failure when another process holds `.git/config.lock`
- Adds two tests verifying no tracking config is written when `branch.autoSetupMerge=always` is enabled

Closes #454

## Test plan
- [x] `npm run typecheck` passes
- [x] All 34 WorktreeManager tests pass, including 2 new tests
- [x] New test: named branch with `autoSetupMerge=always` produces no tracking config
- [x] New test: temp branch with `autoSetupMerge=always` produces no tracking config

🤖 Generated with [Claude Code](https://claude.com/claude-code)