### PR TITLE
Fix three bugs in init template prompts and orchestration

### DIFF
--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -1421,6 +1421,18 @@ describe("InitService scaffold", () => {
       expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
     });
 
+    it("parallel-planner implement-prompt does not contain close-issue instruction", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, { templateName: "parallel-planner" });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "implement-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).not.toContain("close the issue when done");
+      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+    });
+
     it("parallel-planner implement-prompt uses backlog-agnostic language", async () => {
       const dir = await makeDir();
       await runScaffold(dir, {
@@ -1484,6 +1496,20 @@ describe("InitService scaffold", () => {
       expect(main).not.toContain("number: number");
       expect(main).not.toContain("ISSUE_NUMBER");
       expect(main).not.toContain("`  #${");
+    });
+
+    it("parallel-planner-with-review implement-prompt does not contain close-issue instruction", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner-with-review",
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "implement-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).not.toContain("close the issue when done");
+      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
     });
 
     it("parallel-planner-with-review implement-prompt uses TASK_ID placeholder", async () => {

--- a/src/templates/parallel-planner-with-review/implement-prompt.md
+++ b/src/templates/parallel-planner-with-review/implement-prompt.md
@@ -6,7 +6,7 @@ Pull in the issue using `{{VIEW_TASK_COMMAND}}`. If it has a parent PRD, pull th
 
 Only work on the issue specified.
 
-Work on branch {{BRANCH}}. Make commits, run tests, and close the issue when done using `{{CLOSE_TASK_COMMAND}}`.
+Work on branch {{BRANCH}}. Make commits and run tests.
 
 # CONTEXT
 

--- a/src/templates/parallel-planner/implement-prompt.md
+++ b/src/templates/parallel-planner/implement-prompt.md
@@ -6,7 +6,7 @@ Pull in the issue using `{{VIEW_TASK_COMMAND}}`. If it has a parent PRD, pull th
 
 Only work on the issue specified.
 
-Work on branch {{BRANCH}}. Make commits, run tests, and close the issue when done using `{{CLOSE_TASK_COMMAND}}`.
+Work on branch {{BRANCH}}. Make commits and run tests.
 
 # CONTEXT
 


### PR DESCRIPTION
Fixes three issues in init template files:

- **#442**: Remove contradictory "close the issue" instruction from `implement-prompt.md` (parallel-planner and parallel-planner-with-review). Line 9 tells the agent to close the issue; line 56 says not to. The merge phase handles closing, so line 9 is the stray one.
- **#443**: Replace hardcoded `main` in `review-prompt.md` git diff/log commands (sequential-reviewer and parallel-planner-with-review) with `{{SOURCE_BRANCH}}`, the built-in prompt argument that resolves to the actual base branch.
- **#445**: Return the reviewer's result (not the implementer's) from the Phase 2 map callback in `parallel-planner-with-review/main.mts`, so reviewer-added commits are visible to the merge phase.

Closes #442, #443, #445.

Closes #443
Closes #445