### PR TITLE
Investigate and surface error text from Pi, Codex, and OpenCode agents

### DIFF
--- a/.changeset/agent-error-stdout-fallback.md
+++ b/.changeset/agent-error-stdout-fallback.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fall back to resultText then tail of stdout when stderr is empty on non-zero agent exit, so providers like OpenCode surface error details in `AgentError`

--- a/.changeset/codex-error-event-parsing.md
+++ b/.changeset/codex-error-event-parsing.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Parse Codex error events in parseCodexStreamLine so error details from stdout are surfaced when stderr is empty

--- a/.changeset/pi-error-event-parsing.md
+++ b/.changeset/pi-error-event-parsing.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Parse Pi agent error events (`agent_error`, `error`) from stdout JSON stream so error details surface in `AgentError` when stderr is empty

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -632,6 +632,50 @@ describe("codex factory", () => {
     );
   });
 
+  // --- error event parsing tests ---
+
+  it("parseStreamLine captures error event with nested error object as result", () => {
+    const provider = codex("gpt-5.4-mini");
+    const line = JSON.stringify({
+      type: "error",
+      error: { type: "server_error", message: "Internal server error" },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "result", result: "Internal server error" },
+    ]);
+  });
+
+  it("parseStreamLine captures error event with string error as result", () => {
+    const provider = codex("gpt-5.4-mini");
+    const line = JSON.stringify({
+      type: "error",
+      error: "Authentication failed: invalid API key",
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "result", result: "Authentication failed: invalid API key" },
+    ]);
+  });
+
+  it("parseStreamLine captures error event with top-level message as result", () => {
+    const provider = codex("gpt-5.4-mini");
+    const line = JSON.stringify({
+      type: "error",
+      message: "Rate limit exceeded",
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "result", result: "Rate limit exceeded" },
+    ]);
+  });
+
+  it("parseStreamLine returns empty array for error event with no extractable message", () => {
+    const provider = codex("gpt-5.4-mini");
+    const line = JSON.stringify({
+      type: "error",
+      code: "unknown",
+    });
+    expect(provider.parseStreamLine(line)).toEqual([]);
+  });
+
   it("accepts an env option and exposes it on the provider", () => {
     const provider = codex("gpt-5.4-mini", { env: { OPENAI_KEY: "xyz" } });
     expect(provider.env).toEqual({ OPENAI_KEY: "xyz" });

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -383,6 +383,80 @@ describe("pi factory", () => {
     );
   });
 
+  it("parseStreamLine captures agent_error event with string error as result", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const line = JSON.stringify({
+      type: "agent_error",
+      error: "Authentication failed: invalid API key",
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      {
+        type: "result",
+        result: "Authentication failed: invalid API key",
+      },
+    ]);
+  });
+
+  it("parseStreamLine captures agent_error event with object error as result", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const line = JSON.stringify({
+      type: "agent_error",
+      error: { message: "Rate limit exceeded", code: "rate_limit" },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      {
+        type: "result",
+        result: "Rate limit exceeded",
+      },
+    ]);
+  });
+
+  it("parseStreamLine captures error event with string message as result", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const line = JSON.stringify({
+      type: "error",
+      message: "Internal server error",
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      {
+        type: "result",
+        result: "Internal server error",
+      },
+    ]);
+  });
+
+  it("parseStreamLine captures error event with string error field as result", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const line = JSON.stringify({
+      type: "error",
+      error: "Connection refused",
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      {
+        type: "result",
+        result: "Connection refused",
+      },
+    ]);
+  });
+
+  it("parseStreamLine returns empty array for agent_error with no extractable message", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const line = JSON.stringify({
+      type: "agent_error",
+      // no error field
+    });
+    expect(provider.parseStreamLine(line)).toEqual([]);
+  });
+
+  it("parseStreamLine returns empty array for error event with no extractable message", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const line = JSON.stringify({
+      type: "error",
+      // no message or error field
+    });
+    expect(provider.parseStreamLine(line)).toEqual([]);
+  });
+
   it("accepts an env option and exposes it on the provider", () => {
     const provider = pi("claude-sonnet-4-6", { env: { PI_KEY: "abc" } });
     expect(provider.env).toEqual({ PI_KEY: "abc" });

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -241,6 +241,22 @@ const parseCodexStreamLine = (line: string): ParsedStreamEvent[] => {
       return [{ type: "tool_call", name: "Bash", args: obj.item.command }];
     }
 
+    // Codex emits error events on stdout (not stderr) for auth failures,
+    // rate limits, and API errors. Capture them as result events so the
+    // Orchestrator's stderr-empty fallback can surface them to the user.
+    if (obj.type === "error") {
+      const err = obj.error;
+      let msg: string | undefined;
+      if (typeof err === "string") {
+        msg = err;
+      } else if (typeof err === "object" && err !== null && typeof err.message === "string") {
+        msg = err.message;
+      } else if (typeof obj.message === "string") {
+        msg = obj.message;
+      }
+      return msg ? [{ type: "result", result: msg }] : [];
+    }
+
     // turn.completed → skip
   } catch {
     // Not valid JSON — skip

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -138,6 +138,21 @@ const parsePiStreamLine = (line: string): ParsedStreamEvent[] => {
       if (typeof argValue !== "string") return [];
       return [{ type: "tool_call", name: toolName, args: argValue }];
     }
+    // Pi emits agent_error / error events on stdout (not stderr) for auth
+    // failures, rate limits, and API errors. Capture them as result events so
+    // the Orchestrator's stderr-empty fallback can surface them to the user.
+    if (obj.type === "agent_error" || obj.type === "error") {
+      const err = obj.error;
+      const msg =
+        typeof err === "string"
+          ? err
+          : typeof err === "object" && err !== null && typeof err.message === "string"
+            ? (err.message as string)
+            : typeof obj.message === "string"
+              ? (obj.message as string)
+              : undefined;
+      return msg ? [{ type: "result", result: msg }] : [];
+    }
     if (obj.type === "agent_end" && Array.isArray(obj.messages)) {
       const messages = obj.messages as {
         role: string;

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -143,14 +143,14 @@ const parsePiStreamLine = (line: string): ParsedStreamEvent[] => {
     // the Orchestrator's stderr-empty fallback can surface them to the user.
     if (obj.type === "agent_error" || obj.type === "error") {
       const err = obj.error;
-      const msg =
-        typeof err === "string"
-          ? err
-          : typeof err === "object" && err !== null && typeof err.message === "string"
-            ? (err.message as string)
-            : typeof obj.message === "string"
-              ? (obj.message as string)
-              : undefined;
+      let msg: string | undefined;
+      if (typeof err === "string") {
+        msg = err;
+      } else if (typeof err === "object" && err !== null && typeof err.message === "string") {
+        msg = err.message;
+      } else if (typeof obj.message === "string") {
+        msg = obj.message;
+      }
       return msg ? [{ type: "result", result: msg }] : [];
     }
     if (obj.type === "agent_end" && Array.isArray(obj.messages)) {

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -14,6 +14,20 @@ const TOOL_ARG_FIELDS: Record<string, string> = {
   Agent: "description",
 };
 
+/**
+ * Extract an error message from a parsed JSON error event.
+ * Handles { error: "string" }, { error: { message: "string" } }, and { message: "string" }.
+ */
+const extractErrorMessage = (obj: any): string | undefined => {
+  const err = obj.error;
+  if (typeof err === "string") return err;
+  if (typeof err === "object" && err !== null && typeof err.message === "string") {
+    return err.message;
+  }
+  if (typeof obj.message === "string") return obj.message;
+  return undefined;
+};
+
 const parseStreamJsonLine = (line: string): ParsedStreamEvent[] => {
   if (!line.startsWith("{")) return [];
   try {
@@ -142,15 +156,7 @@ const parsePiStreamLine = (line: string): ParsedStreamEvent[] => {
     // failures, rate limits, and API errors. Capture them as result events so
     // the Orchestrator's stderr-empty fallback can surface them to the user.
     if (obj.type === "agent_error" || obj.type === "error") {
-      const err = obj.error;
-      let msg: string | undefined;
-      if (typeof err === "string") {
-        msg = err;
-      } else if (typeof err === "object" && err !== null && typeof err.message === "string") {
-        msg = err.message;
-      } else if (typeof obj.message === "string") {
-        msg = obj.message;
-      }
+      const msg = extractErrorMessage(obj);
       return msg ? [{ type: "result", result: msg }] : [];
     }
     if (obj.type === "agent_end" && Array.isArray(obj.messages)) {
@@ -245,15 +251,7 @@ const parseCodexStreamLine = (line: string): ParsedStreamEvent[] => {
     // rate limits, and API errors. Capture them as result events so the
     // Orchestrator's stderr-empty fallback can surface them to the user.
     if (obj.type === "error") {
-      const err = obj.error;
-      let msg: string | undefined;
-      if (typeof err === "string") {
-        msg = err;
-      } else if (typeof err === "object" && err !== null && typeof err.message === "string") {
-        msg = err.message;
-      } else if (typeof obj.message === "string") {
-        msg = obj.message;
-      }
+      const msg = extractErrorMessage(obj);
       return msg ? [{ type: "result", result: msg }] : [];
     }
 

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -20,12 +20,13 @@ import { orchestrate } from "./Orchestrator.js";
 import {
   claudeCode,
   codex as codexFactory,
+  opencode as opencodeFactory,
   pi as piFactory,
   DEFAULT_MODEL,
 } from "./AgentProvider.js";
 import { Sandbox } from "./SandboxFactory.js";
 import type { DockerError, SandboxError } from "./errors.js";
-import { AgentIdleTimeoutError } from "./errors.js";
+import { AgentError, AgentIdleTimeoutError } from "./errors.js";
 import { SandboxFactory } from "./SandboxFactory.js";
 import { encodeProjectPath } from "./SessionStore.js";
 import { defaultSessionPathsLayer, sessionPathsLayer } from "./SessionPaths.js";
@@ -1402,6 +1403,184 @@ describe("Orchestrator error handling", () => {
     );
 
     expect(exit._tag).toBe("Failure");
+  });
+
+  it("falls back to tail of stdout when stderr is empty on non-zero exit (no-op parser)", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-stderr-fallback-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const opencodeProvider = opencodeFactory("test-model");
+    const stdoutContent = "Setting up environment...\nLoading model...\nError: API key is invalid\nPlease check your credentials";
+
+    const { factoryLayer } = makeTestSandboxFactory(
+      hostDir,
+      (dir) => {
+        const fsLayer = makeLocalSandboxLayer(dir);
+        return Layer.succeed(Sandbox, {
+          exec: (command, options) => {
+            if (command.startsWith("opencode ")) {
+              return Effect.succeed({
+                stdout: stdoutContent,
+                stderr: "",
+                exitCode: 1,
+              });
+            }
+            return Effect.flatMap(Sandbox, (real) =>
+              real.exec(command, options),
+            ).pipe(Effect.provide(fsLayer));
+          },
+          copyIn: (hostPath, sandboxPath) =>
+            Effect.flatMap(Sandbox, (real) =>
+              real.copyIn(hostPath, sandboxPath),
+            ).pipe(Effect.provide(fsLayer)),
+          copyFileOut: (sandboxPath, hostPath) =>
+            Effect.flatMap(Sandbox, (real) =>
+              real.copyFileOut(sandboxPath, hostPath),
+            ).pipe(Effect.provide(fsLayer)),
+        });
+      },
+    );
+
+    const exit = await Effect.runPromiseExit(
+      orchestrate({
+        provider: opencodeProvider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: "do some work",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const err = Cause.squash(exit.cause);
+      expect(err).toBeInstanceOf(AgentError);
+      if (err instanceof AgentError) {
+        expect(err.message).toContain("opencode exited with code 1:");
+        expect(err.message).toContain("API key is invalid");
+      }
+    }
+  });
+
+  it("falls back to resultText when stderr is empty on non-zero exit (structured parser)", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-resulttext-fallback-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    // Use Claude Code provider which has a structured parser that populates resultText
+    const errorLine = JSON.stringify({
+      type: "result",
+      result: "Rate limit exceeded, please retry later",
+    });
+
+    const { factoryLayer } = makeTestSandboxFactory(
+      hostDir,
+      (dir) => {
+        const fsLayer = makeLocalSandboxLayer(dir);
+        return Layer.succeed(Sandbox, {
+          exec: (command, options) => {
+            if (command.startsWith("claude ") && options?.onLine) {
+              options.onLine(errorLine);
+              return Effect.succeed({
+                stdout: errorLine,
+                stderr: "",
+                exitCode: 1,
+              });
+            }
+            return Effect.flatMap(Sandbox, (real) =>
+              real.exec(command, options),
+            ).pipe(Effect.provide(fsLayer));
+          },
+          copyIn: (hostPath, sandboxPath) =>
+            Effect.flatMap(Sandbox, (real) =>
+              real.copyIn(hostPath, sandboxPath),
+            ).pipe(Effect.provide(fsLayer)),
+          copyFileOut: (sandboxPath, hostPath) =>
+            Effect.flatMap(Sandbox, (real) =>
+              real.copyFileOut(sandboxPath, hostPath),
+            ).pipe(Effect.provide(fsLayer)),
+        });
+      },
+    );
+
+    const exit = await Effect.runPromiseExit(
+      orchestrate({
+        provider: testProvider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: "do some work",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const err = Cause.squash(exit.cause);
+      expect(err).toBeInstanceOf(AgentError);
+      if (err instanceof AgentError) {
+        expect(err.message).toContain("claude-code exited with code 1:");
+        expect(err.message).toContain("Rate limit exceeded, please retry later");
+      }
+    }
+  });
+
+  it("preserves stderr in error when stderr is non-empty", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-stderr-present-"));
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const opencodeProvider = opencodeFactory("test-model");
+
+    const { factoryLayer } = makeTestSandboxFactory(
+      hostDir,
+      (dir) => {
+        const fsLayer = makeLocalSandboxLayer(dir);
+        return Layer.succeed(Sandbox, {
+          exec: (command, options) => {
+            if (command.startsWith("opencode ")) {
+              return Effect.succeed({
+                stdout: "some stdout output",
+                stderr: "fatal error from stderr",
+                exitCode: 1,
+              });
+            }
+            return Effect.flatMap(Sandbox, (real) =>
+              real.exec(command, options),
+            ).pipe(Effect.provide(fsLayer));
+          },
+          copyIn: (hostPath, sandboxPath) =>
+            Effect.flatMap(Sandbox, (real) =>
+              real.copyIn(hostPath, sandboxPath),
+            ).pipe(Effect.provide(fsLayer)),
+          copyFileOut: (sandboxPath, hostPath) =>
+            Effect.flatMap(Sandbox, (real) =>
+              real.copyFileOut(sandboxPath, hostPath),
+            ).pipe(Effect.provide(fsLayer)),
+        });
+      },
+    );
+
+    const exit = await Effect.runPromiseExit(
+      orchestrate({
+        provider: opencodeProvider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: "do some work",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const err = Cause.squash(exit.cause);
+      expect(err).toBeInstanceOf(AgentError);
+      if (err instanceof AgentError) {
+        expect(err.message).toContain("fatal error from stderr");
+        // Should NOT fall back to stdout when stderr is present
+        expect(err.message).not.toContain("some stdout output");
+      }
+    }
   });
 });
 

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -119,9 +119,21 @@ const invokeAgent = (
       });
 
       if (execResult.exitCode !== 0) {
+        // Prefer stderr; fall back to resultText (from parsed stream events),
+        // then to the tail of raw stdout (last 20 non-empty lines).
+        let errorDetail = execResult.stderr;
+        if (!errorDetail.trim()) {
+          errorDetail = resultText;
+        }
+        if (!errorDetail.trim()) {
+          const lines = execResult.stdout
+            .split("\n")
+            .filter((l) => l.trim());
+          errorDetail = lines.slice(-20).join("\n");
+        }
         return yield* Effect.fail(
           new AgentError({
-            message: `${provider.name} exited with code ${execResult.exitCode}:\n${execResult.stderr}`,
+            message: `${provider.name} exited with code ${execResult.exitCode}:\n${errorDetail}`,
           }),
         );
       }


### PR DESCRIPTION
Investigates what Pi, Codex, and OpenCode write to stdout vs stderr on error, then implements error text surfacing following the same fallback pattern established in PR #438 for Claude Code.

PR #438 introduces the provider-agnostic Orchestrator fallback from stderr to resultText. These tasks extend parseStreamLine for each agent to capture error events so the fallback has useful text to surface.

Closes #420, #421, #422.

Closes #421
Closes #422