### PR TITLE
Add AgentInvoker seam and e2e tests for all init templates

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,10 @@ _Avoid_: "agent adapter", "agent driver"
 
 ### Execution
 
+**Agent invoker**:
+An Effect `Context.Tag` wrapping the raw agent-spawn call inside the **orchestrator**. The production layer preserves today's behaviour; test layers can record or script invocations.
+_Avoid_: "agent runner", "agent caller"
+
 **Iteration**:
 A single invocation of the **agent** inside the **sandbox**, producing at most one commit against one **task**.
 _Avoid_: "run" (ambiguous with the JS `run()` function), "cycle", "loop"

--- a/src/AgentInvoker.ts
+++ b/src/AgentInvoker.ts
@@ -1,0 +1,185 @@
+import { Context, Effect, Layer, Deferred } from "effect";
+import type { SandboxService } from "./SandboxFactory.js";
+import type { AgentProvider } from "./AgentProvider.js";
+import {
+  AgentError,
+  AgentIdleTimeoutError,
+  type SandboxError,
+} from "./errors.js";
+
+const IDLE_WARNING_INTERVAL_MS = 60_000;
+
+export interface AgentInvocation {
+  readonly sandbox: SandboxService;
+  readonly sandboxRepoDir: string;
+  readonly prompt: string;
+  readonly provider: AgentProvider;
+  readonly idleTimeoutMs: number;
+  readonly onText: (text: string) => void;
+  readonly onToolCall: (name: string, formattedArgs: string) => void;
+  readonly onIdleWarning: (minutes: number) => void;
+  readonly idleWarningIntervalMs?: number;
+  readonly resumeSession?: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface AgentInvokerService {
+  readonly invoke: (
+    invocation: AgentInvocation,
+  ) => Effect.Effect<{ result: string; sessionId?: string }, SandboxError>;
+}
+
+export class AgentInvoker extends Context.Tag("AgentInvoker")<
+  AgentInvoker,
+  AgentInvokerService
+>() {}
+
+/**
+ * Production implementation of AgentInvoker — preserves the original
+ * inline behaviour from the orchestrator.
+ */
+const invokeAgentProduction = (
+  invocation: AgentInvocation,
+): Effect.Effect<{ result: string; sessionId?: string }, SandboxError> =>
+  Effect.gen(function* () {
+    const {
+      sandbox,
+      sandboxRepoDir,
+      prompt,
+      provider,
+      idleTimeoutMs,
+      onText,
+      onToolCall,
+      onIdleWarning,
+      idleWarningIntervalMs = IDLE_WARNING_INTERVAL_MS,
+      resumeSession,
+      signal,
+    } = invocation;
+
+    let resultText = "";
+    let sessionId: string | undefined;
+
+    // Deferred that will be failed when the idle timer fires
+    const timeoutSignal = yield* Deferred.make<never, AgentIdleTimeoutError>();
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+    // Periodic idle warning state
+    let warningHandle: ReturnType<typeof setInterval> | null = null;
+    let idleMinuteCounter = 0;
+
+    const startWarningInterval = () => {
+      if (warningHandle !== null) clearInterval(warningHandle);
+      idleMinuteCounter = 0;
+      warningHandle = setInterval(() => {
+        idleMinuteCounter++;
+        onIdleWarning(idleMinuteCounter);
+      }, idleWarningIntervalMs);
+    };
+
+    const resetIdleTimer = () => {
+      if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+      timeoutHandle = setTimeout(() => {
+        Effect.runPromise(
+          Deferred.fail(
+            timeoutSignal,
+            new AgentIdleTimeoutError({
+              message: `Agent idle for ${idleTimeoutMs / 1000} seconds — no output received. Consider increasing the idle timeout with --idle-timeout.`,
+              timeoutMs: idleTimeoutMs,
+            }),
+          ),
+        ).catch(() => {});
+      }, idleTimeoutMs);
+      // Reset warning interval on activity
+      startWarningInterval();
+    };
+
+    // Deferred that will be resolved (as a defect) when the AbortSignal fires.
+    // Uses Effect.die so the abort reason propagates as-is to run().
+    const abortDeferred = yield* Deferred.make<never, never>();
+    let abortCleanup: (() => void) | null = null;
+    if (signal) {
+      if (signal.aborted) {
+        return yield* Effect.die(signal.reason);
+      }
+      const onAbort = () => {
+        Effect.runPromise(Deferred.die(abortDeferred, signal.reason)).catch(
+          () => {},
+        );
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      abortCleanup = () => signal.removeEventListener("abort", onAbort);
+    }
+
+    resetIdleTimer();
+
+    const execEffect = Effect.gen(function* () {
+      const printCmd = provider.buildPrintCommand({
+        prompt,
+        dangerouslySkipPermissions: true,
+        resumeSession,
+      });
+      const execResult = yield* sandbox.exec(printCmd.command, {
+        onLine: (line) => {
+          resetIdleTimer();
+          for (const parsed of provider.parseStreamLine(line)) {
+            if (parsed.type === "text") {
+              onText(parsed.text);
+            } else if (parsed.type === "result") {
+              resultText = parsed.result;
+            } else if (parsed.type === "tool_call") {
+              onToolCall(parsed.name, parsed.args);
+            } else if (parsed.type === "session_id") {
+              sessionId = parsed.sessionId;
+            }
+          }
+        },
+        cwd: sandboxRepoDir,
+        stdin: printCmd.stdin,
+      });
+
+      if (execResult.exitCode !== 0) {
+        return yield* Effect.fail(
+          new AgentError({
+            message: `${provider.name} exited with code ${execResult.exitCode}:\n${execResult.stderr}`,
+          }),
+        );
+      }
+
+      return { result: resultText || execResult.stdout, sessionId };
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (timeoutHandle !== null) {
+            clearTimeout(timeoutHandle);
+            timeoutHandle = null;
+          }
+          if (warningHandle !== null) {
+            clearInterval(warningHandle);
+            warningHandle = null;
+          }
+        }),
+      ),
+    );
+
+    let raced = Effect.raceFirst(execEffect, Deferred.await(timeoutSignal));
+    if (signal) {
+      raced = Effect.raceFirst(
+        raced,
+        Deferred.await(abortDeferred) as Effect.Effect<never, never>,
+      );
+    }
+
+    return yield* raced.pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          abortCleanup?.();
+        }),
+      ),
+    );
+  });
+
+/** Production layer — preserves the original inline orchestrator behaviour. */
+export const ProductionAgentInvokerLayer: Layer.Layer<AgentInvoker> =
+  Layer.succeed(AgentInvoker, {
+    invoke: invokeAgentProduction,
+  });

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -259,8 +259,8 @@ const BACKLOG_MANAGER_REGISTRY: BacklogManagerEntry[] = [
     label: "GitHub Issues",
     templateArgs: {
       LIST_TASKS_COMMAND: `gh issue list --state open --label Sandcastle --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`,
-      VIEW_TASK_COMMAND: "gh issue view {{TASK_ID}}",
-      CLOSE_TASK_COMMAND: `gh issue close {{TASK_ID}} --comment "Completed by Sandcastle"`,
+      VIEW_TASK_COMMAND: "gh issue view $TASK_ID",
+      CLOSE_TASK_COMMAND: `gh issue close $TASK_ID --comment "Completed by Sandcastle"`,
       BACKLOG_MANAGER_TOOLS: GITHUB_CLI_TOOLS,
     },
     envExample: `# GitHub personal access token
@@ -271,8 +271,8 @@ GH_TOKEN=`,
     label: "Beads",
     templateArgs: {
       LIST_TASKS_COMMAND: "bd ready --json",
-      VIEW_TASK_COMMAND: "bd show {{TASK_ID}}",
-      CLOSE_TASK_COMMAND: `bd close {{TASK_ID}} "Completed by Sandcastle"`,
+      VIEW_TASK_COMMAND: "bd show $TASK_ID",
+      CLOSE_TASK_COMMAND: `bd close $TASK_ID "Completed by Sandcastle"`,
       BACKLOG_MANAGER_TOOLS: BEADS_TOOLS,
     },
     envExample: "",

--- a/src/LocalSandboxFactory.ts
+++ b/src/LocalSandboxFactory.ts
@@ -78,14 +78,9 @@ export const makeLocalSandboxFactoryLayer = (
 
           // Set up worktree / branch per strategy
           let workDir = sandboxDir;
-          let branch = "main";
 
-          if (options.branchStrategy.type === "head") {
-            // head mode: work directly in the repo dir on main
-            // nothing extra
-          } else if (options.branchStrategy.type === "merge-to-head") {
-            // create a temp branch from HEAD
-            branch = `sandcastle/test-${Date.now()}`;
+          if (options.branchStrategy.type === "merge-to-head") {
+            const branch = `sandcastle/test-${Date.now()}`;
             const worktreeDir = await mkdtemp(
               join(tmpdir(), "local-sandbox-worktree-"),
             );
@@ -95,7 +90,7 @@ export const makeLocalSandboxFactoryLayer = (
             );
             workDir = worktreeDir;
           } else if (options.branchStrategy.type === "branch") {
-            branch = options.branchStrategy.branch;
+            const branch = options.branchStrategy.branch;
             const worktreeDir = await mkdtemp(
               join(tmpdir(), "local-sandbox-worktree-"),
             );
@@ -114,7 +109,7 @@ export const makeLocalSandboxFactoryLayer = (
             workDir = worktreeDir;
           }
 
-          return { sandboxDir, workDir, branch };
+          return { sandboxDir, workDir };
         }),
         // Use
         ({ workDir }) => {

--- a/src/LocalSandboxFactory.ts
+++ b/src/LocalSandboxFactory.ts
@@ -5,10 +5,14 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { SandboxFactory, type WithSandboxResult } from "./SandboxFactory.js";
+import {
+  SandboxFactory,
+  Sandbox,
+  type SandboxInfo,
+  type WithSandboxResult,
+} from "./SandboxFactory.js";
 import type { SandboxError } from "./errors.js";
 import type { BranchStrategy } from "./SandboxProvider.js";
-import { Sandbox } from "./SandboxFactory.js";
 import { makeLocalSandboxLayer } from "./testSandbox.js";
 
 const execAsync = promisify(exec);
@@ -40,7 +44,7 @@ export const makeLocalSandboxFactoryLayer = (
   return Layer.succeed(SandboxFactory, {
     withSandbox: <A, E, R>(
       makeEffect: (
-        info: import("./SandboxFactory.js").SandboxInfo,
+        info: SandboxInfo,
       ) => Effect.Effect<A, E, R | Sandbox>,
     ): Effect.Effect<
       WithSandboxResult<A>,
@@ -106,7 +110,7 @@ export const makeLocalSandboxFactoryLayer = (
           return { sandboxDir, workDir, branch };
         }),
         // Use
-        ({ workDir, branch }) => {
+        ({ workDir }) => {
           const sandboxLayer = makeLocalSandboxLayer(workDir);
           return makeEffect({
             hostWorktreePath: workDir,

--- a/src/LocalSandboxFactory.ts
+++ b/src/LocalSandboxFactory.ts
@@ -1,0 +1,144 @@
+import { Effect, Layer } from "effect";
+import { exec } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { SandboxFactory, type WithSandboxResult } from "./SandboxFactory.js";
+import type { SandboxError } from "./errors.js";
+import type { BranchStrategy } from "./SandboxProvider.js";
+import { Sandbox } from "./SandboxFactory.js";
+import { makeLocalSandboxLayer } from "./testSandbox.js";
+
+const execAsync = promisify(exec);
+
+/**
+ * Creates an isolated git global config so that sandbox `git config --global`
+ * writes don't corrupt the developer's real ~/.gitconfig.
+ */
+const createIsolatedGitEnv = (): string => {
+  const tmpDir = mkdtempSync(join(tmpdir(), "local-sandbox-gitconfig-"));
+  const globalConfigPath = join(tmpDir, ".gitconfig");
+  writeFileSync(globalConfigPath, "");
+  return globalConfigPath;
+};
+
+interface LocalSandboxFactoryOptions {
+  readonly branchStrategy: BranchStrategy;
+}
+
+/**
+ * A SandboxFactory backed by a local tmp directory with `git init`.
+ * No Docker, no network. Honours branch strategies using real git.
+ */
+export const makeLocalSandboxFactoryLayer = (
+  options: LocalSandboxFactoryOptions,
+): Layer.Layer<SandboxFactory> => {
+  const gitConfigGlobal = createIsolatedGitEnv();
+
+  return Layer.succeed(SandboxFactory, {
+    withSandbox: <A, E, R>(
+      makeEffect: (
+        info: import("./SandboxFactory.js").SandboxInfo,
+      ) => Effect.Effect<A, E, R | Sandbox>,
+    ): Effect.Effect<
+      WithSandboxResult<A>,
+      E | SandboxError,
+      Exclude<R, Sandbox>
+    > =>
+      Effect.acquireUseRelease(
+        // Acquire: create tmp dir, git init, seed initial commit, set up branch
+        Effect.promise(async () => {
+          const sandboxDir = await mkdtemp(
+            join(tmpdir(), "local-sandbox-repo-"),
+          );
+          const gitEnv = {
+            ...process.env,
+            GIT_CONFIG_GLOBAL: gitConfigGlobal,
+          };
+          const gitOpts = { cwd: sandboxDir, env: gitEnv };
+          await execAsync("git init -b main", gitOpts);
+          await execAsync('git config user.email "test@sandcastle.local"', gitOpts);
+          await execAsync('git config user.name "Sandcastle Test"', gitOpts);
+          await writeFile(join(sandboxDir, ".gitkeep"), "");
+          await execAsync("git add .gitkeep", gitOpts);
+          await execAsync('git commit -m "initial commit"', gitOpts);
+
+          // Set up worktree / branch per strategy
+          let workDir = sandboxDir;
+          let branch = "main";
+
+          if (options.branchStrategy.type === "head") {
+            // head mode: work directly in the repo dir on main
+            // nothing extra
+          } else if (options.branchStrategy.type === "merge-to-head") {
+            // create a temp branch from HEAD
+            branch = `sandcastle/test-${Date.now()}`;
+            const worktreeDir = await mkdtemp(
+              join(tmpdir(), "local-sandbox-worktree-"),
+            );
+            await execAsync(
+              `git worktree add -b "${branch}" "${worktreeDir}" HEAD`,
+              gitOpts,
+            );
+            workDir = worktreeDir;
+          } else if (options.branchStrategy.type === "branch") {
+            branch = options.branchStrategy.branch;
+            const worktreeDir = await mkdtemp(
+              join(tmpdir(), "local-sandbox-worktree-"),
+            );
+            // Try to check out existing branch, else create new
+            try {
+              await execAsync(
+                `git worktree add "${worktreeDir}" "${branch}"`,
+                gitOpts,
+              );
+            } catch {
+              await execAsync(
+                `git worktree add -b "${branch}" "${worktreeDir}" HEAD`,
+                gitOpts,
+              );
+            }
+            workDir = worktreeDir;
+          }
+
+          return { sandboxDir, workDir, branch };
+        }),
+        // Use
+        ({ workDir, branch }) => {
+          const sandboxLayer = makeLocalSandboxLayer(workDir);
+          return makeEffect({
+            hostWorktreePath: workDir,
+            sandboxRepoPath: workDir,
+            applyToHost: () => Effect.void,
+          }).pipe(Effect.provide(sandboxLayer)) as Effect.Effect<
+            A,
+            E | SandboxError,
+            Exclude<R, Sandbox>
+          >;
+        },
+        // Release
+        ({ sandboxDir, workDir }) =>
+          Effect.promise(async () => {
+            // Clean up worktree if separate from sandboxDir
+            if (workDir !== sandboxDir) {
+              try {
+                await execAsync(
+                  `git worktree remove --force "${workDir}"`,
+                  { cwd: sandboxDir },
+                );
+              } catch {}
+              try {
+                await rm(workDir, { recursive: true, force: true });
+              } catch {}
+            }
+            try {
+              await rm(sandboxDir, { recursive: true, force: true });
+            } catch {}
+          }),
+      ).pipe(
+        Effect.map((value) => ({ value, preservedWorktreePath: undefined })),
+      ),
+  });
+};

--- a/src/LocalSandboxFactory.ts
+++ b/src/LocalSandboxFactory.ts
@@ -66,7 +66,14 @@ export const makeLocalSandboxFactoryLayer = (
           await execAsync('git config user.email "test@sandcastle.local"', gitOpts);
           await execAsync('git config user.name "Sandcastle Test"', gitOpts);
           await writeFile(join(sandboxDir, ".gitkeep"), "");
-          await execAsync("git add .gitkeep", gitOpts);
+          // Seed a minimal package.json so that template hooks like
+          // onSandboxReady: [{ command: "npm install" }] don't fail
+          // in the bare test repo.
+          await writeFile(
+            join(sandboxDir, "package.json"),
+            '{ "name": "test-sandbox", "private": true }\n',
+          );
+          await execAsync("git add .gitkeep package.json", gitOpts);
           await execAsync('git commit -m "initial commit"', gitOpts);
 
           // Set up worktree / branch per strategy

--- a/src/LocalSandboxFactory.ts
+++ b/src/LocalSandboxFactory.ts
@@ -95,9 +95,7 @@ export const makeLocalSandboxFactoryLayer = (
               "git rev-parse --abbrev-ref HEAD",
               gitOpts,
             );
-            if (currentBranchOut.trim() === branch) {
-              // Requested branch is already checked out; no worktree needed.
-            } else {
+            if (currentBranchOut.trim() !== branch) {
               const worktreeDir = await mkdtemp(
                 join(tmpdir(), "local-sandbox-worktree-"),
               );

--- a/src/LocalSandboxFactory.ts
+++ b/src/LocalSandboxFactory.ts
@@ -91,22 +91,30 @@ export const makeLocalSandboxFactoryLayer = (
             workDir = worktreeDir;
           } else if (options.branchStrategy.type === "branch") {
             const branch = options.branchStrategy.branch;
-            const worktreeDir = await mkdtemp(
-              join(tmpdir(), "local-sandbox-worktree-"),
+            const { stdout: currentBranchOut } = await execAsync(
+              "git rev-parse --abbrev-ref HEAD",
+              gitOpts,
             );
-            // Try to check out existing branch, else create new
-            try {
-              await execAsync(
-                `git worktree add "${worktreeDir}" "${branch}"`,
-                gitOpts,
+            if (currentBranchOut.trim() === branch) {
+              // Requested branch is already checked out; no worktree needed.
+            } else {
+              const worktreeDir = await mkdtemp(
+                join(tmpdir(), "local-sandbox-worktree-"),
               );
-            } catch {
-              await execAsync(
-                `git worktree add -b "${branch}" "${worktreeDir}" HEAD`,
-                gitOpts,
-              );
+              // Try to check out existing branch, else create new
+              try {
+                await execAsync(
+                  `git worktree add "${worktreeDir}" "${branch}"`,
+                  gitOpts,
+                );
+              } catch {
+                await execAsync(
+                  `git worktree add -b "${branch}" "${worktreeDir}" HEAD`,
+                  gitOpts,
+                );
+              }
+              workDir = worktreeDir;
             }
-            workDir = worktreeDir;
           }
 
           return { sandboxDir, workDir };

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -30,14 +30,18 @@ import { SandboxFactory } from "./SandboxFactory.js";
 import { encodeProjectPath } from "./SessionStore.js";
 import { defaultSessionPathsLayer, sessionPathsLayer } from "./SessionPaths.js";
 import type { BindMountSandboxHandle } from "./SandboxProvider.js";
+import { ProductionAgentInvokerLayer } from "./AgentInvoker.js";
+import { ProductionPromptPreprocessorLayer } from "./PromptPreprocessorTag.js";
 
 const execAsync = promisify(exec);
 
 const testProvider = claudeCode("test-model");
 
-const testDisplayLayer = Layer.merge(
+const testDisplayLayer = Layer.mergeAll(
   SilentDisplay.layer(Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([])),
   defaultSessionPathsLayer,
+  ProductionAgentInvokerLayer,
+  ProductionPromptPreprocessorLayer,
 );
 
 const initRepo = async (dir: string) => {
@@ -1114,6 +1118,8 @@ describe("Orchestrator tool call display integration", () => {
             mockLayer.factoryLayer,
             displayLayer,
             defaultSessionPathsLayer,
+            ProductionAgentInvokerLayer,
+            ProductionPromptPreprocessorLayer,
           ),
         ),
       ),
@@ -1758,7 +1764,7 @@ describe("Orchestrator Display integration", () => {
         prompt: "do some work",
       }).pipe(
         Effect.provide(
-          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer),
+          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer, ProductionAgentInvokerLayer, ProductionPromptPreprocessorLayer),
         ),
       ),
     );
@@ -1825,7 +1831,7 @@ describe("Orchestrator Display integration", () => {
         prompt: "do some work",
       }).pipe(
         Effect.provide(
-          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer),
+          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer, ProductionAgentInvokerLayer, ProductionPromptPreprocessorLayer),
         ),
       ),
     );
@@ -1903,7 +1909,7 @@ describe("Orchestrator Display integration", () => {
         name: "issue-42",
       }).pipe(
         Effect.provide(
-          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer),
+          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer, ProductionAgentInvokerLayer, ProductionPromptPreprocessorLayer),
         ),
       ),
     );
@@ -1947,7 +1953,7 @@ describe("Orchestrator Display integration", () => {
         prompt: "do some work",
       }).pipe(
         Effect.provide(
-          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer),
+          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer, ProductionAgentInvokerLayer, ProductionPromptPreprocessorLayer),
         ),
       ),
     );
@@ -2196,7 +2202,7 @@ describe("Orchestrator Display integration", () => {
         _idleWarningIntervalMs: 100, // fire warnings every 100ms for testing
       }).pipe(
         Effect.provide(
-          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer),
+          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer, ProductionAgentInvokerLayer, ProductionPromptPreprocessorLayer),
         ),
         Effect.exit,
       ),
@@ -2289,7 +2295,7 @@ describe("Orchestrator Display integration", () => {
         _idleWarningIntervalMs: 100,
       }).pipe(
         Effect.provide(
-          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer),
+          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer, ProductionAgentInvokerLayer, ProductionPromptPreprocessorLayer),
         ),
         Effect.exit,
       ),
@@ -2538,7 +2544,7 @@ describe("Orchestrator with pi provider", () => {
         prompt: "do some work",
       }).pipe(
         Effect.provide(
-          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer),
+          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer, ProductionAgentInvokerLayer, ProductionPromptPreprocessorLayer),
         ),
       ),
     );
@@ -2626,7 +2632,7 @@ describe("Orchestrator with pi provider", () => {
         prompt: "do some work",
       }).pipe(
         Effect.provide(
-          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer),
+          Layer.mergeAll(factoryLayer, displayLayer, defaultSessionPathsLayer, ProductionAgentInvokerLayer, ProductionPromptPreprocessorLayer),
         ),
       ),
     );

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -1,13 +1,9 @@
-import { Deferred, Effect } from "effect";
+import { Effect } from "effect";
 import { Display } from "./Display.js";
-import { preprocessPrompt } from "./PromptPreprocessor.js";
-import {
-  AgentError,
-  AgentIdleTimeoutError,
-  SessionCaptureError,
-} from "./errors.js";
+import { PromptPreprocessor } from "./PromptPreprocessorTag.js";
+import { AgentInvoker } from "./AgentInvoker.js";
+import { SessionCaptureError } from "./errors.js";
 import type { SandboxError } from "./errors.js";
-import type { SandboxService } from "./SandboxFactory.js";
 import { SandboxFactory, SANDBOX_REPO_DIR } from "./SandboxFactory.js";
 import { withSandboxLifecycle, type SandboxHooks } from "./SandboxLifecycle.js";
 import type { AgentProvider, IterationUsage } from "./AgentProvider.js";
@@ -20,144 +16,6 @@ import {
 import { SessionPaths } from "./SessionPaths.js";
 
 export type { ParsedStreamEvent, IterationUsage } from "./AgentProvider.js";
-
-const IDLE_WARNING_INTERVAL_MS = 60_000;
-
-const invokeAgent = (
-  sandbox: SandboxService,
-  sandboxRepoDir: string,
-  prompt: string,
-  provider: AgentProvider,
-  idleTimeoutMs: number,
-  onText: (text: string) => void,
-  onToolCall: (name: string, formattedArgs: string) => void,
-  onIdleWarning: (minutes: number) => void,
-  idleWarningIntervalMs: number = IDLE_WARNING_INTERVAL_MS,
-  resumeSession?: string,
-  signal?: AbortSignal,
-): Effect.Effect<{ result: string; sessionId?: string }, SandboxError> =>
-  Effect.gen(function* () {
-    let resultText = "";
-    let sessionId: string | undefined;
-
-    // Deferred that will be failed when the idle timer fires
-    const timeoutSignal = yield* Deferred.make<never, AgentIdleTimeoutError>();
-    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-
-    // Periodic idle warning state
-    let warningHandle: ReturnType<typeof setInterval> | null = null;
-    let idleMinuteCounter = 0;
-
-    const startWarningInterval = () => {
-      if (warningHandle !== null) clearInterval(warningHandle);
-      idleMinuteCounter = 0;
-      warningHandle = setInterval(() => {
-        idleMinuteCounter++;
-        onIdleWarning(idleMinuteCounter);
-      }, idleWarningIntervalMs);
-    };
-
-    const resetIdleTimer = () => {
-      if (timeoutHandle !== null) clearTimeout(timeoutHandle);
-      timeoutHandle = setTimeout(() => {
-        Effect.runPromise(
-          Deferred.fail(
-            timeoutSignal,
-            new AgentIdleTimeoutError({
-              message: `Agent idle for ${idleTimeoutMs / 1000} seconds — no output received. Consider increasing the idle timeout with --idle-timeout.`,
-              timeoutMs: idleTimeoutMs,
-            }),
-          ),
-        ).catch(() => {});
-      }, idleTimeoutMs);
-      // Reset warning interval on activity
-      startWarningInterval();
-    };
-
-    // Deferred that will be resolved (as a defect) when the AbortSignal fires.
-    // Uses Effect.die so the abort reason propagates as-is to run().
-    const abortDeferred = yield* Deferred.make<never, never>();
-    let abortCleanup: (() => void) | null = null;
-    if (signal) {
-      if (signal.aborted) {
-        return yield* Effect.die(signal.reason);
-      }
-      const onAbort = () => {
-        Effect.runPromise(Deferred.die(abortDeferred, signal.reason)).catch(
-          () => {},
-        );
-      };
-      signal.addEventListener("abort", onAbort, { once: true });
-      abortCleanup = () => signal.removeEventListener("abort", onAbort);
-    }
-
-    resetIdleTimer();
-
-    const execEffect = Effect.gen(function* () {
-      const printCmd = provider.buildPrintCommand({
-        prompt,
-        dangerouslySkipPermissions: true,
-        resumeSession,
-      });
-      const execResult = yield* sandbox.exec(printCmd.command, {
-        onLine: (line) => {
-          resetIdleTimer();
-          for (const parsed of provider.parseStreamLine(line)) {
-            if (parsed.type === "text") {
-              onText(parsed.text);
-            } else if (parsed.type === "result") {
-              resultText = parsed.result;
-            } else if (parsed.type === "tool_call") {
-              onToolCall(parsed.name, parsed.args);
-            } else if (parsed.type === "session_id") {
-              sessionId = parsed.sessionId;
-            }
-          }
-        },
-        cwd: sandboxRepoDir,
-        stdin: printCmd.stdin,
-      });
-
-      if (execResult.exitCode !== 0) {
-        return yield* Effect.fail(
-          new AgentError({
-            message: `${provider.name} exited with code ${execResult.exitCode}:\n${execResult.stderr}`,
-          }),
-        );
-      }
-
-      return { result: resultText || execResult.stdout, sessionId };
-    }).pipe(
-      Effect.ensuring(
-        Effect.sync(() => {
-          if (timeoutHandle !== null) {
-            clearTimeout(timeoutHandle);
-            timeoutHandle = null;
-          }
-          if (warningHandle !== null) {
-            clearInterval(warningHandle);
-            warningHandle = null;
-          }
-        }),
-      ),
-    );
-
-    let raced = Effect.raceFirst(execEffect, Deferred.await(timeoutSignal));
-    if (signal) {
-      raced = Effect.raceFirst(
-        raced,
-        Deferred.await(abortDeferred) as Effect.Effect<never, never>,
-      );
-    }
-
-    return yield* raced.pipe(
-      Effect.ensuring(
-        Effect.sync(() => {
-          abortCleanup?.();
-        }),
-      ),
-    );
-  });
 
 const DEFAULT_COMPLETION_SIGNAL = "<promise>COMPLETE</promise>";
 const DEFAULT_IDLE_TIMEOUT_SECONDS = 10 * 60; // 600 seconds
@@ -209,13 +67,15 @@ export const orchestrate = (
 ): Effect.Effect<
   OrchestrateResult,
   SandboxError,
-  SandboxFactory | Display | SessionPaths
+  SandboxFactory | Display | SessionPaths | AgentInvoker | PromptPreprocessor
 > => {
   const idleTimeoutMs =
     (options.idleTimeoutSeconds ?? DEFAULT_IDLE_TIMEOUT_SECONDS) * 1000;
   return Effect.gen(function* () {
     const factory = yield* SandboxFactory;
     const display = yield* Display;
+    const agentInvoker = yield* AgentInvoker;
+    const promptPreprocessor = yield* PromptPreprocessor;
     const { hostProjectsDir, sandboxProjectsDir } = yield* SessionPaths;
     const { hostRepoDir, iterations, hooks, prompt, branch, provider } =
       options;
@@ -283,7 +143,7 @@ export const orchestrate = (
                 }
 
                 // Preprocess prompt (run !`command` expressions inside sandbox)
-                const fullPrompt = yield* preprocessPrompt(
+                const fullPrompt = yield* promptPreprocessor.preprocess(
                   prompt,
                   ctx.sandbox,
                   ctx.sandboxRepoDir,
@@ -310,19 +170,20 @@ export const orchestrate = (
                       : `Agent idle for ${minutes} minutes`;
                   Effect.runPromise(display.status(label(msg), "warn"));
                 };
-                const { result: agentOutput, sessionId } = yield* invokeAgent(
-                  ctx.sandbox,
-                  ctx.sandboxRepoDir,
-                  fullPrompt,
-                  provider,
-                  idleTimeoutMs,
-                  onText,
-                  onToolCall,
-                  onIdleWarning,
-                  options._idleWarningIntervalMs,
-                  iterationResumeSession,
-                  options.signal,
-                );
+                const { result: agentOutput, sessionId } =
+                  yield* agentInvoker.invoke({
+                    sandbox: ctx.sandbox,
+                    sandboxRepoDir: ctx.sandboxRepoDir,
+                    prompt: fullPrompt,
+                    provider,
+                    idleTimeoutMs,
+                    onText,
+                    onToolCall,
+                    onIdleWarning,
+                    idleWarningIntervalMs: options._idleWarningIntervalMs,
+                    resumeSession: iterationResumeSession,
+                    signal: options.signal,
+                  });
 
                 // Flush any remaining buffered text deltas
                 textBuffer.dispose();

--- a/src/PromptPreprocessorTag.ts
+++ b/src/PromptPreprocessorTag.ts
@@ -1,0 +1,32 @@
+import { Context, Effect, Layer } from "effect";
+import { Display } from "./Display.js";
+import { preprocessPrompt } from "./PromptPreprocessor.js";
+import type { SandboxService } from "./SandboxFactory.js";
+import type {
+  ExecError,
+  PromptError,
+  PromptExpansionTimeoutError,
+} from "./errors.js";
+
+export interface PromptPreprocessorService {
+  readonly preprocess: (
+    prompt: string,
+    sandbox: SandboxService,
+    cwd: string,
+  ) => Effect.Effect<
+    string,
+    ExecError | PromptError | PromptExpansionTimeoutError,
+    Display
+  >;
+}
+
+export class PromptPreprocessor extends Context.Tag("PromptPreprocessor")<
+  PromptPreprocessor,
+  PromptPreprocessorService
+>() {}
+
+/** Production layer — delegates to the existing shell-expression expansion. */
+export const ProductionPromptPreprocessorLayer: Layer.Layer<PromptPreprocessor> =
+  Layer.succeed(PromptPreprocessor, {
+    preprocess: preprocessPrompt,
+  });

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -13,6 +13,8 @@ import { resolveEnv } from "./EnvResolver.js";
 import { mergeProviderEnv } from "./mergeProviderEnv.js";
 import { orchestrate, type IterationResult } from "./Orchestrator.js";
 import { defaultSessionPathsLayer } from "./SessionPaths.js";
+import { ProductionAgentInvokerLayer } from "./AgentInvoker.js";
+import { ProductionPromptPreprocessorLayer } from "./PromptPreprocessorTag.js";
 import {
   type PromptArgs,
   substitutePromptArgs,
@@ -289,6 +291,8 @@ const buildSandboxHandle = (
         reuseFactoryLayer,
         runDisplayLayer,
         defaultSessionPathsLayer,
+        ProductionAgentInvokerLayer,
+        ProductionPromptPreprocessorLayer,
       );
 
       let result;

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -6,6 +6,8 @@ import { hostSessionStore } from "./SessionStore.js";
 import type { AgentProvider } from "./AgentProvider.js";
 import { ClackDisplay, Display, FileDisplay } from "./Display.js";
 import { preprocessPrompt } from "./PromptPreprocessor.js";
+import { ProductionAgentInvokerLayer } from "./AgentInvoker.js";
+import { ProductionPromptPreprocessorLayer } from "./PromptPreprocessorTag.js";
 import { resolvePrompt } from "./PromptResolver.js";
 import {
   SandboxFactory,
@@ -580,6 +582,8 @@ export const createWorktree = async (
         reuseFactoryLayer,
         runDisplayLayer,
         defaultSessionPathsLayer,
+        ProductionAgentInvokerLayer,
+        ProductionPromptPreprocessorLayer,
       );
 
       // 7. Run orchestration

--- a/src/initTemplateE2e.test.ts
+++ b/src/initTemplateE2e.test.ts
@@ -1,0 +1,110 @@
+/**
+ * E2E tests for init templates — scaffolds the template, dynamically imports
+ * the generated main.mts with @ai-hero/sandcastle aliased (via vitest.config.ts)
+ * to the internal testSupport module, and asserts the recorded agent invocations.
+ *
+ * No Docker, no real agent, no network.
+ */
+import { NodeFileSystem } from "@effect/platform-node";
+import { exec } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  scaffold,
+  getAgent,
+  getBacklogManager,
+} from "./InitService.js";
+import {
+  clearRecordedInvocations,
+  getRecordedInvocations,
+} from "./testSupport.js";
+
+const execAsync = promisify(exec);
+
+describe("init-template e2e", () => {
+  let scaffoldDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    scaffoldDir = await mkdtemp(join(tmpdir(), "init-template-e2e-"));
+
+    // Create a git repo in the scaffold dir so that branch resolution works
+    await execAsync("git init -b main", { cwd: scaffoldDir });
+    await execAsync('git config user.email "test@sandcastle.local"', {
+      cwd: scaffoldDir,
+    });
+    await execAsync('git config user.name "Sandcastle Test"', {
+      cwd: scaffoldDir,
+    });
+    // Need at least one commit for git branch operations
+    await execAsync("git commit --allow-empty -m 'initial commit'", {
+      cwd: scaffoldDir,
+    });
+
+    clearRecordedInvocations();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    try {
+      await rm(scaffoldDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  describe("blank template", () => {
+    it("scaffolds and executes with claudeCode agent, github-issues backlog manager", async () => {
+      const agent = getAgent("claude-code")!;
+      const backlogManager = getBacklogManager("github-issues")!;
+
+      // Scaffold the blank template
+      const result = await Effect.runPromise(
+        scaffold(scaffoldDir, {
+          agent,
+          model: "claude-opus-4-6",
+          templateName: "blank",
+          createLabel: true,
+          backlogManager,
+        }).pipe(Effect.provide(NodeFileSystem.layer)),
+      );
+
+      // Verify the main file was created
+      const mainFilePath = join(
+        scaffoldDir,
+        ".sandcastle",
+        result.mainFilename,
+      );
+      const mainContent = await readFile(mainFilePath, "utf-8");
+      expect(mainContent).toContain("run");
+      expect(mainContent).toContain("claudeCode");
+
+      // Read the expected prompt content
+      const promptPath = join(scaffoldDir, ".sandcastle", "prompt.md");
+      const expectedPrompt = await readFile(promptPath, "utf-8");
+
+      // chdir to the scaffold dir so relative prompt file paths resolve
+      process.chdir(scaffoldDir);
+
+      // Dynamically import the scaffolded main file.
+      // The vitest alias rewrites @ai-hero/sandcastle → testSupport.ts
+      // which exports runForTest as run, so the template runs unchanged.
+      await import(mainFilePath);
+
+      // Assert the recorded invocation
+      const invocations = getRecordedInvocations();
+      expect(invocations).toHaveLength(1);
+
+      const invocation = invocations[0]!;
+      expect(invocation.agentProvider).toBe("claude-code");
+      expect(invocation.model).toBe("claude-opus-4-6");
+      expect(invocation.prompt).toBe(expectedPrompt);
+      expect(invocation.branchStrategy).toEqual({ type: "head" });
+      expect(invocation.maxIterations).toBe(1);
+      expect(invocation.iterationIndex).toBe(1);
+    });
+  });
+});

--- a/src/initTemplateE2e.test.ts
+++ b/src/initTemplateE2e.test.ts
@@ -166,30 +166,18 @@ describe("init-template e2e", () => {
           );
           await import(mainFilePath);
 
-          // Assert: only one recorded invocation (completion signal stops loop)
+          // Only one invocation: completion signal stops the loop on iteration 1
           const invocations = getRecordedInvocations();
           expect(invocations).toHaveLength(1);
 
           const invocation = invocations[0]!;
-
-          // Assert: agent provider matches the --agent choice
           expect(invocation.agentProvider).toBe(agentName);
-
-          // Assert: model matches the agent's defaultModel
           expect(invocation.model).toBe(agent.defaultModel);
-
-          // Assert: recorded prompt matches the scaffolded prompt
           expect(invocation.prompt).toBe(expectedPrompt);
-
-          // Assert: branch strategy from the template (merge-to-head)
           expect(invocation.branchStrategy).toEqual({
             type: "merge-to-head",
           });
-
-          // Assert: maxIterations from the template (3)
           expect(invocation.maxIterations).toBe(3);
-
-          // Assert: only first iteration ran (completion signal on iteration 1)
           expect(invocation.iterationIndex).toBe(1);
         });
       },
@@ -271,62 +259,34 @@ describe("init-template e2e", () => {
           // First invocation: implement phase
           // -----------------------------------------------------------------
           const implement = invocations[0]!;
-
-          // Agent provider matches the --agent choice
           expect(implement.agentProvider).toBe(agentName);
-
-          // Model matches the agent's defaultModel
           expect(implement.model).toBe(agent.defaultModel);
-
-          // Recorded prompt matches the scaffolded implement-prompt.md
           expect(implement.prompt).toBe(expectedImplementPrompt);
-
-          // Branch strategy from the template (merge-to-head)
           expect(implement.branchStrategy).toEqual({
             type: "merge-to-head",
           });
-
-          // maxIterations from the template (100)
           expect(implement.maxIterations).toBe(100);
-
-          // Run name from the template
           expect(implement.runName).toBe("implementer");
-
-          // No user-provided prompt args for the implement phase
           expect(implement.promptArgs).toEqual({});
 
           // -----------------------------------------------------------------
           // Second invocation: review phase
           // -----------------------------------------------------------------
           const review = invocations[1]!;
-
-          // Agent provider matches the --agent choice
           expect(review.agentProvider).toBe(agentName);
-
-          // Model matches the agent's defaultModel
           expect(review.model).toBe(agent.defaultModel);
 
-          // Review prompt has {{BRANCH}} substituted with the branch name.
-          // The implement result branch is "main" (the scaffoldDir's branch).
           const expectedReviewPrompt = expectedReviewPromptRaw.replace(
             /\{\{BRANCH\}\}/g,
             "main",
           );
           expect(review.prompt).toBe(expectedReviewPrompt);
-
-          // Branch strategy: explicit branch targeting the implement branch
           expect(review.branchStrategy).toEqual({
             type: "branch",
             branch: "main",
           });
-
-          // maxIterations from the template (1)
           expect(review.maxIterations).toBe(1);
-
-          // Run name from the template
           expect(review.runName).toBe("reviewer");
-
-          // Prompt args: BRANCH is passed through
           expect(review.promptArgs).toEqual({ BRANCH: "main" });
         });
       },
@@ -346,7 +306,6 @@ describe("init-template e2e", () => {
   ].join("\n");
 
   describe("parallel-planner template", () => {
-
     describe.each(combinations)(
       "agent=$agentName, backlog-manager=$bmName",
       ({ agentName, bmName }) => {
@@ -437,61 +396,32 @@ describe("init-template e2e", () => {
           // Phase 1: Plan
           // -----------------------------------------------------------
           const plan = invocations[0]!;
-
-          // Agent provider matches the --agent choice
           expect(plan.agentProvider).toBe(agentName);
-
-          // Model matches the agent's defaultModel (scaffold rewrites all
-          // factory calls to the same model)
           expect(plan.model).toBe(agent.defaultModel);
-
-          // Recorded prompt matches the scaffolded plan-prompt.md
           expect(plan.prompt).toBe(expectedPlanPrompt);
-
-          // No explicit branchStrategy → default head
           expect(plan.branchStrategy).toEqual({ type: "head" });
-
-          // maxIterations from the template (1)
           expect(plan.maxIterations).toBe(1);
-
-          // Run name from the template
           expect(plan.runName).toBe("planner");
-
-          // No user-provided prompt args for the plan phase
           expect(plan.promptArgs).toEqual({});
 
           // -----------------------------------------------------------
           // Phase 2: Implement (one issue from the plan)
           // -----------------------------------------------------------
           const implement = invocations[1]!;
-
-          // Agent provider matches the --agent choice
           expect(implement.agentProvider).toBe(agentName);
-
-          // Model matches the agent's defaultModel
           expect(implement.model).toBe(agent.defaultModel);
 
-          // Implement prompt has {{TASK_ID}}, {{ISSUE_TITLE}}, {{BRANCH}}
-          // substituted with the plan issue's values.
           const expectedImplementPrompt = expectedImplementPromptRaw
             .replace(/\{\{TASK_ID\}\}/g, planIssue.id)
             .replace(/\{\{ISSUE_TITLE\}\}/g, planIssue.title)
             .replace(/\{\{BRANCH\}\}/g, planIssue.branch);
           expect(implement.prompt).toBe(expectedImplementPrompt);
-
-          // Branch strategy: explicit branch targeting the plan issue's branch
           expect(implement.branchStrategy).toEqual({
             type: "branch",
             branch: planIssue.branch,
           });
-
-          // maxIterations from the template (100)
           expect(implement.maxIterations).toBe(100);
-
-          // Run name from the template
           expect(implement.runName).toBe("implementer");
-
-          // Prompt args: TASK_ID, ISSUE_TITLE, BRANCH from the plan issue
           expect(implement.promptArgs).toEqual({
             TASK_ID: planIssue.id,
             ISSUE_TITLE: planIssue.title,
@@ -502,31 +432,18 @@ describe("init-template e2e", () => {
           // Phase 3: Merge
           // -----------------------------------------------------------
           const merge = invocations[2]!;
-
-          // Agent provider matches the --agent choice
           expect(merge.agentProvider).toBe(agentName);
-
-          // Model matches the agent's defaultModel
           expect(merge.model).toBe(agent.defaultModel);
 
-          // Merge prompt has {{BRANCHES}} and {{ISSUES}} substituted
           const expectedBranches = `- ${planIssue.branch}`;
           const expectedIssues = `- ${planIssue.id}: ${planIssue.title}`;
           const expectedMergePrompt = expectedMergePromptRaw
             .replace(/\{\{BRANCHES\}\}/g, expectedBranches)
             .replace(/\{\{ISSUES\}\}/g, expectedIssues);
           expect(merge.prompt).toBe(expectedMergePrompt);
-
-          // No explicit branchStrategy → default head
           expect(merge.branchStrategy).toEqual({ type: "head" });
-
-          // maxIterations from the template (1)
           expect(merge.maxIterations).toBe(1);
-
-          // Run name from the template
           expect(merge.runName).toBe("merger");
-
-          // Prompt args: BRANCHES and ISSUES lists
           expect(merge.promptArgs).toEqual({
             BRANCHES: expectedBranches,
             ISSUES: expectedIssues,

--- a/src/initTemplateE2e.test.ts
+++ b/src/initTemplateE2e.test.ts
@@ -333,18 +333,19 @@ describe("init-template e2e", () => {
     );
   });
 
+  // Plan data shared by parallel-planner and parallel-planner-with-review
+  // tests — one issue to exercise all phases.
+  const planIssue = {
+    id: "42",
+    title: "Fix auth bug",
+    branch: "sandcastle/issue-42-fix-auth-bug",
+  };
+  const planResponse = [
+    `<plan>${JSON.stringify({ issues: [planIssue] })}</plan>`,
+    "<promise>COMPLETE</promise>",
+  ].join("\n");
+
   describe("parallel-planner template", () => {
-    // Plan data returned by the planner agent — one issue to exercise all
-    // three phases (plan → implement → merge).
-    const planIssue = {
-      id: "42",
-      title: "Fix auth bug",
-      branch: "sandcastle/issue-42-fix-auth-bug",
-    };
-    const planResponse = [
-      `<plan>${JSON.stringify({ issues: [planIssue] })}</plan>`,
-      "<promise>COMPLETE</promise>",
-    ].join("\n");
 
     describe.each(combinations)(
       "agent=$agentName, backlog-manager=$bmName",
@@ -526,6 +527,194 @@ describe("init-template e2e", () => {
           expect(merge.runName).toBe("merger");
 
           // Prompt args: BRANCHES and ISSUES lists
+          expect(merge.promptArgs).toEqual({
+            BRANCHES: expectedBranches,
+            ISSUES: expectedIssues,
+          });
+        });
+      },
+    );
+  });
+
+  describe("parallel-planner-with-review template", () => {
+    describe.each(combinations)(
+      "agent=$agentName, backlog-manager=$bmName",
+      ({ agentName, bmName }) => {
+        it("scaffolds and executes plan→implement→review→merge pipeline", async () => {
+          const agent = getAgent(agentName)!;
+          const backlogManager = getBacklogManager(bmName)!;
+
+          // Scaffold the parallel-planner-with-review template
+          const result = await Effect.runPromise(
+            scaffold(scaffoldDir, {
+              agent,
+              model: agent.defaultModel,
+              templateName: "parallel-planner-with-review",
+              createLabel: true,
+              backlogManager,
+            }).pipe(Effect.provide(NodeFileSystem.layer)),
+          );
+
+          const mainFilePath = join(
+            scaffoldDir,
+            ".sandcastle",
+            result.mainFilename,
+          );
+
+          // Patch MAX_ITERATIONS to 1 so only one plan→execute→review→merge
+          // cycle runs.
+          let mainContent = await readFile(mainFilePath, "utf-8");
+          mainContent = mainContent.replace(
+            /const MAX_ITERATIONS = \d+;/,
+            "const MAX_ITERATIONS = 1;",
+          );
+          await writeFile(mainFilePath, mainContent);
+
+          // Read expected prompts from the scaffolded template files
+          const planPromptPath = join(
+            scaffoldDir,
+            ".sandcastle",
+            "plan-prompt.md",
+          );
+          const implementPromptPath = join(
+            scaffoldDir,
+            ".sandcastle",
+            "implement-prompt.md",
+          );
+          const reviewPromptPath = join(
+            scaffoldDir,
+            ".sandcastle",
+            "review-prompt.md",
+          );
+          const mergePromptPath = join(
+            scaffoldDir,
+            ".sandcastle",
+            "merge-prompt.md",
+          );
+          const expectedPlanPrompt = await readFile(planPromptPath, "utf-8");
+          const expectedImplementPromptRaw = await readFile(
+            implementPromptPath,
+            "utf-8",
+          );
+          const expectedReviewPromptRaw = await readFile(
+            reviewPromptPath,
+            "utf-8",
+          );
+          const expectedMergePromptRaw = await readFile(
+            mergePromptPath,
+            "utf-8",
+          );
+
+          // Assert the prompts contain backlog-manager shell expressions
+          // (pre-expansion, since IdentityPromptPreprocessor is used)
+          const allPromptText = [
+            expectedPlanPrompt,
+            expectedImplementPromptRaw,
+            expectedReviewPromptRaw,
+            expectedMergePromptRaw,
+          ].join("\n");
+          for (const expr of shellExpressionsByBm[bmName]!) {
+            expect(allPromptText).toContain(expr);
+          }
+
+          // Configure the planner to return a valid plan so the template
+          // proceeds through all four phases.
+          setStdoutByRunName({ planner: planResponse });
+
+          // chdir to the scaffold dir so relative prompt file paths resolve
+          process.chdir(scaffoldDir);
+
+          try {
+            await import(mainFilePath);
+          } finally {
+            setStdoutByRunName(undefined);
+          }
+
+          // Assert: 4 recorded invocations (plan + implement + review + merge)
+          const invocations = getRecordedInvocations();
+          expect(invocations).toHaveLength(4);
+
+          // -----------------------------------------------------------
+          // Phase 1: Plan
+          // -----------------------------------------------------------
+          const plan = invocations[0]!;
+
+          expect(plan.agentProvider).toBe(agentName);
+          expect(plan.model).toBe(agent.defaultModel);
+          expect(plan.prompt).toBe(expectedPlanPrompt);
+          expect(plan.branchStrategy).toEqual({ type: "head" });
+          expect(plan.maxIterations).toBe(1);
+          expect(plan.runName).toBe("planner");
+          expect(plan.promptArgs).toEqual({});
+
+          // -----------------------------------------------------------
+          // Phase 2: Implement (one issue from the plan)
+          // -----------------------------------------------------------
+          const implement = invocations[1]!;
+
+          expect(implement.agentProvider).toBe(agentName);
+          expect(implement.model).toBe(agent.defaultModel);
+
+          const expectedImplementPrompt = expectedImplementPromptRaw
+            .replace(/\{\{TASK_ID\}\}/g, planIssue.id)
+            .replace(/\{\{ISSUE_TITLE\}\}/g, planIssue.title)
+            .replace(/\{\{BRANCH\}\}/g, planIssue.branch);
+          expect(implement.prompt).toBe(expectedImplementPrompt);
+
+          expect(implement.branchStrategy).toEqual({
+            type: "branch",
+            branch: planIssue.branch,
+          });
+          expect(implement.maxIterations).toBe(100);
+          expect(implement.runName).toBe("implementer");
+          expect(implement.promptArgs).toEqual({
+            TASK_ID: planIssue.id,
+            ISSUE_TITLE: planIssue.title,
+            BRANCH: planIssue.branch,
+          });
+
+          // -----------------------------------------------------------
+          // Phase 3: Review (runs because implementer produced commits)
+          // -----------------------------------------------------------
+          const review = invocations[2]!;
+
+          expect(review.agentProvider).toBe(agentName);
+          expect(review.model).toBe(agent.defaultModel);
+
+          const expectedReviewPrompt = expectedReviewPromptRaw.replace(
+            /\{\{BRANCH\}\}/g,
+            planIssue.branch,
+          );
+          expect(review.prompt).toBe(expectedReviewPrompt);
+
+          expect(review.branchStrategy).toEqual({
+            type: "branch",
+            branch: planIssue.branch,
+          });
+          expect(review.maxIterations).toBe(1);
+          expect(review.runName).toBe("reviewer");
+          expect(review.promptArgs).toEqual({
+            BRANCH: planIssue.branch,
+          });
+
+          // -----------------------------------------------------------
+          // Phase 4: Merge
+          // -----------------------------------------------------------
+          const merge = invocations[3]!;
+
+          expect(merge.agentProvider).toBe(agentName);
+          expect(merge.model).toBe(agent.defaultModel);
+
+          const expectedBranches = `- ${planIssue.branch}`;
+          const expectedIssues = `- ${planIssue.id}: ${planIssue.title}`;
+          const expectedMergePrompt = expectedMergePromptRaw
+            .replace(/\{\{BRANCHES\}\}/g, expectedBranches)
+            .replace(/\{\{ISSUES\}\}/g, expectedIssues);
+          expect(merge.prompt).toBe(expectedMergePrompt);
+
+          expect(merge.branchStrategy).toEqual({ type: "head" });
+          expect(merge.maxIterations).toBe(1);
+          expect(merge.runName).toBe("merger");
           expect(merge.promptArgs).toEqual({
             BRANCHES: expectedBranches,
             ISSUES: expectedIssues,

--- a/src/initTemplateE2e.test.ts
+++ b/src/initTemplateE2e.test.ts
@@ -17,6 +17,8 @@ import {
   scaffold,
   getAgent,
   getBacklogManager,
+  listAgents,
+  listBacklogManagers,
 } from "./InitService.js";
 import {
   clearRecordedInvocations,
@@ -106,5 +108,90 @@ describe("init-template e2e", () => {
       expect(invocation.maxIterations).toBe(1);
       expect(invocation.iterationIndex).toBe(1);
     });
+  });
+
+  describe("simple-loop template", () => {
+    const agents = listAgents();
+    const backlogManagers = listBacklogManagers();
+
+    const combinations = agents.flatMap((agent) =>
+      backlogManagers.map((bm) => ({
+        agentName: agent.name,
+        bmName: bm.name,
+      })),
+    );
+
+    /** Shell expression substrings expected per backlog manager. */
+    const shellExpressionsByBm: Record<string, string[]> = {
+      "github-issues": ["gh issue list", "gh issue close"],
+      beads: ["bd ready", "bd close"],
+    };
+
+    describe.each(combinations)(
+      "agent=$agentName, backlog-manager=$bmName",
+      ({ agentName, bmName }) => {
+        it("scaffolds and executes with iterate-until-COMPLETE wiring", async () => {
+          const agent = getAgent(agentName)!;
+          const backlogManager = getBacklogManager(bmName)!;
+
+          // Scaffold the simple-loop template
+          const result = await Effect.runPromise(
+            scaffold(scaffoldDir, {
+              agent,
+              model: agent.defaultModel,
+              templateName: "simple-loop",
+              createLabel: true,
+              backlogManager,
+            }).pipe(Effect.provide(NodeFileSystem.layer)),
+          );
+
+          // Read the expected prompt content
+          const promptPath = join(scaffoldDir, ".sandcastle", "prompt.md");
+          const expectedPrompt = await readFile(promptPath, "utf-8");
+
+          // Assert the prompt contains the backlog-manager's shell expressions
+          for (const expr of shellExpressionsByBm[bmName]!) {
+            expect(expectedPrompt).toContain(expr);
+          }
+
+          // chdir to the scaffold dir so relative prompt file paths resolve
+          process.chdir(scaffoldDir);
+
+          // Dynamically import the scaffolded main file.
+          const mainFilePath = join(
+            scaffoldDir,
+            ".sandcastle",
+            result.mainFilename,
+          );
+          await import(mainFilePath);
+
+          // Assert: only one recorded invocation (completion signal stops loop)
+          const invocations = getRecordedInvocations();
+          expect(invocations).toHaveLength(1);
+
+          const invocation = invocations[0]!;
+
+          // Assert: agent provider matches the --agent choice
+          expect(invocation.agentProvider).toBe(agentName);
+
+          // Assert: model matches the agent's defaultModel
+          expect(invocation.model).toBe(agent.defaultModel);
+
+          // Assert: recorded prompt matches the scaffolded prompt
+          expect(invocation.prompt).toBe(expectedPrompt);
+
+          // Assert: branch strategy from the template (merge-to-head)
+          expect(invocation.branchStrategy).toEqual({
+            type: "merge-to-head",
+          });
+
+          // Assert: maxIterations from the template (3)
+          expect(invocation.maxIterations).toBe(3);
+
+          // Assert: only first iteration ran (completion signal on iteration 1)
+          expect(invocation.iterationIndex).toBe(1);
+        });
+      },
+    );
   });
 });

--- a/src/initTemplateE2e.test.ts
+++ b/src/initTemplateE2e.test.ts
@@ -7,7 +7,7 @@
  */
 import { NodeFileSystem } from "@effect/platform-node";
 import { exec } from "node:child_process";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -190,6 +190,159 @@ describe("init-template e2e", () => {
 
           // Assert: only first iteration ran (completion signal on iteration 1)
           expect(invocation.iterationIndex).toBe(1);
+        });
+      },
+    );
+  });
+
+  describe("sequential-reviewer template", () => {
+    const agents = listAgents();
+    const backlogManagers = listBacklogManagers();
+
+    const combinations = agents.flatMap((agent) =>
+      backlogManagers.map((bm) => ({
+        agentName: agent.name,
+        bmName: bm.name,
+      })),
+    );
+
+    /** Shell expression substrings expected per backlog manager (implement prompt only). */
+    const shellExpressionsByBm: Record<string, string[]> = {
+      "github-issues": ["gh issue list", "gh issue close"],
+      beads: ["bd ready", "bd close"],
+    };
+
+    describe.each(combinations)(
+      "agent=$agentName, backlog-manager=$bmName",
+      ({ agentName, bmName }) => {
+        it("scaffolds and executes implement→review cycle", async () => {
+          const agent = getAgent(agentName)!;
+          const backlogManager = getBacklogManager(bmName)!;
+
+          // Scaffold the sequential-reviewer template
+          const result = await Effect.runPromise(
+            scaffold(scaffoldDir, {
+              agent,
+              model: agent.defaultModel,
+              templateName: "sequential-reviewer",
+              createLabel: true,
+              backlogManager,
+            }).pipe(Effect.provide(NodeFileSystem.layer)),
+          );
+
+          const mainFilePath = join(
+            scaffoldDir,
+            ".sandcastle",
+            result.mainFilename,
+          );
+
+          // Patch MAX_ITERATIONS to 1 so only one implement→review cycle runs.
+          // The template uses a for-loop; without this patch it would run 10
+          // cycles, each producing 2 recorded invocations.
+          let mainContent = await readFile(mainFilePath, "utf-8");
+          mainContent = mainContent.replace(
+            /const MAX_ITERATIONS = \d+;/,
+            "const MAX_ITERATIONS = 1;",
+          );
+          await writeFile(mainFilePath, mainContent);
+
+          // Read expected prompts from the scaffolded template files
+          const implementPromptPath = join(
+            scaffoldDir,
+            ".sandcastle",
+            "implement-prompt.md",
+          );
+          const reviewPromptPath = join(
+            scaffoldDir,
+            ".sandcastle",
+            "review-prompt.md",
+          );
+          const expectedImplementPrompt = await readFile(
+            implementPromptPath,
+            "utf-8",
+          );
+          const expectedReviewPromptRaw = await readFile(
+            reviewPromptPath,
+            "utf-8",
+          );
+
+          // Assert the implement prompt contains the backlog-manager's shell
+          // expressions (pre-expansion, since IdentityPromptPreprocessor is used)
+          for (const expr of shellExpressionsByBm[bmName]!) {
+            expect(expectedImplementPrompt).toContain(expr);
+          }
+
+          // chdir to the scaffold dir so relative prompt file paths resolve
+          process.chdir(scaffoldDir);
+
+          // Dynamically import the scaffolded main file.
+          await import(mainFilePath);
+
+          // Assert: exactly 2 recorded invocations (implement + review)
+          const invocations = getRecordedInvocations();
+          expect(invocations).toHaveLength(2);
+
+          // -----------------------------------------------------------------
+          // First invocation: implement phase
+          // -----------------------------------------------------------------
+          const implement = invocations[0]!;
+
+          // Agent provider matches the --agent choice
+          expect(implement.agentProvider).toBe(agentName);
+
+          // Model matches the agent's defaultModel
+          expect(implement.model).toBe(agent.defaultModel);
+
+          // Recorded prompt matches the scaffolded implement-prompt.md
+          expect(implement.prompt).toBe(expectedImplementPrompt);
+
+          // Branch strategy from the template (merge-to-head)
+          expect(implement.branchStrategy).toEqual({
+            type: "merge-to-head",
+          });
+
+          // maxIterations from the template (100)
+          expect(implement.maxIterations).toBe(100);
+
+          // Run name from the template
+          expect(implement.runName).toBe("implementer");
+
+          // No user-provided prompt args for the implement phase
+          expect(implement.promptArgs).toEqual({});
+
+          // -----------------------------------------------------------------
+          // Second invocation: review phase
+          // -----------------------------------------------------------------
+          const review = invocations[1]!;
+
+          // Agent provider matches the --agent choice
+          expect(review.agentProvider).toBe(agentName);
+
+          // Model matches the agent's defaultModel
+          expect(review.model).toBe(agent.defaultModel);
+
+          // Review prompt has {{BRANCH}} substituted with the branch name.
+          // The implement result branch is "main" (the scaffoldDir's branch).
+          const expectedReviewPrompt = expectedReviewPromptRaw.replace(
+            /\{\{BRANCH\}\}/g,
+            "main",
+          );
+          expect(review.prompt).toBe(expectedReviewPrompt);
+
+          // Branch strategy: explicit branch targeting the implement branch
+          expect(review.branchStrategy).toEqual({
+            type: "branch",
+            branch: "main",
+          });
+
+          // maxIterations from the template (1)
+          expect(review.maxIterations).toBe(1);
+
+          // Run name from the template
+          expect(review.runName).toBe("reviewer");
+
+          // Prompt args: BRANCH is passed through
+          expect(review.promptArgs).toEqual({ BRANCH: "main" });
         });
       },
     );

--- a/src/initTemplateE2e.test.ts
+++ b/src/initTemplateE2e.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   clearRecordedInvocations,
   getRecordedInvocations,
+  setStdoutByRunName,
 } from "./testSupport.js";
 
 const execAsync = promisify(exec);
@@ -327,6 +328,208 @@ describe("init-template e2e", () => {
 
           // Prompt args: BRANCH is passed through
           expect(review.promptArgs).toEqual({ BRANCH: "main" });
+        });
+      },
+    );
+  });
+
+  describe("parallel-planner template", () => {
+    // Plan data returned by the planner agent — one issue to exercise all
+    // three phases (plan → implement → merge).
+    const planIssue = {
+      id: "42",
+      title: "Fix auth bug",
+      branch: "sandcastle/issue-42-fix-auth-bug",
+    };
+    const planResponse = [
+      `<plan>${JSON.stringify({ issues: [planIssue] })}</plan>`,
+      "<promise>COMPLETE</promise>",
+    ].join("\n");
+
+    describe.each(combinations)(
+      "agent=$agentName, backlog-manager=$bmName",
+      ({ agentName, bmName }) => {
+        it("scaffolds and executes plan→implement→merge pipeline", async () => {
+          const agent = getAgent(agentName)!;
+          const backlogManager = getBacklogManager(bmName)!;
+
+          // Scaffold the parallel-planner template
+          const result = await Effect.runPromise(
+            scaffold(scaffoldDir, {
+              agent,
+              model: agent.defaultModel,
+              templateName: "parallel-planner",
+              createLabel: true,
+              backlogManager,
+            }).pipe(Effect.provide(NodeFileSystem.layer)),
+          );
+
+          const mainFilePath = join(
+            scaffoldDir,
+            ".sandcastle",
+            result.mainFilename,
+          );
+
+          // Patch MAX_ITERATIONS to 1 so only one plan→execute→merge cycle runs.
+          let mainContent = await readFile(mainFilePath, "utf-8");
+          mainContent = mainContent.replace(
+            /const MAX_ITERATIONS = \d+;/,
+            "const MAX_ITERATIONS = 1;",
+          );
+          await writeFile(mainFilePath, mainContent);
+
+          // Read expected prompts from the scaffolded template files
+          const planPromptPath = join(
+            scaffoldDir,
+            ".sandcastle",
+            "plan-prompt.md",
+          );
+          const implementPromptPath = join(
+            scaffoldDir,
+            ".sandcastle",
+            "implement-prompt.md",
+          );
+          const mergePromptPath = join(
+            scaffoldDir,
+            ".sandcastle",
+            "merge-prompt.md",
+          );
+          const expectedPlanPrompt = await readFile(planPromptPath, "utf-8");
+          const expectedImplementPromptRaw = await readFile(
+            implementPromptPath,
+            "utf-8",
+          );
+          const expectedMergePromptRaw = await readFile(
+            mergePromptPath,
+            "utf-8",
+          );
+
+          // Assert the prompts contain backlog-manager shell expressions
+          // (pre-expansion, since IdentityPromptPreprocessor is used)
+          const allPromptText = [
+            expectedPlanPrompt,
+            expectedImplementPromptRaw,
+            expectedMergePromptRaw,
+          ].join("\n");
+          for (const expr of shellExpressionsByBm[bmName]!) {
+            expect(allPromptText).toContain(expr);
+          }
+
+          // Configure the planner to return a valid plan so the template
+          // proceeds through all three phases.
+          setStdoutByRunName({ planner: planResponse });
+
+          // chdir to the scaffold dir so relative prompt file paths resolve
+          process.chdir(scaffoldDir);
+
+          try {
+            await import(mainFilePath);
+          } finally {
+            setStdoutByRunName(undefined);
+          }
+
+          // Assert: 3 recorded invocations (plan + implement + merge)
+          const invocations = getRecordedInvocations();
+          expect(invocations).toHaveLength(3);
+
+          // -----------------------------------------------------------
+          // Phase 1: Plan
+          // -----------------------------------------------------------
+          const plan = invocations[0]!;
+
+          // Agent provider matches the --agent choice
+          expect(plan.agentProvider).toBe(agentName);
+
+          // Model matches the agent's defaultModel (scaffold rewrites all
+          // factory calls to the same model)
+          expect(plan.model).toBe(agent.defaultModel);
+
+          // Recorded prompt matches the scaffolded plan-prompt.md
+          expect(plan.prompt).toBe(expectedPlanPrompt);
+
+          // No explicit branchStrategy → default head
+          expect(plan.branchStrategy).toEqual({ type: "head" });
+
+          // maxIterations from the template (1)
+          expect(plan.maxIterations).toBe(1);
+
+          // Run name from the template
+          expect(plan.runName).toBe("planner");
+
+          // No user-provided prompt args for the plan phase
+          expect(plan.promptArgs).toEqual({});
+
+          // -----------------------------------------------------------
+          // Phase 2: Implement (one issue from the plan)
+          // -----------------------------------------------------------
+          const implement = invocations[1]!;
+
+          // Agent provider matches the --agent choice
+          expect(implement.agentProvider).toBe(agentName);
+
+          // Model matches the agent's defaultModel
+          expect(implement.model).toBe(agent.defaultModel);
+
+          // Implement prompt has {{TASK_ID}}, {{ISSUE_TITLE}}, {{BRANCH}}
+          // substituted with the plan issue's values.
+          const expectedImplementPrompt = expectedImplementPromptRaw
+            .replace(/\{\{TASK_ID\}\}/g, planIssue.id)
+            .replace(/\{\{ISSUE_TITLE\}\}/g, planIssue.title)
+            .replace(/\{\{BRANCH\}\}/g, planIssue.branch);
+          expect(implement.prompt).toBe(expectedImplementPrompt);
+
+          // Branch strategy: explicit branch targeting the plan issue's branch
+          expect(implement.branchStrategy).toEqual({
+            type: "branch",
+            branch: planIssue.branch,
+          });
+
+          // maxIterations from the template (100)
+          expect(implement.maxIterations).toBe(100);
+
+          // Run name from the template
+          expect(implement.runName).toBe("implementer");
+
+          // Prompt args: TASK_ID, ISSUE_TITLE, BRANCH from the plan issue
+          expect(implement.promptArgs).toEqual({
+            TASK_ID: planIssue.id,
+            ISSUE_TITLE: planIssue.title,
+            BRANCH: planIssue.branch,
+          });
+
+          // -----------------------------------------------------------
+          // Phase 3: Merge
+          // -----------------------------------------------------------
+          const merge = invocations[2]!;
+
+          // Agent provider matches the --agent choice
+          expect(merge.agentProvider).toBe(agentName);
+
+          // Model matches the agent's defaultModel
+          expect(merge.model).toBe(agent.defaultModel);
+
+          // Merge prompt has {{BRANCHES}} and {{ISSUES}} substituted
+          const expectedBranches = `- ${planIssue.branch}`;
+          const expectedIssues = `- ${planIssue.id}: ${planIssue.title}`;
+          const expectedMergePrompt = expectedMergePromptRaw
+            .replace(/\{\{BRANCHES\}\}/g, expectedBranches)
+            .replace(/\{\{ISSUES\}\}/g, expectedIssues);
+          expect(merge.prompt).toBe(expectedMergePrompt);
+
+          // No explicit branchStrategy → default head
+          expect(merge.branchStrategy).toEqual({ type: "head" });
+
+          // maxIterations from the template (1)
+          expect(merge.maxIterations).toBe(1);
+
+          // Run name from the template
+          expect(merge.runName).toBe("merger");
+
+          // Prompt args: BRANCHES and ISSUES lists
+          expect(merge.promptArgs).toEqual({
+            BRANCHES: expectedBranches,
+            ISSUES: expectedIssues,
+          });
         });
       },
     );

--- a/src/initTemplateE2e.test.ts
+++ b/src/initTemplateE2e.test.ts
@@ -110,23 +110,23 @@ describe("init-template e2e", () => {
     });
   });
 
+  const agents = listAgents();
+  const backlogManagers = listBacklogManagers();
+
+  const combinations = agents.flatMap((agent) =>
+    backlogManagers.map((bm) => ({
+      agentName: agent.name,
+      bmName: bm.name,
+    })),
+  );
+
+  /** Shell expression substrings expected per backlog manager. */
+  const shellExpressionsByBm: Record<string, string[]> = {
+    "github-issues": ["gh issue list", "gh issue close"],
+    beads: ["bd ready", "bd close"],
+  };
+
   describe("simple-loop template", () => {
-    const agents = listAgents();
-    const backlogManagers = listBacklogManagers();
-
-    const combinations = agents.flatMap((agent) =>
-      backlogManagers.map((bm) => ({
-        agentName: agent.name,
-        bmName: bm.name,
-      })),
-    );
-
-    /** Shell expression substrings expected per backlog manager. */
-    const shellExpressionsByBm: Record<string, string[]> = {
-      "github-issues": ["gh issue list", "gh issue close"],
-      beads: ["bd ready", "bd close"],
-    };
-
     describe.each(combinations)(
       "agent=$agentName, backlog-manager=$bmName",
       ({ agentName, bmName }) => {
@@ -196,22 +196,6 @@ describe("init-template e2e", () => {
   });
 
   describe("sequential-reviewer template", () => {
-    const agents = listAgents();
-    const backlogManagers = listBacklogManagers();
-
-    const combinations = agents.flatMap((agent) =>
-      backlogManagers.map((bm) => ({
-        agentName: agent.name,
-        bmName: bm.name,
-      })),
-    );
-
-    /** Shell expression substrings expected per backlog manager (implement prompt only). */
-    const shellExpressionsByBm: Record<string, string[]> = {
-      "github-issues": ["gh issue list", "gh issue close"],
-      beads: ["bd ready", "bd close"],
-    };
-
     describe.each(combinations)(
       "agent=$agentName, backlog-manager=$bmName",
       ({ agentName, bmName }) => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -21,6 +21,8 @@ import {
   WorktreeDockerSandboxFactory,
   SandboxConfig,
 } from "./SandboxFactory.js";
+import { ProductionAgentInvokerLayer } from "./AgentInvoker.js";
+import { ProductionPromptPreprocessorLayer } from "./PromptPreprocessorTag.js";
 import type { SandboxProvider, BranchStrategy } from "./SandboxProvider.js";
 import { resolveEnv } from "./EnvResolver.js";
 import { formatErrorMessage } from "./ErrorHandler.js";
@@ -380,6 +382,8 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
     factoryLayer,
     displayLayer,
     defaultSessionPathsLayer,
+    ProductionAgentInvokerLayer,
+    ProductionPromptPreprocessorLayer,
   );
 
   const baseEffect = Effect.gen(function* () {

--- a/src/testSupport.ts
+++ b/src/testSupport.ts
@@ -1,0 +1,345 @@
+/**
+ * Internal test-support module for init-template e2e tests.
+ *
+ * NOT a published subpath of @ai-hero/sandcastle.
+ * Exports: runForTest, recording agent-invoker layer, identity preprocessor
+ * layer, and a recorder accessor.
+ */
+import { NodeContext, NodeFileSystem } from "@effect/platform-node";
+import { Effect, Layer, Ref } from "effect";
+import { resolveCwd } from "./resolveCwd.js";
+import type { AgentProvider } from "./AgentProvider.js";
+import { SilentDisplay, type DisplayEntry } from "./Display.js";
+import {
+  orchestrate,
+  type OrchestrateResult,
+} from "./Orchestrator.js";
+import { resolvePrompt } from "./PromptResolver.js";
+import { defaultSessionPathsLayer } from "./SessionPaths.js";
+import { getCurrentBranch, generateTempBranchName } from "./WorktreeManager.js";
+import {
+  type PromptArgs,
+  substitutePromptArgs,
+  validateNoBuiltInArgOverride,
+  BUILT_IN_PROMPT_ARG_KEYS,
+} from "./PromptArgumentSubstitution.js";
+import { AgentInvoker, type AgentInvocation } from "./AgentInvoker.js";
+import { PromptPreprocessor } from "./PromptPreprocessorTag.js";
+import { makeLocalSandboxFactoryLayer } from "./LocalSandboxFactory.js";
+import type { BranchStrategy } from "./SandboxProvider.js";
+import type { RunOptions, RunResult } from "./run.js";
+import { DEFAULT_MAX_ITERATIONS } from "./run.js";
+
+// -----------------------------------------------------------------------
+// Recorded invocation type
+// -----------------------------------------------------------------------
+
+export interface RecordedInvocation {
+  readonly prompt: string;
+  readonly promptArgs: PromptArgs;
+  readonly agentProvider: string;
+  readonly model: string;
+  readonly branchStrategy: BranchStrategy;
+  readonly maxIterations: number;
+  readonly runName: string | undefined;
+  readonly iterationIndex: number;
+}
+
+// -----------------------------------------------------------------------
+// Recorder — shared mutable state for recording invocations
+// -----------------------------------------------------------------------
+
+let _invocations: RecordedInvocation[] = [];
+
+export const getRecordedInvocations = (): ReadonlyArray<RecordedInvocation> =>
+  _invocations;
+
+export const clearRecordedInvocations = (): void => {
+  _invocations = [];
+};
+
+// -----------------------------------------------------------------------
+// Recording AgentInvoker layer
+// -----------------------------------------------------------------------
+
+const DEFAULT_COMPLETION_SIGNAL = "<promise>COMPLETE</promise>";
+
+/**
+ * A test AgentInvoker that records each invocation and returns the default
+ * completion signal after one iteration, causing multi-iteration templates
+ * to terminate predictably.
+ */
+/**
+ * Extract the --model value from the provider's print command.
+ */
+const extractModelFromProvider = (provider: AgentProvider): string => {
+  try {
+    const cmd = provider.buildPrintCommand({
+      prompt: "",
+      dangerouslySkipPermissions: false,
+    });
+    const match = cmd.command.match(/--model\s+'([^']+)'/);
+    if (match) return match[1]!;
+    const match2 = cmd.command.match(/--model\s+(\S+)/);
+    if (match2) return match2[1]!;
+  } catch {}
+  return "unknown";
+};
+
+export const makeRecordingAgentInvokerLayer = (
+  context: {
+    promptArgs: PromptArgs;
+    branchStrategy: BranchStrategy;
+    maxIterations: number;
+    runName: string | undefined;
+  },
+): Layer.Layer<AgentInvoker> => {
+  let iterationCounter = 0;
+
+  return Layer.succeed(AgentInvoker, {
+    invoke: (
+      invocation: AgentInvocation,
+    ) =>
+      Effect.sync(() => {
+        iterationCounter++;
+        _invocations.push({
+          prompt: invocation.prompt,
+          promptArgs: context.promptArgs,
+          agentProvider: invocation.provider.name,
+          model: extractModelFromProvider(invocation.provider),
+          branchStrategy: context.branchStrategy,
+          maxIterations: context.maxIterations,
+          runName: context.runName,
+          iterationIndex: iterationCounter,
+        });
+
+        return {
+          result: `Agent completed. ${DEFAULT_COMPLETION_SIGNAL}`,
+          sessionId: undefined,
+        };
+      }),
+  });
+};
+
+// -----------------------------------------------------------------------
+// Identity PromptPreprocessor layer
+// -----------------------------------------------------------------------
+
+/**
+ * A test PromptPreprocessor that returns the prompt unchanged (no shell
+ * expression expansion). This ensures the recorded prompt is
+ * post-argument-substitution but pre-shell-expression-expansion.
+ */
+export const IdentityPromptPreprocessorLayer: Layer.Layer<PromptPreprocessor> =
+  Layer.succeed(PromptPreprocessor, {
+    preprocess: (prompt, _sandbox, _cwd) => Effect.succeed(prompt),
+  });
+
+// -----------------------------------------------------------------------
+// runForTest — same signature as run(), wired with test layers
+// -----------------------------------------------------------------------
+
+export const runForTest = async (options: RunOptions): Promise<RunResult> => {
+  // If signal is already aborted, reject immediately
+  options.signal?.throwIfAborted();
+
+  const {
+    prompt,
+    promptFile,
+    maxIterations = DEFAULT_MAX_ITERATIONS,
+    hooks,
+    agent: provider,
+  } = options;
+
+  // Derive branch strategy: explicit option > default for test
+  // In tests, default to "head" since LocalSandboxFactory supports all modes
+  const branchStrategy: BranchStrategy =
+    options.branchStrategy ?? { type: "head" };
+
+  // Extract explicit branch when in branch mode
+  const branch: string | undefined =
+    branchStrategy.type === "branch" ? branchStrategy.branch : undefined;
+
+  const hostRepoDir = await Effect.runPromise(
+    resolveCwd(options.cwd).pipe(Effect.provide(NodeContext.layer)),
+  );
+
+  // Resolve prompt (production behaviour)
+  const rawPrompt = await Effect.runPromise(
+    resolvePrompt({ prompt, promptFile }).pipe(
+      Effect.provide(NodeContext.layer),
+    ),
+  );
+
+  // Get current branch from the host repo for prompt argument substitution
+  const currentHostBranch = await Effect.runPromise(
+    getCurrentBranch(hostRepoDir),
+  );
+
+  const effectiveBranchType = branchStrategy.type;
+  const resolvedBranch =
+    effectiveBranchType === "head"
+      ? currentHostBranch
+      : (branch ?? generateTempBranchName(options.name));
+
+  // Test layers
+  const displayLayer = SilentDisplay.layer(
+    Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]),
+  );
+
+  const factoryLayer = makeLocalSandboxFactoryLayer({
+    branchStrategy,
+  });
+
+  const userArgs = options.promptArgs ?? {};
+
+  const agentInvokerLayer = makeRecordingAgentInvokerLayer({
+    promptArgs: userArgs,
+    branchStrategy,
+    maxIterations,
+    runName: options.name,
+  });
+
+  const runLayer = Layer.mergeAll(
+    factoryLayer,
+    displayLayer,
+    defaultSessionPathsLayer,
+    agentInvokerLayer,
+    IdentityPromptPreprocessorLayer,
+  );
+
+  const baseEffect = Effect.gen(function* () {
+    // Production prompt-arg substitution
+    yield* validateNoBuiltInArgOverride(userArgs);
+
+    const effectiveArgs = {
+      SOURCE_BRANCH: resolvedBranch,
+      TARGET_BRANCH: currentHostBranch,
+      ...userArgs,
+    };
+    const builtInArgKeysSet = new Set<string>(BUILT_IN_PROMPT_ARG_KEYS);
+    const resolvedPrompt = yield* substitutePromptArgs(
+      rawPrompt,
+      effectiveArgs,
+      builtInArgKeysSet,
+    );
+
+    const orchestrateBranch =
+      effectiveBranchType === "head" ? currentHostBranch : branch;
+
+    const orchestrateResult = yield* orchestrate({
+      hostRepoDir,
+      iterations: maxIterations,
+      hooks,
+      prompt: resolvedPrompt,
+      branch: orchestrateBranch,
+      provider,
+      completionSignal: options.completionSignal,
+      idleTimeoutSeconds: options.idleTimeoutSeconds,
+      name: options.name,
+      signal: options.signal,
+    });
+
+    return orchestrateResult;
+  });
+
+  let result: OrchestrateResult;
+  try {
+    result = await Effect.runPromise(
+      baseEffect.pipe(Effect.provide(runLayer)),
+    );
+  } catch (error: unknown) {
+    options.signal?.throwIfAborted();
+    throw error;
+  }
+
+  return {
+    ...result,
+    logFilePath: undefined,
+  };
+};
+
+// Re-export everything from index so templates can import from the test alias.
+// IMPORTANT: export runForTest AS run so the generated main.mts uses it unchanged.
+export { runForTest as run };
+export type {
+  RunOptions,
+  RunResult,
+  LoggingOption,
+  IterationResult,
+  IterationUsage,
+} from "./run.js";
+export { interactive } from "./interactive.js";
+export type { InteractiveOptions, InteractiveResult } from "./interactive.js";
+export { createSandbox } from "./createSandbox.js";
+export type {
+  CreateSandboxOptions,
+  Sandbox,
+  SandboxRunOptions,
+  SandboxRunResult,
+  SandboxInteractiveOptions,
+  SandboxInteractiveResult,
+  CloseResult,
+} from "./createSandbox.js";
+export { createWorktree } from "./createWorktree.js";
+export type {
+  CreateWorktreeOptions,
+  Worktree,
+  WorktreeBranchStrategy,
+  WorktreeInteractiveOptions,
+  WorktreeRunOptions,
+  WorktreeRunResult,
+  WorktreeCreateSandboxOptions,
+} from "./createWorktree.js";
+export type { PromptArgs } from "./PromptArgumentSubstitution.js";
+export {
+  hostSessionStore,
+  sandboxSessionStore,
+  transferSession,
+} from "./SessionStore.js";
+export type { SessionStore } from "./SessionStore.js";
+export {
+  SessionPaths,
+  sessionPathsLayer,
+  defaultSessionPathsLayer,
+} from "./SessionPaths.js";
+export type { SandboxHooks } from "./SandboxLifecycle.js";
+export type { MountConfig } from "./MountConfig.js";
+export { CwdError } from "./resolveCwd.js";
+export { claudeCode, codex, opencode, pi } from "./AgentProvider.js";
+export type {
+  AgentProvider,
+  AgentCommandOptions,
+  PrintCommand,
+  ClaudeCodeOptions,
+  CodexOptions,
+  OpenCodeOptions,
+  PiOptions,
+} from "./AgentProvider.js";
+export {
+  createBindMountSandboxProvider,
+  createIsolatedSandboxProvider,
+} from "./SandboxProvider.js";
+export type {
+  SandboxProvider,
+  AnySandboxProvider,
+  BindMountSandboxProvider,
+  IsolatedSandboxProvider,
+  NoSandboxProvider,
+  BindMountSandboxHandle,
+  IsolatedSandboxHandle,
+  NoSandboxHandle,
+  InteractiveExecOptions,
+  ExecResult,
+  BindMountCreateOptions,
+  BindMountSandboxProviderConfig,
+  IsolatedCreateOptions,
+  IsolatedSandboxProviderConfig,
+  BranchStrategy,
+  BindMountBranchStrategy,
+  IsolatedBranchStrategy,
+  NoSandboxBranchStrategy,
+  HeadBranchStrategy,
+  MergeToHeadBranchStrategy,
+  NamedBranchStrategy,
+} from "./SandboxProvider.js";

--- a/src/testSupport.ts
+++ b/src/testSupport.ts
@@ -5,7 +5,7 @@
  * Exports: runForTest, recording agent-invoker layer, identity preprocessor
  * layer, and a recorder accessor.
  */
-import { NodeContext, NodeFileSystem } from "@effect/platform-node";
+import { NodeContext } from "@effect/platform-node";
 import { Effect, Layer, Ref } from "effect";
 import { resolveCwd } from "./resolveCwd.js";
 import type { AgentProvider } from "./AgentProvider.js";
@@ -64,11 +64,6 @@ export const clearRecordedInvocations = (): void => {
 
 const DEFAULT_COMPLETION_SIGNAL = "<promise>COMPLETE</promise>";
 
-/**
- * A test AgentInvoker that records each invocation and returns the default
- * completion signal after one iteration, causing multi-iteration templates
- * to terminate predictably.
- */
 /**
  * Extract the --model value from the provider's print command.
  */

--- a/src/testSupport.ts
+++ b/src/testSupport.ts
@@ -29,6 +29,12 @@ import { makeLocalSandboxFactoryLayer } from "./LocalSandboxFactory.js";
 import type { BranchStrategy } from "./SandboxProvider.js";
 import type { RunOptions, RunResult } from "./run.js";
 import { DEFAULT_MAX_ITERATIONS } from "./run.js";
+import type {
+  CreateSandboxOptions,
+  Sandbox,
+  SandboxRunOptions,
+  SandboxRunResult,
+} from "./createSandbox.js";
 
 // -----------------------------------------------------------------------
 // Recorded invocation type
@@ -285,6 +291,56 @@ export const runForTest = async (options: RunOptions): Promise<RunResult> => {
   };
 };
 
+// -----------------------------------------------------------------------
+// Test createSandbox — delegates sandbox.run() calls to runForTest so that
+// templates using createSandbox() record invocations through the same
+// recording agent invoker as top-level run() calls.
+// -----------------------------------------------------------------------
+
+const createSandboxForTest = async (
+  options: CreateSandboxOptions,
+): Promise<Sandbox> => {
+  const branch = options.branch;
+
+  return {
+    branch,
+    worktreePath: process.cwd(),
+
+    async run(runOptions: SandboxRunOptions): Promise<SandboxRunResult> {
+      const result = await runForTest({
+        agent: runOptions.agent,
+        sandbox: undefined as any, // runForTest ignores sandbox
+        prompt: runOptions.prompt,
+        promptFile: runOptions.promptFile,
+        promptArgs: runOptions.promptArgs,
+        maxIterations: runOptions.maxIterations,
+        name: runOptions.name,
+        completionSignal: runOptions.completionSignal,
+        idleTimeoutSeconds: runOptions.idleTimeoutSeconds,
+        signal: runOptions.signal,
+        branchStrategy: { type: "branch", branch },
+      });
+      return {
+        iterations: result.iterations,
+        completionSignal: result.completionSignal,
+        stdout: result.stdout,
+        commits: result.commits,
+        logFilePath: result.logFilePath,
+      };
+    },
+
+    async interactive(): Promise<never> {
+      throw new Error("interactive() not supported in test createSandbox");
+    },
+
+    async close() {
+      return {};
+    },
+
+    async [Symbol.asyncDispose]() {},
+  };
+};
+
 // Re-export everything from index so templates can import from the test alias.
 // IMPORTANT: export runForTest AS run so the generated main.mts uses it unchanged.
 export { runForTest as run };
@@ -297,7 +353,7 @@ export type {
 } from "./run.js";
 export { interactive } from "./interactive.js";
 export type { InteractiveOptions, InteractiveResult } from "./interactive.js";
-export { createSandbox } from "./createSandbox.js";
+export { createSandboxForTest as createSandbox };
 export type {
   CreateSandboxOptions,
   Sandbox,

--- a/src/testSupport.ts
+++ b/src/testSupport.ts
@@ -252,6 +252,14 @@ export const runForTest = async (options: RunOptions): Promise<RunResult> => {
 
   return {
     ...result,
+    // In the test environment the recording invoker doesn't make real git
+    // commits, so result.commits is always empty. Inject a synthetic commit
+    // so templates that guard on commits.length (e.g. sequential-reviewer's
+    // "skip review if no commits") can proceed past the guard.
+    commits:
+      result.commits.length > 0
+        ? result.commits
+        : [{ sha: "synthetic-test-commit" }],
     logFilePath: undefined,
   };
 };

--- a/src/testSupport.ts
+++ b/src/testSupport.ts
@@ -73,9 +73,11 @@ const extractModelFromProvider = (provider: AgentProvider): string => {
       prompt: "",
       dangerouslySkipPermissions: false,
     });
-    const match = cmd.command.match(/--model\s+'([^']+)'/);
+    // Match --model 'quoted' or -m 'quoted'
+    const match = cmd.command.match(/(?:--model|-m)\s+'([^']+)'/);
     if (match) return match[1]!;
-    const match2 = cmd.command.match(/--model\s+(\S+)/);
+    // Match --model unquoted or -m unquoted
+    const match2 = cmd.command.match(/(?:--model|-m)\s+(\S+)/);
     if (match2) return match2[1]!;
   } catch {}
   return "unknown";

--- a/src/testSupport.ts
+++ b/src/testSupport.ts
@@ -59,6 +59,23 @@ export const clearRecordedInvocations = (): void => {
 };
 
 // -----------------------------------------------------------------------
+// Per-runName stdout override — allows tests to control the response
+// returned by the recording invoker for specific run names.
+// -----------------------------------------------------------------------
+
+let _stdoutByRunName: Record<string, string> | undefined;
+
+/**
+ * Set per-runName response overrides for the recording agent invoker.
+ * Pass `undefined` to clear all overrides.
+ */
+export const setStdoutByRunName = (
+  map: Record<string, string> | undefined,
+): void => {
+  _stdoutByRunName = map;
+};
+
+// -----------------------------------------------------------------------
 // Recording AgentInvoker layer
 // -----------------------------------------------------------------------
 
@@ -110,8 +127,12 @@ export const makeRecordingAgentInvokerLayer = (
           iterationIndex: iterationCounter,
         });
 
+        const response =
+          (context.runName && _stdoutByRunName?.[context.runName]) ??
+          `Agent completed. ${DEFAULT_COMPLETION_SIGNAL}`;
+
         return {
-          result: `Agent completed. ${DEFAULT_COMPLETION_SIGNAL}`,
+          result: response,
           sessionId: undefined,
         };
       }),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,26 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Alias @ai-hero/sandcastle subpath imports first (more specific match)
+      "@ai-hero/sandcastle/sandboxes/docker": resolve(
+        __dirname,
+        "src/sandboxes/docker.ts",
+      ),
+      "@ai-hero/sandcastle/sandboxes/podman": resolve(
+        __dirname,
+        "src/sandboxes/podman.ts",
+      ),
+      "@ai-hero/sandcastle/sandboxes/no-sandbox": resolve(
+        __dirname,
+        "src/sandboxes/no-sandbox.ts",
+      ),
+      // Alias the main package to the test-support module
+      "@ai-hero/sandcastle": resolve(__dirname, "src/testSupport.ts"),
+    },
+  },
   test: {
     include: ["src/**/*.test.ts"],
     globalSetup: ["src/globalSetup.ts"],


### PR DESCRIPTION
Implements PRD #447: end-to-end tests for init templates via an AgentInvoker seam.

Introduces three new deep modules (AgentInvoker Tag, PromptPreprocessor Tag, LocalSandboxFactory) and an internal test-support entry point (`runForTest`). Then adds e2e tests for each init template — blank, simple-loop, sequential-reviewer, parallel-planner, parallel-planner-with-review — parameterised across all valid (agent, backlog-manager) combinations.

Tests scaffold each template into a tmp dir, execute the generated `main.mts` with `@ai-hero/sandcastle` aliased to the internal testing entry via Vitest module aliasing, and assert recorded agent invocations against expected prompt file, prompt arguments, agent provider, model, branch strategy, and call count. No Docker, no real agent, no network.

Closes #447, #448, #449, #450, #451, #452.

Closes #448
Closes #449
Closes #450
Closes #451
Closes #452