### PR TITLE
Fix review-prompt hardcoded main and dropped reviewer commits

### DIFF
--- a/.changeset/fix-review-prompt-hardcoded-main.md
+++ b/.changeset/fix-review-prompt-hardcoded-main.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Replace hardcoded `main` with `{{SOURCE_BRANCH}}` in review-prompt.md templates

--- a/.changeset/fix-reviewer-result-dropped.md
+++ b/.changeset/fix-reviewer-result-dropped.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix parallel-planner-with-review template to capture reviewer result and merge commits from both implementer and reviewer runs

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -945,6 +945,21 @@ describe("InitService scaffold", () => {
       expect(mainTs).toContain("implement.commits.length > 0");
     });
 
+    it("main.mts captures reviewer result and merges commits from both runs", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, { templateName: "parallel-planner-with-review" });
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      // Reviewer result must be captured, not discarded
+      expect(mainTs).toContain("const review = await sandbox.run");
+      // Commits from both implementer and reviewer must be merged
+      expect(mainTs).toContain("implement.commits");
+      expect(mainTs).toContain("review.commits");
+    });
+
     it("main.mts uses Promise.allSettled for parallel execution", async () => {
       const dir = await makeDir();
       await runScaffold(dir, { templateName: "parallel-planner-with-review" });

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -516,6 +516,20 @@ describe("InitService scaffold", () => {
       );
       expect(prompt).toContain("@.sandcastle/CODING_STANDARDS.md");
     });
+
+    it("review-prompt.md uses {{SOURCE_BRANCH}} instead of hardcoded main", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, { templateName: "sequential-reviewer" });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "review-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("git diff {{SOURCE_BRANCH}}...{{BRANCH}}");
+      expect(prompt).toContain("git log {{SOURCE_BRANCH}}..{{BRANCH}}");
+      expect(prompt).not.toContain("git diff main");
+      expect(prompt).not.toContain("git log main");
+    });
   });
 
   it("simple-loop template does not scaffold compiled .js or .d.ts files", async () => {
@@ -1072,6 +1086,20 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(prompt).toContain("@.sandcastle/CODING_STANDARDS.md");
+    });
+
+    it("review-prompt.md uses {{SOURCE_BRANCH}} instead of hardcoded main", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, { templateName: "parallel-planner-with-review" });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "review-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("git diff {{SOURCE_BRANCH}}...{{BRANCH}}");
+      expect(prompt).toContain("git log {{SOURCE_BRANCH}}..{{BRANCH}}");
+      expect(prompt).not.toContain("git diff main");
+      expect(prompt).not.toContain("git log main");
     });
   });
 

--- a/src/templates/parallel-planner-with-review/main.mts
+++ b/src/templates/parallel-planner-with-review/main.mts
@@ -132,7 +132,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
 
         // Only review if the implementer produced commits
         if (implement.commits.length > 0) {
-          await sandbox.run({
+          const review = await sandbox.run({
             name: "reviewer",
             maxIterations: 1,
             agent: sandcastle.claudeCode("claude-sonnet-4-6"),
@@ -141,6 +141,13 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
               BRANCH: issue.branch,
             },
           });
+
+          // Merge commits from both runs so the merge phase sees all of them.
+          // Each sandbox.run() only returns commits from its own run.
+          return {
+            ...review,
+            commits: [...implement.commits, ...review.commits],
+          };
         }
 
         return implement;

--- a/src/templates/parallel-planner-with-review/review-prompt.md
+++ b/src/templates/parallel-planner-with-review/review-prompt.md
@@ -6,11 +6,11 @@ Review the code changes on branch `{{BRANCH}}` and improve code clarity, consist
 
 ## Branch diff
 
-!`git diff main...{{BRANCH}}`
+!`git diff {{SOURCE_BRANCH}}...{{BRANCH}}`
 
 ## Commits on this branch
 
-!`git log main..{{BRANCH}} --oneline`
+!`git log {{SOURCE_BRANCH}}..{{BRANCH}} --oneline`
 
 # REVIEW PROCESS
 

--- a/src/templates/sequential-reviewer/review-prompt.md
+++ b/src/templates/sequential-reviewer/review-prompt.md
@@ -6,11 +6,11 @@ Review the code changes on branch `{{BRANCH}}` and improve code clarity, consist
 
 ## Branch diff
 
-!`git diff main...{{BRANCH}}`
+!`git diff {{SOURCE_BRANCH}}...{{BRANCH}}`
 
 ## Commits on this branch
 
-!`git log main..{{BRANCH}} --oneline`
+!`git log {{SOURCE_BRANCH}}..{{BRANCH}} --oneline`
 
 # REVIEW PROCESS
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `main` with `{{SOURCE_BRANCH}}` in `sequential-reviewer` and `parallel-planner-with-review` review-prompt templates (#443)
- Capture reviewer `RunResult` in `parallel-planner-with-review/main.mts` and merge its commits with the implementer's so reviewer refinement commits aren't dropped from the merge phase (#445)

These two commits were on `implement/template-prompt-fixes` but were not included in the previously-merged PR #456 (which only brought in the implement-prompt close-issue fix).

## Test plan
- [ ] `npm run typecheck`
- [ ] Regression tests in `src/InitService.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)