### PR TITLE
Add worktree locking to prevent concurrent agent access

### DIFF
--- a/.changeset/prune-stale-locks.md
+++ b/.changeset/prune-stale-locks.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add WorktreeLock.pruneStale() to clean up stale lock files alongside orphaned worktree directories during pruneStale()

--- a/.changeset/worktree-lock-contention.md
+++ b/.changeset/worktree-lock-contention.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Enhance WorktreeLock.acquire() with PID-based contention detection and stale lock recovery. Add WorktreeLockError type for diagnostic lock contention errors. Move lock acquisition before worktree creation for named branches to serialize concurrent access.

--- a/.changeset/worktree-lock-module.md
+++ b/.changeset/worktree-lock-module.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add WorktreeLock module with atomic O_EXCL lock acquisition and idempotent release. Wire into createWorktree() and Worktree.close() to track live worktrees in .sandcastle/locks/.

--- a/src/ErrorHandler.ts
+++ b/src/ErrorHandler.ts
@@ -42,6 +42,7 @@ export const formatErrorMessage = (error: SandboxError): string => {
     case "MergeToHostTimeoutError":
     case "SessionCaptureError":
     case "CwdError":
+    case "WorktreeLockError":
       return error.message;
   }
 };
@@ -86,4 +87,5 @@ export const withFriendlyErrors = <A, E, R>(
     MergeToHostTimeoutError: showErrorAndExit,
     SessionCaptureError: showErrorAndExit,
     CwdError: showErrorAndExit,
+    WorktreeLockError: showErrorAndExit,
   }) as Effect.Effect<A, Exclude<E, SandboxError>, R | Display>;

--- a/src/WorktreeLock.test.ts
+++ b/src/WorktreeLock.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   acquire,
+  pruneStale,
   release,
   WorktreeLockError,
   type LockData,
@@ -153,5 +154,75 @@ describe("WorktreeLock", () => {
     } finally {
       await rm(lockDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("WorktreeLock.pruneStale", () => {
+  it("removes lock files whose worktree is not in the active set", async () => {
+    const lockDir = await makeTmpDir();
+    try {
+      // Create a lock for a worktree that is NOT in the active set
+      const lockPath = join(lockDir, "orphan-worktree.lock");
+      const lockData: LockData = {
+        pid: process.pid,
+        branch: "orphan-branch",
+        acquiredAt: new Date().toISOString(),
+      };
+      await writeFile(lockPath, JSON.stringify(lockData, null, 2));
+
+      // Active set does NOT include "orphan-worktree"
+      await pruneStale(lockDir, new Set(["other-worktree"]));
+
+      expect(existsSync(lockPath)).toBe(false);
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
+
+  it("removes lock files whose owning PID is dead", async () => {
+    const lockDir = await makeTmpDir();
+    try {
+      const lockPath = join(lockDir, "dead-pid-worktree.lock");
+      const lockData: LockData = {
+        pid: 999999999, // PID that almost certainly doesn't exist
+        branch: "some-branch",
+        acquiredAt: "2025-01-01T00:00:00.000Z",
+      };
+      await writeFile(lockPath, JSON.stringify(lockData, null, 2));
+
+      // Worktree IS in the active set, but owning PID is dead
+      await pruneStale(lockDir, new Set(["dead-pid-worktree"]));
+
+      expect(existsSync(lockPath)).toBe(false);
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves lock files for live processes with active worktrees", async () => {
+    const lockDir = await makeTmpDir();
+    try {
+      const lockPath = join(lockDir, "live-worktree.lock");
+      const lockData: LockData = {
+        pid: process.pid, // Current process — definitely alive
+        branch: "active-branch",
+        acquiredAt: new Date().toISOString(),
+      };
+      await writeFile(lockPath, JSON.stringify(lockData, null, 2));
+
+      // Worktree IS in the active set and PID is alive
+      await pruneStale(lockDir, new Set(["live-worktree"]));
+
+      expect(existsSync(lockPath)).toBe(true);
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
+
+  it("handles missing lock directory gracefully", async () => {
+    // Pass a path that does not exist
+    await expect(
+      pruneStale("/tmp/nonexistent-lock-dir-" + Date.now(), new Set()),
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/WorktreeLock.test.ts
+++ b/src/WorktreeLock.test.ts
@@ -1,0 +1,83 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { acquire, release, type LockData } from "./WorktreeLock.js";
+
+const makeTmpDir = async (): Promise<string> => {
+  const dir = join(
+    tmpdir(),
+    `lock-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await mkdir(dir, { recursive: true });
+  return dir;
+};
+
+describe("WorktreeLock", () => {
+  it("acquire creates a lock file with correct JSON content", async () => {
+    const lockDir = await makeTmpDir();
+    try {
+      await acquire(lockDir, "test-worktree", "my-branch");
+
+      const lockPath = join(lockDir, "test-worktree.lock");
+      expect(existsSync(lockPath)).toBe(true);
+
+      const data: LockData = JSON.parse(await readFile(lockPath, "utf-8"));
+      expect(data.pid).toBe(process.pid);
+      expect(data.branch).toBe("my-branch");
+      expect(data.acquiredAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
+
+  it("release removes the lock file", async () => {
+    const lockDir = await makeTmpDir();
+    try {
+      await acquire(lockDir, "test-worktree", "my-branch");
+      await release(lockDir, "test-worktree");
+
+      const lockPath = join(lockDir, "test-worktree.lock");
+      expect(existsSync(lockPath)).toBe(false);
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
+
+  it("release is idempotent when lock file does not exist", async () => {
+    const lockDir = await makeTmpDir();
+    try {
+      await expect(
+        release(lockDir, "no-such-worktree"),
+      ).resolves.toBeUndefined();
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
+
+  it("acquire fails if lock file already exists", async () => {
+    const lockDir = await makeTmpDir();
+    try {
+      await acquire(lockDir, "test-worktree", "my-branch");
+      await expect(
+        acquire(lockDir, "test-worktree", "my-branch"),
+      ).rejects.toThrow("Worktree lock already held for 'test-worktree'");
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
+
+  it("acquire creates the lockDir if it does not exist", async () => {
+    const baseDir = await makeTmpDir();
+    const lockDir = join(baseDir, "locks");
+    try {
+      await acquire(lockDir, "test-worktree", "my-branch");
+
+      const lockPath = join(lockDir, "test-worktree.lock");
+      expect(existsSync(lockPath)).toBe(true);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/WorktreeLock.test.ts
+++ b/src/WorktreeLock.test.ts
@@ -1,9 +1,14 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { acquire, release, type LockData } from "./WorktreeLock.js";
+import {
+  acquire,
+  release,
+  WorktreeLockError,
+  type LockData,
+} from "./WorktreeLock.js";
 
 const makeTmpDir = async (): Promise<string> => {
   const dir = join(
@@ -56,13 +61,13 @@ describe("WorktreeLock", () => {
     }
   });
 
-  it("acquire fails if lock file already exists", async () => {
+  it("acquire fails if lock file already exists (live PID)", async () => {
     const lockDir = await makeTmpDir();
     try {
       await acquire(lockDir, "test-worktree", "my-branch");
       await expect(
         acquire(lockDir, "test-worktree", "my-branch"),
-      ).rejects.toThrow("Worktree lock already held for 'test-worktree'");
+      ).rejects.toThrow("Worktree is in use by process");
     } finally {
       await rm(lockDir, { recursive: true, force: true });
     }
@@ -78,6 +83,75 @@ describe("WorktreeLock", () => {
       expect(existsSync(lockPath)).toBe(true);
     } finally {
       await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("acquire throws WorktreeLockError with owning PID when lock held by live process", async () => {
+    const lockDir = await makeTmpDir();
+    try {
+      // Manually write a lock file with the current process PID (which is alive)
+      const lockPath = join(lockDir, "test-worktree.lock");
+      const lockData: LockData = {
+        pid: process.pid,
+        branch: "feature-x",
+        acquiredAt: "2026-01-15T10:00:00.000Z",
+      };
+      await writeFile(lockPath, JSON.stringify(lockData, null, 2));
+
+      const err = await acquire(lockDir, "test-worktree", "other-branch").catch(
+        (e) => e,
+      );
+
+      expect(err).toBeInstanceOf(WorktreeLockError);
+      expect(err.message).toContain(`process ${process.pid}`);
+      expect(err.message).toContain("feature-x");
+      expect(err.owningPid).toBe(process.pid);
+      expect(err.branch).toBe("feature-x");
+      expect(err.timestamp).toBe("2026-01-15T10:00:00.000Z");
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
+
+  it("acquire recovers stale lock when owning PID is dead", async () => {
+    const lockDir = await makeTmpDir();
+    try {
+      // Write a lock file with a PID that almost certainly doesn't exist
+      const lockPath = join(lockDir, "test-worktree.lock");
+      const staleLock: LockData = {
+        pid: 999999999,
+        branch: "stale-branch",
+        acquiredAt: "2025-01-01T00:00:00.000Z",
+      };
+      await writeFile(lockPath, JSON.stringify(staleLock, null, 2));
+
+      // acquire should succeed by removing the stale lock and re-acquiring
+      await acquire(lockDir, "test-worktree", "new-branch");
+
+      // Verify the new lock file has our PID
+      const data: LockData = JSON.parse(await readFile(lockPath, "utf-8"));
+      expect(data.pid).toBe(process.pid);
+      expect(data.branch).toBe("new-branch");
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
+
+  it("two concurrent acquire() calls for the same name — exactly one succeeds", async () => {
+    const lockDir = await makeTmpDir();
+    try {
+      const results = await Promise.allSettled([
+        acquire(lockDir, "race-worktree", "branch-a"),
+        acquire(lockDir, "race-worktree", "branch-b"),
+      ]);
+
+      const fulfilled = results.filter((r) => r.status === "fulfilled");
+      const rejected = results.filter((r) => r.status === "rejected");
+
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/WorktreeLock.ts
+++ b/src/WorktreeLock.ts
@@ -1,0 +1,69 @@
+import { constants } from "node:fs";
+import { mkdir, open, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface LockData {
+  pid: number;
+  branch: string;
+  acquiredAt: string;
+}
+
+/**
+ * Acquires a lock for a worktree using O_EXCL atomic file creation.
+ * Creates the lockDir on first use.
+ * Throws if a lock file already exists for the given worktreeName.
+ */
+export const acquire = async (
+  lockDir: string,
+  worktreeName: string,
+  branch: string,
+): Promise<void> => {
+  await mkdir(lockDir, { recursive: true });
+  const lockPath = join(lockDir, `${worktreeName}.lock`);
+
+  let fd;
+  try {
+    fd = await open(
+      lockPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
+    );
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new Error(
+        `Worktree lock already held for '${worktreeName}' (lock file: ${lockPath})`,
+      );
+    }
+    throw err;
+  }
+
+  const data: LockData = {
+    pid: process.pid,
+    branch,
+    acquiredAt: new Date().toISOString(),
+  };
+
+  try {
+    await fd.writeFile(JSON.stringify(data, null, 2));
+  } finally {
+    await fd.close();
+  }
+};
+
+/**
+ * Releases a lock for a worktree by removing the lock file.
+ * Idempotent: does not throw if the lock file does not exist.
+ */
+export const release = async (
+  lockDir: string,
+  worktreeName: string,
+): Promise<void> => {
+  const lockPath = join(lockDir, `${worktreeName}.lock`);
+  try {
+    await rm(lockPath);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+};

--- a/src/WorktreeLock.ts
+++ b/src/WorktreeLock.ts
@@ -1,6 +1,6 @@
 import { constants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
-import { mkdir, open, readFile, rm } from "node:fs/promises";
+import { mkdir, open, readdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { WorktreeLockError } from "./errors.js";
 
@@ -133,5 +133,53 @@ export const release = async (
       return;
     }
     throw err;
+  }
+};
+
+/**
+ * Removes stale lock files from the lock directory.
+ *
+ * A lock is stale if:
+ * - Its worktree name is not in the active set (orphaned lock), OR
+ * - Its worktree name IS active but the owning PID is dead (crashed process)
+ *
+ * Live locks for active worktrees are preserved.
+ * Handles a missing lockDir gracefully (no error).
+ */
+export const pruneStale = async (
+  lockDir: string,
+  activeWorktreeNames: Set<string>,
+): Promise<void> => {
+  let entries: string[];
+  try {
+    entries = await readdir(lockDir);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw err;
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".lock")) continue;
+
+    const worktreeName = entry.slice(0, -".lock".length);
+    const lockPath = join(lockDir, entry);
+
+    if (!activeWorktreeNames.has(worktreeName)) {
+      // Orphaned lock — worktree no longer exists
+      await rm(lockPath, { force: true });
+      continue;
+    }
+
+    // Active worktree — check PID liveness
+    try {
+      const raw = await readFile(lockPath, "utf-8");
+      const lockData = JSON.parse(raw) as LockData;
+      if (!isPidAlive(lockData.pid)) {
+        await rm(lockPath, { force: true });
+      }
+    } catch {
+      // Corrupt/unreadable lock — treat as stale
+      await rm(lockPath, { force: true });
+    }
   }
 };

--- a/src/WorktreeLock.ts
+++ b/src/WorktreeLock.ts
@@ -1,4 +1,5 @@
 import { constants } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
 import { mkdir, open, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { WorktreeLockError } from "./errors.js";
@@ -24,6 +25,41 @@ const isPidAlive = (pid: number): boolean => {
   }
 };
 
+const CREATE_FLAGS = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL;
+
+/**
+ * Remove a stale lock file, then retry atomic O_EXCL creation.
+ * If the retry loses a race (another process created the file first),
+ * throws a WorktreeLockError with the winner's diagnostic info.
+ */
+const removeStaleAndRetry = async (
+  lockPath: string,
+  worktreeName: string,
+): Promise<FileHandle> => {
+  await rm(lockPath, { force: true });
+  try {
+    return await open(lockPath, CREATE_FLAGS);
+  } catch (retryErr: unknown) {
+    if ((retryErr as NodeJS.ErrnoException).code !== "EEXIST") throw retryErr;
+    // Another process raced us and won — re-read to report contention
+    try {
+      const raw = await readFile(lockPath, "utf-8");
+      const winner = JSON.parse(raw) as LockData;
+      throw new WorktreeLockError({
+        message: `Worktree is in use by process ${winner.pid} (branch '${winner.branch}', acquired at ${winner.acquiredAt})`,
+        owningPid: winner.pid,
+        branch: winner.branch,
+        timestamp: winner.acquiredAt,
+      });
+    } catch (readErr) {
+      if (readErr instanceof WorktreeLockError) throw readErr;
+      throw new Error(
+        `Worktree lock already held for '${worktreeName}' (lock file: ${lockPath})`,
+      );
+    }
+  }
+};
+
 /**
  * Acquires a lock for a worktree using O_EXCL atomic file creation.
  * Creates the lockDir on first use.
@@ -40,82 +76,32 @@ export const acquire = async (
   await mkdir(lockDir, { recursive: true });
   const lockPath = join(lockDir, `${worktreeName}.lock`);
 
-  const tryCreate = async (): Promise<
-    import("node:fs/promises").FileHandle
-  > => {
-    return await open(
-      lockPath,
-      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
-    );
-  };
-
-  let fd;
+  let fd: FileHandle;
   try {
-    fd = await tryCreate();
+    fd = await open(lockPath, CREATE_FLAGS);
   } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-      // Lock file exists — check PID liveness
-      let lockData: LockData;
-      try {
-        const raw = await readFile(lockPath, "utf-8");
-        lockData = JSON.parse(raw) as LockData;
-      } catch {
-        // Lock file is corrupt or unreadable — treat as stale
-        await rm(lockPath, { force: true });
-        try {
-          fd = await tryCreate();
-        } catch (retryErr: unknown) {
-          if ((retryErr as NodeJS.ErrnoException).code === "EEXIST") {
-            throw new Error(
-              `Worktree lock already held for '${worktreeName}' (lock file: ${lockPath})`,
-            );
-          }
-          throw retryErr;
-        }
-        // fd acquired after stale removal — fall through to write
-        lockData = undefined as unknown as LockData;
-      }
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
 
-      if (lockData) {
-        if (isPidAlive(lockData.pid)) {
-          // Active contention — throw diagnostic error
-          throw new WorktreeLockError({
-            message: `Worktree is in use by process ${lockData.pid} (branch '${lockData.branch}', acquired at ${lockData.acquiredAt})`,
-            owningPid: lockData.pid,
-            branch: lockData.branch,
-            timestamp: lockData.acquiredAt,
-          });
-        }
-
-        // PID is dead — remove stale lock and retry
-        await rm(lockPath, { force: true });
-        try {
-          fd = await tryCreate();
-        } catch (retryErr: unknown) {
-          if ((retryErr as NodeJS.ErrnoException).code === "EEXIST") {
-            // Another process raced us and won — re-read to report contention
-            try {
-              const raw = await readFile(lockPath, "utf-8");
-              const newLock = JSON.parse(raw) as LockData;
-              throw new WorktreeLockError({
-                message: `Worktree is in use by process ${newLock.pid} (branch '${newLock.branch}', acquired at ${newLock.acquiredAt})`,
-                owningPid: newLock.pid,
-                branch: newLock.branch,
-                timestamp: newLock.acquiredAt,
-              });
-            } catch (readErr) {
-              if (readErr instanceof WorktreeLockError) throw readErr;
-              throw new Error(
-                `Worktree lock already held for '${worktreeName}' (lock file: ${lockPath})`,
-              );
-            }
-          }
-          throw retryErr;
-        }
-      }
-    } else {
-      throw err;
+    // Lock file exists — read and check PID liveness
+    let lockData: LockData | undefined;
+    try {
+      const raw = await readFile(lockPath, "utf-8");
+      lockData = JSON.parse(raw) as LockData;
+    } catch {
+      // Corrupt or unreadable — treat as stale
     }
+
+    if (lockData && isPidAlive(lockData.pid)) {
+      throw new WorktreeLockError({
+        message: `Worktree is in use by process ${lockData.pid} (branch '${lockData.branch}', acquired at ${lockData.acquiredAt})`,
+        owningPid: lockData.pid,
+        branch: lockData.branch,
+        timestamp: lockData.acquiredAt,
+      });
+    }
+
+    // Stale lock (corrupt, unreadable, or dead PID) — remove and retry
+    fd = await removeStaleAndRetry(lockPath, worktreeName);
   }
 
   const data: LockData = {
@@ -125,9 +111,9 @@ export const acquire = async (
   };
 
   try {
-    await fd!.writeFile(JSON.stringify(data, null, 2));
+    await fd.writeFile(JSON.stringify(data, null, 2));
   } finally {
-    await fd!.close();
+    await fd.close();
   }
 };
 

--- a/src/WorktreeLock.ts
+++ b/src/WorktreeLock.ts
@@ -7,9 +7,9 @@ import { WorktreeLockError } from "./errors.js";
 export { WorktreeLockError };
 
 export interface LockData {
-  pid: number;
-  branch: string;
-  acquiredAt: string;
+  readonly pid: number;
+  readonly branch: string;
+  readonly acquiredAt: string;
 }
 
 /**

--- a/src/WorktreeLock.ts
+++ b/src/WorktreeLock.ts
@@ -1,6 +1,9 @@
 import { constants } from "node:fs";
-import { mkdir, open, rm } from "node:fs/promises";
+import { mkdir, open, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
+import { WorktreeLockError } from "./errors.js";
+
+export { WorktreeLockError };
 
 export interface LockData {
   pid: number;
@@ -9,9 +12,25 @@ export interface LockData {
 }
 
 /**
+ * Check whether a process with the given PID is alive.
+ * Uses `process.kill(pid, 0)` which sends no signal — it only checks existence.
+ */
+const isPidAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
  * Acquires a lock for a worktree using O_EXCL atomic file creation.
  * Creates the lockDir on first use.
- * Throws if a lock file already exists for the given worktreeName.
+ *
+ * When the lock file already exists:
+ * - If the owning PID is alive → throws WorktreeLockError with diagnostic info
+ * - If the owning PID is dead → removes stale lock and retries atomic creation
  */
 export const acquire = async (
   lockDir: string,
@@ -21,19 +40,82 @@ export const acquire = async (
   await mkdir(lockDir, { recursive: true });
   const lockPath = join(lockDir, `${worktreeName}.lock`);
 
-  let fd;
-  try {
-    fd = await open(
+  const tryCreate = async (): Promise<
+    import("node:fs/promises").FileHandle
+  > => {
+    return await open(
       lockPath,
       constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
     );
+  };
+
+  let fd;
+  try {
+    fd = await tryCreate();
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-      throw new Error(
-        `Worktree lock already held for '${worktreeName}' (lock file: ${lockPath})`,
-      );
+      // Lock file exists — check PID liveness
+      let lockData: LockData;
+      try {
+        const raw = await readFile(lockPath, "utf-8");
+        lockData = JSON.parse(raw) as LockData;
+      } catch {
+        // Lock file is corrupt or unreadable — treat as stale
+        await rm(lockPath, { force: true });
+        try {
+          fd = await tryCreate();
+        } catch (retryErr: unknown) {
+          if ((retryErr as NodeJS.ErrnoException).code === "EEXIST") {
+            throw new Error(
+              `Worktree lock already held for '${worktreeName}' (lock file: ${lockPath})`,
+            );
+          }
+          throw retryErr;
+        }
+        // fd acquired after stale removal — fall through to write
+        lockData = undefined as unknown as LockData;
+      }
+
+      if (lockData) {
+        if (isPidAlive(lockData.pid)) {
+          // Active contention — throw diagnostic error
+          throw new WorktreeLockError({
+            message: `Worktree is in use by process ${lockData.pid} (branch '${lockData.branch}', acquired at ${lockData.acquiredAt})`,
+            owningPid: lockData.pid,
+            branch: lockData.branch,
+            timestamp: lockData.acquiredAt,
+          });
+        }
+
+        // PID is dead — remove stale lock and retry
+        await rm(lockPath, { force: true });
+        try {
+          fd = await tryCreate();
+        } catch (retryErr: unknown) {
+          if ((retryErr as NodeJS.ErrnoException).code === "EEXIST") {
+            // Another process raced us and won — re-read to report contention
+            try {
+              const raw = await readFile(lockPath, "utf-8");
+              const newLock = JSON.parse(raw) as LockData;
+              throw new WorktreeLockError({
+                message: `Worktree is in use by process ${newLock.pid} (branch '${newLock.branch}', acquired at ${newLock.acquiredAt})`,
+                owningPid: newLock.pid,
+                branch: newLock.branch,
+                timestamp: newLock.acquiredAt,
+              });
+            } catch (readErr) {
+              if (readErr instanceof WorktreeLockError) throw readErr;
+              throw new Error(
+                `Worktree lock already held for '${worktreeName}' (lock file: ${lockPath})`,
+              );
+            }
+          }
+          throw retryErr;
+        }
+      }
+    } else {
+      throw err;
     }
-    throw err;
   }
 
   const data: LockData = {
@@ -43,9 +125,9 @@ export const acquire = async (
   };
 
   try {
-    await fd.writeFile(JSON.stringify(data, null, 2));
+    await fd!.writeFile(JSON.stringify(data, null, 2));
   } finally {
-    await fd.close();
+    await fd!.close();
   }
 };
 

--- a/src/WorktreeManager.test.ts
+++ b/src/WorktreeManager.test.ts
@@ -405,6 +405,34 @@ describe("WorktreeManager.pruneStale", () => {
     // suppress unused var warning
     void name;
   });
+
+  it("cleans up a stale lock left by a simulated crash", async () => {
+    const repoDir = await setupRepo();
+    const { path } = await run(create(repoDir, { branch: "crash-branch" }));
+    const worktreeName = path.split("/").pop()!;
+
+    // Write a stale lock file (simulates a process that crashed without releasing)
+    const lockDir = join(repoDir, ".sandcastle", "locks");
+    await mkdir(lockDir, { recursive: true });
+    const lockPath = join(lockDir, `${worktreeName}.lock`);
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: 999999999, // dead PID
+        branch: "crash-branch",
+        acquiredAt: "2025-01-01T00:00:00.000Z",
+      }),
+    );
+
+    // pruneStale should remove the stale lock (dead PID)
+    await run(pruneStale(repoDir));
+
+    const entries = await readdir(lockDir).catch(() => []);
+    expect(entries).not.toContain(`${worktreeName}.lock`);
+
+    // cleanup
+    await run(remove(path));
+  });
 });
 
 describe("WorktreeManager.hasUncommittedChanges", () => {

--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -1,8 +1,9 @@
 import { Effect, Option } from "effect";
 import { FileSystem } from "@effect/platform";
 import { execFile } from "node:child_process";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { WorktreeError, WorktreeTimeoutError, withTimeout } from "./errors.js";
+import { pruneStale as pruneStaleLocks } from "./WorktreeLock.js";
 
 const WORKTREE_TIMEOUT_MS = 30_000;
 
@@ -185,7 +186,14 @@ export const create = (
         Effect.catchAll((e) => {
           if (e.message.includes("invalid reference")) {
             return execGit(
-              ["worktree", "add", "-b", branch, worktreePath, opts?.baseBranch ?? "HEAD"],
+              [
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                worktreePath,
+                opts?.baseBranch ?? "HEAD",
+              ],
               repoDir,
             );
           }
@@ -318,6 +326,13 @@ export const pruneStale = (
         );
       }
     }
+
+    // Prune stale lock files alongside orphaned directories
+    const lockDir = join(repoDir, ".sandcastle", "locks");
+    const activeWorktreeNames = new Set(
+      [...activeWorktreePaths].map((p) => basename(p)),
+    );
+    yield* Effect.promise(() => pruneStaleLocks(lockDir, activeWorktreeNames));
   }).pipe(
     withTimeout(
       WORKTREE_TIMEOUT_MS,

--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -281,22 +281,8 @@ export const pruneStale = (
     // Let git clean up metadata for worktrees whose directories are gone
     yield* execGit(["worktree", "prune"], repoDir);
 
-    const worktreesDir = join(repoDir, ".sandcastle", "worktrees");
-
-    // Read directory entries — return null if directory doesn't exist
-    const entries: string[] | null = yield* fs.readDirectory(worktreesDir).pipe(
-      Effect.map((es): string[] | null => es),
-      Effect.catchSome((e) =>
-        e._tag === "SystemError" && e.reason === "NotFound"
-          ? Option.some(Effect.succeed(null as string[] | null))
-          : Option.none(),
-      ),
-      Effect.mapError((e) => new WorktreeError({ message: e.message })),
-    );
-
-    if (entries === null) return;
-
-    // Get the list of active worktree paths from git
+    // Get the list of active worktree paths from git (needed for both
+    // directory cleanup and lock pruning)
     const worktreeList = yield* execGit(
       ["worktree", "list", "--porcelain"],
       repoDir,
@@ -308,22 +294,37 @@ export const pruneStale = (
         .map((line) => line.slice("worktree ".length).trim()),
     );
 
-    // Remove any directory under .sandcastle/worktrees/ that is not an active worktree
-    for (const entry of entries) {
-      const entryPath = join(worktreesDir, entry);
-      const isDir = yield* fs.stat(entryPath).pipe(
-        Effect.map((s) => s.type === "Directory"),
-        Effect.catchAll(() => Effect.succeed(false)),
-      );
-      if (isDir && !activeWorktreePaths.has(entryPath)) {
-        yield* fs.remove(entryPath, { recursive: true, force: true }).pipe(
-          Effect.mapError(
-            (e) =>
-              new WorktreeError({
-                message: `Failed to remove ${entryPath}: ${e.message}`,
-              }),
-          ),
+    const worktreesDir = join(repoDir, ".sandcastle", "worktrees");
+
+    // Read directory entries — skip directory cleanup if directory doesn't exist
+    const entries: string[] | null = yield* fs.readDirectory(worktreesDir).pipe(
+      Effect.map((es): string[] | null => es),
+      Effect.catchSome((e) =>
+        e._tag === "SystemError" && e.reason === "NotFound"
+          ? Option.some(Effect.succeed(null as string[] | null))
+          : Option.none(),
+      ),
+      Effect.mapError((e) => new WorktreeError({ message: e.message })),
+    );
+
+    if (entries !== null) {
+      // Remove any directory under .sandcastle/worktrees/ that is not an active worktree
+      for (const entry of entries) {
+        const entryPath = join(worktreesDir, entry);
+        const isDir = yield* fs.stat(entryPath).pipe(
+          Effect.map((s) => s.type === "Directory"),
+          Effect.catchAll(() => Effect.succeed(false)),
         );
+        if (isDir && !activeWorktreePaths.has(entryPath)) {
+          yield* fs.remove(entryPath, { recursive: true, force: true }).pipe(
+            Effect.mapError(
+              (e) =>
+                new WorktreeError({
+                  message: `Failed to remove ${entryPath}: ${e.message}`,
+                }),
+            ),
+          );
+        }
       }
     }
 

--- a/src/createWorktree.test.ts
+++ b/src/createWorktree.test.ts
@@ -993,4 +993,33 @@ describe("worktree.createSandbox()", () => {
       branch: "should-not-work",
     };
   });
+
+  it("lock file exists after createWorktree and is gone after close", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "ws-lock-test-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "init.txt", "init", "initial commit");
+
+    const ws = await createWorktree({
+      branchStrategy: { type: "branch", branch: "lock-integration-branch" },
+      cwd: hostDir,
+    });
+
+    try {
+      const worktreeName = ws.worktreePath.split("/").at(-1)!;
+      const lockPath = join(
+        hostDir,
+        ".sandcastle",
+        "locks",
+        `${worktreeName}.lock`,
+      );
+
+      expect(existsSync(lockPath)).toBe(true);
+
+      await ws.close();
+
+      expect(existsSync(lockPath)).toBe(false);
+    } finally {
+      await rm(hostDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/createWorktree.test.ts
+++ b/src/createWorktree.test.ts
@@ -167,20 +167,13 @@ describe("createWorktree", () => {
     // Close the first handle (worktree is clean, so it gets removed)
     await ws1.close();
 
-    // Re-create the branch so worktree collision can happen
+    // Re-create — lock was released by close(), so re-acquire succeeds
     const ws1b = await createWorktree({
       branchStrategy: { type: "branch", branch: "reuse-branch" },
       cwd: hostDir,
     });
 
-    // Now create a second handle while the first is still alive
-    const ws2 = await createWorktree({
-      branchStrategy: { type: "branch", branch: "reuse-branch" },
-      cwd: hostDir,
-    });
-
-    expect(ws2.worktreePath).toBe(ws1b.worktreePath);
-    expect(ws2.branch).toBe("reuse-branch");
+    expect(ws1b.branch).toBe("reuse-branch");
 
     await ws1b.close();
     await rm(hostDir, { recursive: true, force: true });
@@ -196,18 +189,24 @@ describe("createWorktree", () => {
       cwd: hostDir,
     });
 
-    // Make the worktree dirty
-    await writeFile(join(ws1.worktreePath, "dirty.txt"), "uncommitted");
+    const worktreePath = ws1.worktreePath;
 
+    // Make the worktree dirty
+    await writeFile(join(worktreePath, "dirty.txt"), "uncommitted");
+
+    // Close ws1 — dirty worktree is preserved, lock is released
+    await ws1.close();
+
+    // Re-create — lock was released, so re-acquire succeeds; worktree is reused
     const ws2 = await createWorktree({
       branchStrategy: { type: "branch", branch: "dirty-branch" },
       cwd: hostDir,
     });
 
-    expect(ws2.worktreePath).toBe(ws1.worktreePath);
+    expect(ws2.worktreePath).toBe(worktreePath);
 
     // Clean up
-    await rm(ws1.worktreePath, { recursive: true, force: true });
+    await rm(worktreePath, { recursive: true, force: true });
     await execAsync("git worktree prune", { cwd: hostDir });
     await rm(hostDir, { recursive: true, force: true });
   });
@@ -1021,5 +1020,44 @@ describe("worktree.createSandbox()", () => {
     } finally {
       await rm(hostDir, { recursive: true, force: true });
     }
+  });
+
+  it("two concurrent createWorktree() calls for the same branch — second fails with lock contention", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "ws-contention-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "init.txt", "init", "initial commit");
+
+    const results = await Promise.allSettled([
+      createWorktree({
+        branchStrategy: { type: "branch", branch: "contention-branch" },
+        cwd: hostDir,
+      }),
+      createWorktree({
+        branchStrategy: { type: "branch", branch: "contention-branch" },
+        cwd: hostDir,
+      }),
+    ]);
+
+    const fulfilled = results.filter(
+      (
+        r,
+      ): r is PromiseSettledResult<
+        Awaited<ReturnType<typeof createWorktree>>
+      > & { status: "fulfilled" } => r.status === "fulfilled",
+    );
+    const rejected = results.filter(
+      (r): r is PromiseRejectedResult => r.status === "rejected",
+    );
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    // Effect wraps the error in a FiberFailure — check the message directly
+    expect(String(rejected[0]!.reason)).toMatch(
+      /Worktree is in use by process/,
+    );
+
+    // Clean up
+    await fulfilled[0]!.value.close();
+    await rm(hostDir, { recursive: true, force: true });
   });
 });

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -1,6 +1,6 @@
 import { NodeContext, NodeFileSystem } from "@effect/platform-node";
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { Effect, Layer } from "effect";
 import { hostSessionStore } from "./SessionStore.js";
 import type { AgentProvider } from "./AgentProvider.js";
@@ -39,6 +39,7 @@ import { mergeProviderEnv } from "./mergeProviderEnv.js";
 import { startSandbox } from "./startSandbox.js";
 import { syncOut } from "./syncOut.js";
 import * as WorktreeManager from "./WorktreeManager.js";
+import { acquire, release } from "./WorktreeLock.js";
 import { copyToWorktree } from "./CopyToWorktree.js";
 import { resolveCwd } from "./resolveCwd.js";
 import {
@@ -216,7 +217,28 @@ export const createWorktree = async (
     yield* WorktreeManager.pruneStale(hostRepoDir).pipe(
       Effect.catchAll(() => Effect.void),
     );
-    const info = yield* WorktreeManager.create(hostRepoDir, { branch, baseBranch });
+    const info = yield* WorktreeManager.create(hostRepoDir, {
+      branch,
+      baseBranch,
+    });
+    // Only acquire the lock for newly-created worktrees. When WorktreeManager
+    // reuses an existing worktree (collision path), the existing handle still
+    // holds the lock — attempting to re-acquire would fail.
+    const lockFilePath = join(
+      hostRepoDir,
+      ".sandcastle",
+      "locks",
+      `${basename(info.path)}.lock`,
+    );
+    if (!existsSync(lockFilePath)) {
+      yield* Effect.promise(() =>
+        acquire(
+          join(hostRepoDir, ".sandcastle", "locks"),
+          basename(info.path),
+          info.branch,
+        ),
+      );
+    }
     if (options.copyToWorktree && options.copyToWorktree.length > 0) {
       yield* copyToWorktree(options.copyToWorktree, hostRepoDir, info.path);
     }
@@ -229,9 +251,14 @@ export const createWorktree = async (
 
   let closed = false;
 
+  const lockDir = join(hostRepoDir, ".sandcastle", "locks");
+  const worktreeName = basename(worktreeInfo.path);
+
   const close = async (): Promise<CloseResult> => {
     if (closed) return { preservedWorktreePath: undefined };
     closed = true;
+
+    await release(lockDir, worktreeName).catch(() => {});
 
     return Effect.gen(function* () {
       const isDirty = yield* WorktreeManager.hasUncommittedChanges(

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -217,28 +217,42 @@ export const createWorktree = async (
     yield* WorktreeManager.pruneStale(hostRepoDir).pipe(
       Effect.catchAll(() => Effect.void),
     );
-    const info = yield* WorktreeManager.create(hostRepoDir, {
+
+    const lockDir = join(hostRepoDir, ".sandcastle", "locks");
+
+    // For named branches, acquire lock BEFORE create to serialize concurrent
+    // access.  acquire() uses O_EXCL for atomicity and checks PID liveness
+    // when a lock already exists — live PID → WorktreeLockError, dead PID →
+    // stale recovery.
+    if (branch) {
+      const worktreeName = branch.replace(/\//g, "-");
+      yield* Effect.promise(() => acquire(lockDir, worktreeName, branch));
+    }
+
+    const createEffect = WorktreeManager.create(hostRepoDir, {
       branch,
       baseBranch,
     });
-    // Only acquire the lock for newly-created worktrees. When WorktreeManager
-    // reuses an existing worktree (collision path), the existing handle still
-    // holds the lock — attempting to re-acquire would fail.
-    const lockFilePath = join(
-      hostRepoDir,
-      ".sandcastle",
-      "locks",
-      `${basename(info.path)}.lock`,
-    );
-    if (!existsSync(lockFilePath)) {
+    // If create fails and we hold a lock for a named branch, release it so
+    // the lock doesn't become stale.
+    const info = yield* branch
+      ? createEffect.pipe(
+          Effect.tapError(() =>
+            Effect.promise(() =>
+              release(lockDir, branch.replace(/\//g, "-")).catch(() => {}),
+            ),
+          ),
+        )
+      : createEffect;
+
+    // For merge-to-head, acquire lock AFTER create (unique names per call,
+    // no contention possible).
+    if (!branch) {
       yield* Effect.promise(() =>
-        acquire(
-          join(hostRepoDir, ".sandcastle", "locks"),
-          basename(info.path),
-          info.branch,
-        ),
+        acquire(lockDir, basename(info.path), info.branch),
       );
     }
+
     if (options.copyToWorktree && options.copyToWorktree.length > 0) {
       yield* copyToWorktree(options.copyToWorktree, hostRepoDir, info.path);
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -159,6 +159,14 @@ export const withTimeout =
       }),
     );
 
+/** Worktree lock contention — another process holds the lock */
+export class WorktreeLockError extends Data.TaggedError("WorktreeLockError")<{
+  readonly message: string;
+  readonly owningPid: number;
+  readonly branch: string;
+  readonly timestamp: string;
+}> {}
+
 /** Session capture (read, rewrite, or write) failed */
 export class SessionCaptureError extends Data.TaggedError(
   "SessionCaptureError",
@@ -195,4 +203,5 @@ export type SandboxError =
   | PromptExpansionTimeoutError
   | CommitCollectionTimeoutError
   | MergeToHostTimeoutError
-  | SessionCaptureError;
+  | SessionCaptureError
+  | WorktreeLockError;


### PR DESCRIPTION
Implements PRD #427: file-based locking to prevent two processes from operating on the same worktree simultaneously.

Introduces a `WorktreeLock` module with `acquire()`, `release()`, and `pruneStale()`. Lock files live at `.sandcastle/locks/<worktree-dir-name>.lock` with JSON content (`{ pid, branch, acquiredAt }`). Atomic creation via `O_EXCL` prevents races. PID liveness checking via `process.kill(pid, 0)` detects stale locks from crashed processes.

Wired into `createWorktree()` — lock acquired after worktree creation, released unconditionally on `close()`/dispose. `WorktreeManager.pruneStale()` cleans up stale locks alongside orphaned worktree directories.

Closes #427, #428, #429, #430.

Closes #428
Closes #429
Closes #430