### PR TITLE
Show context window size per iteration in run summary

### DIFF
--- a/.changeset/context-window-summary.md
+++ b/.changeset/context-window-summary.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Show context window size per iteration in the run summary. Each iteration with usage data emits a `Context window: NNNk` line (tokens rounded up to the nearest 1000) in both terminal and log-to-file mode.

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -4,9 +4,11 @@ import { tmpdir } from "node:os";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
   buildCompletionMessage,
+  buildContextWindowLines,
   buildLogFilename,
   buildRunSummaryRows,
   DEFAULT_MAX_ITERATIONS,
+  formatContextWindowSize,
   printFileDisplayStartup,
   run,
   sanitizeBranchForFilename,
@@ -749,5 +751,163 @@ describe("run() error logging to file", () => {
         logging: { type: "file", path: logPath },
       }),
     ).rejects.toThrow("SOURCE_BRANCH");
+  });
+});
+
+describe("formatContextWindowSize", () => {
+  it("rounds up to the nearest 1000 tokens", () => {
+    expect(
+      formatContextWindowSize({
+        inputTokens: 102400,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        outputTokens: 0,
+      }),
+    ).toBe("103k");
+  });
+
+  it("returns exact k value when total is a multiple of 1000", () => {
+    expect(
+      formatContextWindowSize({
+        inputTokens: 100000,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        outputTokens: 0,
+      }),
+    ).toBe("100k");
+  });
+
+  it("rounds 100001 up to 101k", () => {
+    expect(
+      formatContextWindowSize({
+        inputTokens: 100001,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        outputTokens: 0,
+      }),
+    ).toBe("101k");
+  });
+
+  it("rounds 1 up to 1k", () => {
+    expect(
+      formatContextWindowSize({
+        inputTokens: 1,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        outputTokens: 0,
+      }),
+    ).toBe("1k");
+  });
+
+  it("rounds 999 up to 1k", () => {
+    expect(
+      formatContextWindowSize({
+        inputTokens: 999,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        outputTokens: 0,
+      }),
+    ).toBe("1k");
+  });
+
+  it("returns 1k for exactly 1000", () => {
+    expect(
+      formatContextWindowSize({
+        inputTokens: 1000,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        outputTokens: 0,
+      }),
+    ).toBe("1k");
+  });
+
+  it("rounds 1001 up to 2k", () => {
+    expect(
+      formatContextWindowSize({
+        inputTokens: 1001,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        outputTokens: 0,
+      }),
+    ).toBe("2k");
+  });
+
+  it("sums inputTokens, cacheCreationInputTokens, and cacheReadInputTokens", () => {
+    expect(
+      formatContextWindowSize({
+        inputTokens: 50000,
+        cacheCreationInputTokens: 25000,
+        cacheReadInputTokens: 25000,
+        outputTokens: 9999,
+      }),
+    ).toBe("100k");
+  });
+
+  it("rounds 99500 up to 100k", () => {
+    expect(
+      formatContextWindowSize({
+        inputTokens: 99500,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        outputTokens: 0,
+      }),
+    ).toBe("100k");
+  });
+});
+
+describe("buildContextWindowLines", () => {
+  it("returns one line per iteration with usage data", () => {
+    const lines = buildContextWindowLines([
+      {
+        usage: {
+          inputTokens: 50000,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          outputTokens: 1000,
+        },
+      },
+      {
+        usage: {
+          inputTokens: 100000,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          outputTokens: 2000,
+        },
+      },
+    ]);
+    expect(lines).toEqual(["Context window: 50k", "Context window: 100k"]);
+  });
+
+  it("skips iterations without usage data", () => {
+    const lines = buildContextWindowLines([
+      {
+        usage: {
+          inputTokens: 50000,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          outputTokens: 1000,
+        },
+      },
+      {},
+      {
+        usage: {
+          inputTokens: 100000,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          outputTokens: 2000,
+        },
+      },
+    ]);
+    expect(lines).toEqual(["Context window: 50k", "Context window: 100k"]);
+  });
+
+  it("returns empty array when no iterations have usage", () => {
+    const lines = buildContextWindowLines([{}, {}, {}]);
+    expect(lines).toEqual([]);
+  });
+
+  it("returns empty array for empty iterations list", () => {
+    const lines = buildContextWindowLines([]);
+    expect(lines).toEqual([]);
   });
 });

--- a/src/run.ts
+++ b/src/run.ts
@@ -14,6 +14,7 @@ import {
 import {
   orchestrate,
   type IterationResult,
+  type IterationUsage,
   type OrchestrateResult,
 } from "./Orchestrator.js";
 import { resolvePrompt } from "./PromptResolver.js";
@@ -144,6 +145,31 @@ export const buildCompletionMessage = (
     severity: "warn",
   };
 };
+
+/**
+ * Format the context window size from an iteration's usage data.
+ * Returns a string like "103k" representing the total input-side tokens
+ * (inputTokens + cacheCreationInputTokens + cacheReadInputTokens)
+ * rounded up to the nearest 1000.
+ */
+export const formatContextWindowSize = (usage: IterationUsage): string => {
+  const total =
+    usage.inputTokens +
+    usage.cacheCreationInputTokens +
+    usage.cacheReadInputTokens;
+  return `${Math.ceil(total / 1000)}k`;
+};
+
+/**
+ * Build "Context window: NNNk" lines for iterations that have usage data.
+ * Returns an empty array when no iterations carry usage.
+ */
+export const buildContextWindowLines = (
+  iterations: readonly Pick<IterationResult, "usage">[],
+): string[] =>
+  iterations
+    .filter((it): it is { usage: IterationUsage } => it.usage !== undefined)
+    .map((it) => `Context window: ${formatContextWindowSize(it.usage)}`);
 
 /**
  * Controls where Sandcastle writes iteration progress and agent output.
@@ -466,6 +492,10 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
       orchestrateResult.iterations.length,
     );
     yield* d.status(completion.message, completion.severity);
+
+    for (const line of buildContextWindowLines(orchestrateResult.iterations)) {
+      yield* d.text(line);
+    }
 
     return orchestrateResult;
   });


### PR DESCRIPTION
Displays the context window size for each iteration in the run summary, in both log-to-file and terminal mode. The context window for an iteration is `inputTokens + cacheCreationInputTokens + cacheReadInputTokens`, rounded up to the nearest 1000 and displayed as `Context Window: NNNk`. Iterations without usage data are skipped silently.

Closes #459.