### PR TITLE
Fix rebase worktree collision detection

### DIFF
--- a/.changeset/fix-rebase-worktree-collision.md
+++ b/.changeset/fix-rebase-worktree-collision.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix `createWorktree` failing with "already exists" when reusing a preserved mid-rebase worktree. Collision detection now also matches by target path, covering the detached-HEAD state during an in-progress rebase.

--- a/src/WorktreeManager.test.ts
+++ b/src/WorktreeManager.test.ts
@@ -325,6 +325,49 @@ describe("WorktreeManager.create", () => {
     await run(remove(first.path));
   });
 
+  it("reuses preserved worktree when branch is mid-rebase (detached HEAD)", async () => {
+    const repoDir = await setupRepo();
+
+    // Create a branch with a commit that will conflict during rebase
+    await execAsync("git checkout -b feat/rebase-test", { cwd: repoDir });
+    await commitFile(repoDir, "conflict.txt", "branch-content", "branch commit");
+    await execAsync("git checkout main", { cwd: repoDir });
+
+    // Create a conflicting commit on main so rebase will pause
+    await commitFile(
+      repoDir,
+      "conflict.txt",
+      "main-content",
+      "main conflicting commit",
+    );
+
+    // Create the worktree for feat/rebase-test
+    const first = await run(create(repoDir, { branch: "feat/rebase-test" }));
+    expect(first.branch).toBe("feat/rebase-test");
+
+    // Start a rebase inside the worktree that will conflict (detaches HEAD)
+    await execAsync("git rebase main", { cwd: first.path }).catch(() => {
+      // Expected to fail due to conflict — HEAD is now detached mid-rebase
+    });
+
+    // Verify HEAD is detached (mid-rebase state)
+    const { stdout: headRef } = await execAsync(
+      "git rev-parse --abbrev-ref HEAD",
+      { cwd: first.path },
+    );
+    expect(headRef.trim()).toBe("HEAD"); // detached
+
+    // Now try to create the worktree again — should reuse the existing one
+    const second = await run(create(repoDir, { branch: "feat/rebase-test" }));
+
+    expect(second.path).toBe(first.path);
+    expect(second.branch).toBe("feat/rebase-test");
+
+    // Cleanup: abort the rebase so git worktree remove works
+    await execAsync("git rebase --abort", { cwd: first.path });
+    await run(remove(first.path));
+  });
+
   it("detects collision when branch is checked out in the main working tree", async () => {
     const repoDir = await setupRepo();
     // "main" is the currently checked-out branch in the main working tree

--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -166,9 +166,13 @@ export const create = (
     const worktreePath = join(worktreesDir, worktreeName);
 
     if (opts?.branch) {
-      // Proactively detect collision before git produces a confusing error
+      // Proactively detect collision before git produces a confusing error.
+      // Match by branch first; fall back to target path (covers mid-rebase
+      // detached-HEAD state where the branch field is null).
       const existing = yield* listWorktrees(repoDir);
-      const collision = existing.find((wt) => wt.branch === branch);
+      const collision =
+        existing.find((wt) => wt.branch === branch) ??
+        existing.find((wt) => wt.path === worktreePath);
       if (collision) {
         // Only reuse worktrees managed by sandcastle (under .sandcastle/worktrees/)
         const isManagedWorktree = collision.path.startsWith(worktreesDir);


### PR DESCRIPTION
## Summary

- Extends collision detection in `WorktreeManager.create` to also match by target path (not only branch name), fixing #467
- During a mid-rebase, git detaches HEAD so the `branch` field is null in porcelain output — the branch-only check missed the collision, causing `git worktree add` to fail with "already exists"
- Added a test that creates a real mid-rebase conflict to verify the reuse scenario

## Test plan

- [x] New test: "reuses preserved worktree when branch is mid-rebase (detached HEAD)" passes
- [x] All existing WorktreeManager tests pass (35 total)
- [x] Typecheck passes
- [x] Pre-existing `syncOut.test.ts` failures are unrelated

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)