### PR TITLE
feat: add thinking option to pi provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,6 +758,19 @@ agent: codex("gpt-5.4", { effort: "high" });
 | `effort` | `"low"` \| `"medium"` \| `"high"` \| `"xhigh"` | —       | Codex reasoning effort level via `model_reasoning_effort` |
 | `env`    | `Record<string, string>`                       | `{}`    | Environment variables injected by this agent provider     |
 
+### `PiOptions`
+
+The `pi()` factory accepts an optional second argument for provider-specific options:
+
+```typescript
+agent: pi("zai/glm-5.1", { thinking: "high" });
+```
+
+| Option     | Type                                                                     | Default | Description                                           |
+| ---------- | ------------------------------------------------------------------------ | ------- | ----------------------------------------------------- |
+| `thinking` | `"off"` \| `"minimal"` \| `"low"` \| `"medium"` \| `"high"` \| `"xhigh"` | —       | Pi thinking level via `--thinking`                    |
+| `env`      | `Record<string, string>`                                                 | `{}`    | Environment variables injected by this agent provider |
+
 ### Provider `env`
 
 Both **agent providers** and **sandbox providers** accept an optional `env: Record<string, string>` in their options. These environment variables are merged with the `.sandcastle/.env` resolver output at launch time:

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -466,6 +466,53 @@ describe("pi factory", () => {
     const provider = pi("claude-sonnet-4-6");
     expect(provider.env).toEqual({});
   });
+
+  it("buildPrintCommand includes --thinking when specified", () => {
+    const provider = pi("claude-sonnet-4-6", { thinking: "high" });
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).toContain("--thinking high");
+  });
+
+  it("buildPrintCommand omits --thinking when not specified", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).not.toContain("--thinking");
+  });
+
+  it("buildPrintCommand omits --thinking when options is empty", () => {
+    const provider = pi("claude-sonnet-4-6", {});
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).not.toContain("--thinking");
+  });
+
+  it("supports all thinking levels", () => {
+    for (const thinking of [
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ] as const) {
+      const provider = pi("claude-sonnet-4-6", { thinking });
+      expect(provider.buildPrintCommand(opts("test")).command).toContain(
+        `--thinking ${thinking}`,
+      );
+    }
+  });
+
+  it("buildInteractiveArgs includes --thinking when specified", () => {
+    const provider = pi("claude-sonnet-4-6", { thinking: "xhigh" });
+    const args = provider.buildInteractiveArgs!(opts("do something"));
+    expect(args).toContain("--thinking");
+    expect(args).toContain("xhigh");
+  });
+
+  it("buildInteractiveArgs omits --thinking when not specified", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const args = provider.buildInteractiveArgs!(opts("do something"));
+    expect(args).not.toContain("--thinking");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -21,7 +21,11 @@ const TOOL_ARG_FIELDS: Record<string, string> = {
 const extractErrorMessage = (obj: any): string | undefined => {
   const err = obj.error;
   if (typeof err === "string") return err;
-  if (typeof err === "object" && err !== null && typeof err.message === "string") {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    typeof err.message === "string"
+  ) {
     return err.message;
   }
   if (typeof obj.message === "string") return obj.message;
@@ -191,6 +195,8 @@ const parsePiStreamLine = (line: string): ParsedStreamEvent[] => {
 export interface PiOptions {
   /** Environment variables injected by this agent provider. */
   readonly env?: Record<string, string>;
+  /** Thinking level for the agent. Maps to pi's --thinking flag. */
+  readonly thinking?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 }
 
 export const pi = (model: string, options?: PiOptions): AgentProvider => ({
@@ -199,14 +205,18 @@ export const pi = (model: string, options?: PiOptions): AgentProvider => ({
   captureSessions: false,
 
   buildPrintCommand({ prompt }: AgentCommandOptions): PrintCommand {
+    const thinkingFlag = options?.thinking
+      ? ` --thinking ${options.thinking}`
+      : "";
     return {
-      command: `pi -p --mode json --no-session --model ${shellEscape(model)}`,
+      command: `pi -p --mode json --no-session --model ${shellEscape(model)}${thinkingFlag}`,
       stdin: prompt,
     };
   },
 
   buildInteractiveArgs({ prompt }: AgentCommandOptions): string[] {
     const args = ["pi", "--model", model];
+    if (options?.thinking) args.push("--thinking", options.thinking);
     if (prompt) args.push(prompt);
     return args;
   },


### PR DESCRIPTION
Adds support for pi's `--thinking` flag via the `pi()` provider options.

example:

```typescript
agent: pi("zai/glm-5.1", { thinking: "high" });
```

Supported levels: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`.

Includes tests for print and interactive command construction.