### PR TITLE
Add optional per-hook timeoutMs override for lifecycle hooks

### DIFF
--- a/.changeset/per-hook-timeout.md
+++ b/.changeset/per-hook-timeout.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add optional `timeoutMs` field to hook objects, allowing per-hook timeout overrides with fallback to the default 60s

--- a/README.md
+++ b/README.md
@@ -1108,7 +1108,7 @@ hooks: {
   },
   sandbox: {
     onSandboxReady: [
-      { command: "npm install" },
+      { command: "npm install", timeoutMs: 300_000 },
       { command: "apt-get install -y ffmpeg", sudo: true },
     ],
   },
@@ -1123,8 +1123,9 @@ hooks: {
 
 **Ordering:** `copyToWorktree` -> `host.onWorktreeReady` (sequential) -> sandbox created -> `host.onSandboxReady` + `sandbox.onSandboxReady` (parallel).
 
-- **Host hooks** accept `{ command: string }` — no `sudo`, no `cwd`. Use `cd` or inline env in the command string.
-- **Sandbox hooks** accept `{ command: string; sudo?: boolean }` — set `sudo: true` for elevated privileges.
+- **Host hooks** accept `{ command: string; timeoutMs?: number }` — no `sudo`, no `cwd`. Use `cd` or inline env in the command string.
+- **Sandbox hooks** accept `{ command: string; sudo?: boolean; timeoutMs?: number }` — set `sudo: true` for elevated privileges.
+- **`timeoutMs`** overrides the default 60 s per-hook timeout. Useful for long-running setup commands like dependency installs (e.g. `timeoutMs: 300_000` for 5 minutes).
 - Within each hook point, sandbox hooks run in parallel; host hooks within `onSandboxReady` also run in parallel with sandbox hooks. `host.onWorktreeReady` hooks run sequentially in declared order.
 - If any hook exits non-zero, setup fails fast.
 - When a `signal` is passed to `run()`, it is threaded to all hooks — aborting the signal cancels any in-flight hook commands.

--- a/src/SandboxLifecycle.test.ts
+++ b/src/SandboxLifecycle.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { type DisplayEntry, SilentDisplay } from "./Display.js";
 import { Sandbox, type SandboxService } from "./SandboxFactory.js";
 import { makeLocalSandboxLayer } from "./testSandbox.js";
-import { ExecError, HookTimeoutError, SyncError } from "./errors.js";
+import { ExecError, SyncError } from "./errors.js";
 import { withSandboxLifecycle, runHostHooks } from "./SandboxLifecycle.js";
 
 /**

--- a/src/SandboxLifecycle.test.ts
+++ b/src/SandboxLifecycle.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { type DisplayEntry, SilentDisplay } from "./Display.js";
 import { Sandbox, type SandboxService } from "./SandboxFactory.js";
 import { makeLocalSandboxLayer } from "./testSandbox.js";
-import { ExecError, SyncError } from "./errors.js";
+import { ExecError, HookTimeoutError, SyncError } from "./errors.js";
 import { withSandboxLifecycle, runHostHooks } from "./SandboxLifecycle.js";
 
 /**
@@ -1136,6 +1136,96 @@ describe("withSandboxLifecycle (worktree mode)", () => {
       ),
     ).rejects.toThrow(/Host hook failed/);
   });
+
+  it("sandbox.onSandboxReady respects per-hook timeoutMs", async () => {
+    const { hostDir, worktreeDir } = await setupWorktree();
+
+    const spySandboxLayer = Layer.succeed(Sandbox, {
+      exec: (command, _options) => {
+        if (command === "slow-install") {
+          // Simulate a command that takes longer than the short timeout
+          return Effect.gen(function* () {
+            yield* Effect.sleep("2 seconds");
+            return { stdout: "", stderr: "", exitCode: 0 };
+          });
+        }
+        return Effect.succeed({ stdout: "", stderr: "", exitCode: 0 });
+      },
+      copyIn: () => Effect.succeed(undefined as never),
+      copyFileOut: () => Effect.succeed(undefined as never),
+    });
+
+    const result = Effect.runPromise(
+      withSandboxLifecycle(
+        {
+          hostRepoDir: hostDir,
+          sandboxRepoDir: worktreeDir,
+          branch: "sandcastle/test",
+          hooks: {
+            sandbox: {
+              onSandboxReady: [
+                { command: "slow-install", timeoutMs: 500 },
+              ],
+            },
+          },
+        },
+        () => Effect.succeed("ok"),
+      ).pipe(Effect.provide(Layer.merge(spySandboxLayer, testDisplayLayer))),
+    );
+
+    await expect(result).rejects.toThrow(/timed out/);
+  });
+
+  it("host.onSandboxReady respects per-hook timeoutMs", async () => {
+    const { hostDir, worktreeDir, layer } = await setupWorktree();
+
+    const result = Effect.runPromise(
+      withSandboxLifecycle(
+        {
+          hostRepoDir: hostDir,
+          sandboxRepoDir: worktreeDir,
+          branch: "sandcastle/test",
+          hooks: {
+            host: {
+              onSandboxReady: [
+                { command: "sleep 2", timeoutMs: 500 },
+              ],
+            },
+          },
+        },
+        () => Effect.succeed("ok"),
+      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+    );
+
+    await expect(result).rejects.toThrow(/timed out/);
+  });
+
+  it("sandbox.onSandboxReady uses default timeout when timeoutMs omitted", async () => {
+    const { hostDir, worktreeDir, layer } = await setupWorktree();
+
+    // A fast hook with no timeoutMs should succeed with the default 60s timeout
+    await Effect.runPromise(
+      withSandboxLifecycle(
+        {
+          hostRepoDir: hostDir,
+          sandboxRepoDir: worktreeDir,
+          branch: "sandcastle/test",
+          hooks: {
+            sandbox: {
+              onSandboxReady: [{ command: "echo default-timeout > dt.txt" }],
+            },
+          },
+        },
+        (ctx) =>
+          Effect.gen(function* () {
+            const result = yield* ctx.sandbox.exec("cat dt.txt", {
+              cwd: ctx.sandboxRepoDir,
+            });
+            expect(result.stdout.trim()).toBe("default-timeout");
+          }),
+      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+    );
+  });
 });
 
 describe("runHostHooks", () => {
@@ -1206,6 +1296,32 @@ describe("runHostHooks", () => {
     );
 
     const content = await readFile(join(dir, "result.txt"), "utf-8");
+    expect(content.trim()).toBe("ok");
+  });
+
+  it("respects per-hook timeoutMs override", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "host-hooks-"));
+
+    // sleep 2 with a 500ms timeout should fail
+    await expect(
+      Effect.runPromise(
+        runHostHooks(
+          [{ command: "sleep 2", timeoutMs: 500 }],
+          dir,
+        ),
+      ),
+    ).rejects.toThrow(/timed out/);
+  });
+
+  it("uses default timeout when timeoutMs is not specified", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "host-hooks-"));
+
+    // A fast command should succeed with default 60s timeout
+    await Effect.runPromise(
+      runHostHooks([{ command: "echo ok > timeout-default.txt" }], dir),
+    );
+
+    const content = await readFile(join(dir, "timeout-default.txt"), "utf-8");
     expect(content.trim()).toBe("ok");
   });
 });

--- a/src/SandboxLifecycle.ts
+++ b/src/SandboxLifecycle.ts
@@ -62,15 +62,18 @@ export type SandboxHooks = {
   readonly host?: {
     readonly onWorktreeReady?: ReadonlyArray<{
       readonly command: string;
+      readonly timeoutMs?: number;
     }>;
     readonly onSandboxReady?: ReadonlyArray<{
       readonly command: string;
+      readonly timeoutMs?: number;
     }>;
   };
   readonly sandbox?: {
     readonly onSandboxReady?: ReadonlyArray<{
       readonly command: string;
       readonly sudo?: boolean;
+      readonly timeoutMs?: number;
     }>;
   };
 };
@@ -81,12 +84,16 @@ export type SandboxHooks = {
  * Fails fast on non-zero exit.
  */
 export const runHostHooks = (
-  hooks: ReadonlyArray<{ readonly command: string }>,
+  hooks: ReadonlyArray<{
+    readonly command: string;
+    readonly timeoutMs?: number;
+  }>,
   cwd: string,
   signal?: AbortSignal,
 ): Effect.Effect<void, ExecError | HookTimeoutError> =>
   Effect.gen(function* () {
     for (const hook of hooks) {
+      const timeout = hook.timeoutMs ?? HOOK_TIMEOUT_MS;
       yield* Effect.tryPromise({
         try: () => execAsync(hook.command, { cwd, signal }),
         catch: (err) =>
@@ -96,11 +103,11 @@ export const runHostHooks = (
           }),
       }).pipe(
         withTimeout(
-          HOOK_TIMEOUT_MS,
+          timeout,
           () =>
             new HookTimeoutError({
-              message: `Host hook '${hook.command}' timed out after ${HOOK_TIMEOUT_MS}ms`,
-              timeoutMs: HOOK_TIMEOUT_MS,
+              message: `Host hook '${hook.command}' timed out after ${timeout}ms`,
+              timeoutMs: timeout,
               command: hook.command,
             }),
         ),
@@ -258,18 +265,19 @@ export const withSandboxLifecycle = <A>(
           abortCleanup = () => signal.removeEventListener("abort", onAbort);
         }
 
-        const sandboxHookEffects = (sandboxHooks ?? []).map((hook) =>
-          Effect.raceFirst(
+        const sandboxHookEffects = (sandboxHooks ?? []).map((hook) => {
+          const timeout = hook.timeoutMs ?? HOOK_TIMEOUT_MS;
+          return Effect.raceFirst(
             execOk(sandbox, hook.command, {
               cwd: sandboxRepoDir,
               sudo: hook.sudo,
             }).pipe(
               withTimeout(
-                HOOK_TIMEOUT_MS,
+                timeout,
                 () =>
                   new HookTimeoutError({
-                    message: `Hook '${hook.command}' timed out after ${HOOK_TIMEOUT_MS}ms`,
-                    timeoutMs: HOOK_TIMEOUT_MS,
+                    message: `Hook '${hook.command}' timed out after ${timeout}ms`,
+                    timeoutMs: timeout,
                     command: hook.command,
                   }),
               ),
@@ -279,11 +287,12 @@ export const withSandboxLifecycle = <A>(
               ExecError,
               never
             >,
-          ),
-        );
+          );
+        });
 
-        const hostHookEffects = (hostOnSandboxReady ?? []).map((hook) =>
-          Effect.tryPromise({
+        const hostHookEffects = (hostOnSandboxReady ?? []).map((hook) => {
+          const timeout = hook.timeoutMs ?? HOOK_TIMEOUT_MS;
+          return Effect.tryPromise({
             try: () =>
               execAsync(hook.command, {
                 cwd: hostSideWorktreePath,
@@ -296,16 +305,16 @@ export const withSandboxLifecycle = <A>(
               }),
           }).pipe(
             withTimeout(
-              HOOK_TIMEOUT_MS,
+              timeout,
               () =>
                 new HookTimeoutError({
-                  message: `Host hook '${hook.command}' timed out after ${HOOK_TIMEOUT_MS}ms`,
-                  timeoutMs: HOOK_TIMEOUT_MS,
+                  message: `Host hook '${hook.command}' timed out after ${timeout}ms`,
+                  timeoutMs: timeout,
                   command: hook.command,
                 }),
             ),
-          ),
-        );
+          );
+        });
 
         const allOnSandboxReady = [...sandboxHookEffects, ...hostHookEffects];
         yield* (


### PR DESCRIPTION
## Summary

Revives the work from branch `implement/per-hook-timeout` (originally tied to #441) and opens it for merge. Addresses part 1 of #478 (hook-side hardcoded 60s timeout).

Adds an optional `timeoutMs` field to all hook object types in `SandboxHooks`. The three hook execution sites (`runHostHooks`, `sandbox.onSandboxReady`, `host.onSandboxReady`) respect the per-hook value, falling back to the existing 60s default when unset.

```ts
hooks: {
  sandbox: {
    onSandboxReady: [
      { command: "bun install --frozen-lockfile", timeoutMs: 300_000 },
    ],
  },
}
```

Files changed:
- `src/SandboxLifecycle.ts` — `SandboxHooks` type + 3 execution sites
- `src/SandboxLifecycle.test.ts` — 5 new tests
- `README.md` — document `timeoutMs` in hook API reference
- `.changeset/per-hook-timeout.md`

Branch was 2 ahead / 39 behind main; `git merge-tree` reports a clean merge.

## Related

- Closes #441
- Partially addresses #478 (hook-timeout side only — `COPY_TO_WORKTREE_TIMEOUT_MS`, macOS `cp -cR`, and docs remain)

## Test plan

- [ ] `npm run typecheck`
- [ ] Test suite passes
- [ ] Manual: hook with `timeoutMs: 300_000` survives a >60s install

🤖 Generated with [Claude Code](https://claude.com/claude-code)