### PR TITLE
docs: recommend --save-dev in Quick Start install command

### DIFF
--- a/.changeset/recommend-dev-dependency.md
+++ b/.changeset/recommend-dev-dependency.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Update Quick Start install command to recommend `--save-dev` and note that Sandcastle is a dev/CI tool

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Sandcastle is provider-agnostic — it ships with built-in providers for Docker,
 
 ## Quick start
 
-1. Install the package as a dev dependency (Sandcastle is a dev/CI tool — it orchestrates agents during development, not at runtime):
+1. Install the package:
 
 ```bash
 npm install --save-dev @ai-hero/sandcastle

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Sandcastle is provider-agnostic — it ships with built-in providers for Docker,
 
 ## Quick start
 
-1. Install the package:
+1. Install the package as a dev dependency (Sandcastle is a dev/CI tool — it orchestrates agents during development, not at runtime):
 
 ```bash
-npm install @ai-hero/sandcastle
+npm install --save-dev @ai-hero/sandcastle
 ```
 
 2. Run `sandcastle init`. This scaffolds a `.sandcastle` directory with all the files needed.


### PR DESCRIPTION
## Summary
- Updated the Quick Start install command from `npm install` to `npm install --save-dev`
- Added inline note explaining Sandcastle is a dev/CI tool, not a runtime dependency

Closes #476

## Test plan
- [x] `npm run typecheck` passes
- [x] No test changes needed (docs-only change)
- [x] Verified README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)