### PR TITLE
feat: Add Docker context option - support docker compatible runtimes.

### DIFF
--- a/.changeset/docker-context-option.md
+++ b/.changeset/docker-context-option.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add a Docker sandbox `context` option so callers can run Sandcastle against any configured Docker context instead of only the active context.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ const result = await run({
     env: { DOCKER_SPECIFIC: "value" },
     // Optional: attach container to Docker network(s) — string or string[]
     network: "my-network",
-    // Optional: run against a specific Docker context instead of the active one
+    // Optional: run against a specific Docker context instead of the active one.
+    // Only set this in trusted configs; remote contexts run containers on that daemon.
     context: "colima",
   }),
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ const result = await run({
     env: { DOCKER_SPECIFIC: "value" },
     // Optional: attach container to Docker network(s) — string or string[]
     network: "my-network",
+    // Optional: run against a specific Docker context instead of the active one
+    context: "colima",
   }),
 
   // Host repo directory — replaces process.cwd() as the anchor for

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -3,11 +3,25 @@ import { execFile } from "node:child_process";
 import { resolve } from "node:path";
 import { DockerError } from "./errors.js";
 
-const dockerExec = (args: string[]): Effect.Effect<string, DockerError> =>
+export interface DockerCommandOptions {
+  /** Docker context to run commands against. Uses Docker's active context when omitted. */
+  readonly context?: string;
+}
+
+export const dockerArgs = (
+  args: readonly string[],
+  options?: DockerCommandOptions,
+): string[] =>
+  options?.context ? ["--context", options.context, ...args] : [...args];
+
+const dockerExec = (
+  args: string[],
+  options?: DockerCommandOptions,
+): Effect.Effect<string, DockerError> =>
   Effect.async((resume) => {
     execFile(
       "docker",
-      args,
+      dockerArgs(args, options),
       { maxBuffer: 10 * 1024 * 1024 },
       (error, stdout, stderr) => {
         if (error) {
@@ -35,20 +49,26 @@ const dockerExec = (args: string[]): Effect.Effect<string, DockerError> =>
 export const buildImage = (
   imageName: string,
   dockerfileDir: string,
-  options?: { readonly dockerfile?: string },
+  options?: { readonly dockerfile?: string } & DockerCommandOptions,
 ): Effect.Effect<void, DockerError> =>
   Effect.gen(function* () {
     if (options?.dockerfile) {
-      yield* dockerExec([
-        "build",
-        "-t",
-        imageName,
-        "-f",
-        resolve(options.dockerfile),
-        process.cwd(),
-      ]);
+      yield* dockerExec(
+        [
+          "build",
+          "-t",
+          imageName,
+          "-f",
+          resolve(options.dockerfile),
+          process.cwd(),
+        ],
+        options,
+      );
     } else {
-      yield* dockerExec(["build", "-t", imageName, resolve(dockerfileDir)]);
+      yield* dockerExec(
+        ["build", "-t", imageName, resolve(dockerfileDir)],
+        options,
+      );
     }
   });
 
@@ -59,6 +79,8 @@ export interface StartContainerOptions {
   readonly user?: string;
   /** Docker network(s) to attach the container to. Passed as `--network` flags. */
   readonly network?: string | readonly string[];
+  /** Docker context to run commands against. Uses Docker's active context when omitted. */
+  readonly context?: string;
 }
 
 /**
@@ -72,14 +94,17 @@ export const startContainer = (
 ): Effect.Effect<void, DockerError> =>
   Effect.gen(function* () {
     // Check if container already exists
-    const existing = yield* dockerExec([
-      "ps",
-      "-a",
-      "--filter",
-      `name=^${containerName}$`,
-      "--format",
-      "{{.Names}}",
-    ]);
+    const existing = yield* dockerExec(
+      [
+        "ps",
+        "-a",
+        "--filter",
+        `name=^${containerName}$`,
+        "--format",
+        "{{.Names}}",
+      ],
+      options,
+    );
 
     if (existing.trim() === containerName) {
       yield* Effect.fail(
@@ -108,18 +133,21 @@ export const startContainer = (
       : [];
     const networkFlags = networks.flatMap((n) => ["--network", n]);
 
-    yield* dockerExec([
-      "run",
-      "-d",
-      "--name",
-      containerName,
-      ...envFlags,
-      ...volumeFlags,
-      ...workdirFlags,
-      ...userFlags,
-      ...networkFlags,
-      imageName,
-    ]);
+    yield* dockerExec(
+      [
+        "run",
+        "-d",
+        "--name",
+        containerName,
+        ...envFlags,
+        ...volumeFlags,
+        ...workdirFlags,
+        ...userFlags,
+        ...networkFlags,
+        imageName,
+      ],
+      options,
+    );
   });
 
 /**
@@ -127,12 +155,13 @@ export const startContainer = (
  */
 export const removeContainer = (
   containerName: string,
+  options?: DockerCommandOptions,
 ): Effect.Effect<void, DockerError> =>
   Effect.gen(function* () {
     // Stop container (ignore errors if already stopped)
-    yield* Effect.ignore(dockerExec(["stop", containerName]));
+    yield* Effect.ignore(dockerExec(["stop", containerName], options));
     // Remove container (ignore errors if not found)
-    yield* Effect.ignore(dockerExec(["rm", containerName]));
+    yield* Effect.ignore(dockerExec(["rm", containerName], options));
   });
 
 /**
@@ -140,7 +169,8 @@ export const removeContainer = (
  */
 export const removeImage = (
   imageName: string,
+  options?: DockerCommandOptions,
 ): Effect.Effect<void, DockerError> =>
   Effect.gen(function* () {
-    yield* dockerExec(["rmi", imageName]);
+    yield* dockerExec(["rmi", imageName], options);
   });

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
 
 vi.mock("node:child_process", async () => {
   const actual =
@@ -14,14 +15,16 @@ vi.mock("node:child_process", async () => {
   };
 });
 
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { docker } from "./docker.js";
 import type { BindMountSandboxHandle } from "../SandboxProvider.js";
 
 const mockExecFile = vi.mocked(execFile);
+const mockSpawn = vi.mocked(spawn);
 
 afterEach(() => {
   mockExecFile.mockReset();
+  mockSpawn.mockReset();
 });
 
 describe("docker()", () => {
@@ -124,6 +127,82 @@ describe("docker()", () => {
   it("accepts a network option as an array", () => {
     const provider = docker({ network: ["net1", "net2"] });
     expect(provider.tag).toBe("bind-mount");
+  });
+
+  it("passes context to docker lifecycle commands", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+    mockSpawn.mockImplementation(() => {
+      const proc = new EventEmitter() as any;
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.stdin = { write: vi.fn(), end: vi.fn() };
+      queueMicrotask(() => proc.emit("close", 0));
+      return proc;
+    });
+
+    const provider = docker({ context: "colima" });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["--context", "colima", "ps"]),
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["--context", "colima", "run"]),
+      expect.any(Object),
+      expect.any(Function),
+    );
+
+    await handle.exec("echo hello");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["--context", "colima", "exec"]),
+      expect.any(Object),
+    );
+
+    const bmHandle = handle as BindMountSandboxHandle;
+    await bmHandle.copyFileIn("/host/file.txt", "/sandbox/file.txt");
+    await bmHandle.copyFileOut("/sandbox/output.txt", "/host/output.txt");
+
+    const cpCalls = mockExecFile.mock.calls.filter(
+      ([cmd, args]) =>
+        cmd === "docker" &&
+        Array.isArray(args) &&
+        args.includes("--context") &&
+        args.includes("colima") &&
+        args.includes("cp"),
+    );
+    expect(cpCalls).toHaveLength(2);
+
+    await handle.close();
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["--context", "colima", "stop"]),
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["--context", "colima", "rm"]),
+      expect.any(Object),
+      expect.any(Function),
+    );
   });
 
   it("copyFileIn calls docker cp with correct arguments", async () => {

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -15,7 +15,11 @@ import {
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline";
 import { Effect } from "effect";
-import { startContainer, removeContainer } from "../DockerLifecycle.js";
+import {
+  dockerArgs,
+  startContainer,
+  removeContainer,
+} from "../DockerLifecycle.js";
 import {
   createBindMountSandboxProvider,
   type SandboxProvider,
@@ -48,6 +52,14 @@ export interface DockerOptions {
    * When omitted, Docker's default bridge network is used.
    */
   readonly network?: string | readonly string[];
+  /**
+   * Docker context to use for sandbox containers.
+   *
+   * When omitted, Sandcastle uses Docker's active context. Set this to any
+   * configured Docker context name (for example `"colima"`, `"orbstack"`, or a
+   * remote context) to make Sandcastle run against that daemon explicitly.
+   */
+  readonly context?: string;
 }
 
 /**
@@ -105,6 +117,7 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
             workdir: worktreePath,
             user: `${hostUid}:${hostGid}`,
             network: options?.network,
+            context: options?.context,
           },
         ),
       );
@@ -112,9 +125,13 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
       // Set up signal handlers for cleanup
       const onExit = () => {
         try {
-          execFileSync("docker", ["rm", "-f", containerName], {
-            stdio: "ignore",
-          });
+          execFileSync(
+            "docker",
+            dockerArgs(["rm", "-f", containerName], options),
+            {
+              stdio: "ignore",
+            },
+          );
         } catch {
           /* best-effort */
         }
@@ -140,7 +157,7 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
           },
         ): Promise<ExecResult> => {
           const effectiveCommand = opts?.sudo ? `sudo ${command}` : command;
-          const args = ["exec"];
+          const args = dockerArgs(["exec"], options);
           if (opts?.stdin !== undefined) args.push("-i");
           if (opts?.cwd) args.push("-w", opts.cwd);
           args.push(containerName, "sh", "-c", effectiveCommand);
@@ -198,20 +215,20 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
           opts: InteractiveExecOptions,
         ): Promise<{ exitCode: number }> => {
           return new Promise((resolve, reject) => {
-            const dockerArgs = ["exec"];
+            const dockerExecArgs = dockerArgs(["exec"], options);
             // Allocate a pseudo-terminal when stdin looks like a TTY
             if (
               "isTTY" in opts.stdin &&
               (opts.stdin as { isTTY?: boolean }).isTTY
             ) {
-              dockerArgs.push("-it");
+              dockerExecArgs.push("-it");
             } else {
-              dockerArgs.push("-i");
+              dockerExecArgs.push("-i");
             }
-            if (opts.cwd) dockerArgs.push("-w", opts.cwd);
-            dockerArgs.push(containerName, ...args);
+            if (opts.cwd) dockerExecArgs.push("-w", opts.cwd);
+            dockerExecArgs.push(containerName, ...args);
 
-            const proc = spawn("docker", dockerArgs, {
+            const proc = spawn("docker", dockerExecArgs, {
               stdio: [opts.stdin, opts.stdout, opts.stderr] as StdioOptions,
             });
 
@@ -229,7 +246,10 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
           new Promise((resolve, reject) => {
             execFile(
               "docker",
-              ["cp", hostPath, `${containerName}:${sandboxPath}`],
+              dockerArgs(
+                ["cp", hostPath, `${containerName}:${sandboxPath}`],
+                options,
+              ),
               (error) => {
                 if (error) {
                   reject(new Error(`docker cp (in) failed: ${error.message}`));
@@ -244,7 +264,10 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
           new Promise((resolve, reject) => {
             execFile(
               "docker",
-              ["cp", `${containerName}:${sandboxPath}`, hostPath],
+              dockerArgs(
+                ["cp", `${containerName}:${sandboxPath}`, hostPath],
+                options,
+              ),
               (error) => {
                 if (error) {
                   reject(new Error(`docker cp (out) failed: ${error.message}`));
@@ -259,7 +282,7 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
           process.removeListener("exit", onExit);
           process.removeListener("SIGINT", onSignal);
           process.removeListener("SIGTERM", onSignal);
-          await Effect.runPromise(removeContainer(containerName));
+          await Effect.runPromise(removeContainer(containerName, options));
         },
       };
 

--- a/src/sandboxes/podman.test.ts
+++ b/src/sandboxes/podman.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", async () => {
   const actual =
@@ -22,8 +22,25 @@ import type { BindMountSandboxHandle } from "../SandboxProvider.js";
 const mockExecFile = vi.mocked(execFile);
 const mockExecFileSync = vi.mocked(execFileSync);
 
+const mockPodmanExecSuccess = () => {
+  mockExecFile.mockImplementation((_command, args, ...rest: any[]) => {
+    const callback = rest[rest.length - 1];
+    if (Array.isArray(args) && args[0] === "machine") {
+      callback(null, JSON.stringify([{ Running: true }]), "");
+    } else {
+      callback(null, "", "");
+    }
+    return undefined as any;
+  });
+};
+
+beforeEach(() => {
+  mockPodmanExecSuccess();
+});
+
 afterEach(() => {
   mockExecFile.mockReset();
+  mockExecFileSync.mockReset();
 });
 
 describe("podman()", () => {
@@ -97,12 +114,6 @@ describe("podman()", () => {
   });
 
   it("resolves relative sandboxPath against sandbox repo dir", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman({
       selinuxLabel: false,
       mounts: [{ hostPath: "src", sandboxPath: "data" }],
@@ -142,12 +153,6 @@ describe("podman()", () => {
   });
 
   it("formats readonly SELinux mounts as :ro,z", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman({
       selinuxLabel: "z",
       mounts: [{ hostPath: "~", sandboxPath: "/mnt/home", readonly: true }],
@@ -172,12 +177,6 @@ describe("podman()", () => {
   });
 
   it("formats writable SELinux mounts as :z", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman({
       selinuxLabel: "z",
       mounts: [{ hostPath: "~", sandboxPath: "/mnt/home" }],
@@ -202,12 +201,6 @@ describe("podman()", () => {
   });
 
   it("formats readonly mounts without SELinux as :ro", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman({
       selinuxLabel: false,
       mounts: [{ hostPath: "~", sandboxPath: "/mnt/home", readonly: true }],
@@ -232,12 +225,6 @@ describe("podman()", () => {
   });
 
   it("formats mounts with no options when writable and no SELinux", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman({
       selinuxLabel: false,
       mounts: [{ hostPath: "~", sandboxPath: "/mnt/home" }],
@@ -264,12 +251,6 @@ describe("podman()", () => {
   });
 
   it("passes --userns=keep-id by default", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman();
     const handle = await provider.create({
       worktreePath: "/tmp/worktree",
@@ -290,12 +271,6 @@ describe("podman()", () => {
   });
 
   it("passes custom containerUid/containerGid to --userns and --user", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman({ containerUid: 500, containerGid: 500 });
     const handle = await provider.create({
       worktreePath: "/tmp/worktree",
@@ -318,12 +293,6 @@ describe("podman()", () => {
   });
 
   it("allows disabling userns via option", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman({ userns: false });
     const handle = await provider.create({
       worktreePath: "/tmp/worktree",
@@ -344,9 +313,15 @@ describe("podman()", () => {
   });
 
   it("throws a clear error when image is not found locally", async () => {
-    // First call is podman image inspect — fail it
-    mockExecFile.mockImplementationOnce((_command, _args, callback: any) => {
-      callback(new Error("no such image"), "", "");
+    mockExecFile.mockImplementation((_command, args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      if (Array.isArray(args) && args[0] === "machine") {
+        callback(null, JSON.stringify([{ Running: true }]), "");
+      } else if (Array.isArray(args) && args[0] === "image") {
+        callback(new Error("no such image"), "", "");
+      } else {
+        callback(null, "", "");
+      }
       return undefined as any;
     });
 
@@ -405,12 +380,6 @@ describe("podman()", () => {
   });
 
   it("passes --network flag when network is a string", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman({ network: "my-network" });
     const handle = await provider.create({
       worktreePath: "/tmp/worktree",
@@ -433,12 +402,6 @@ describe("podman()", () => {
   });
 
   it("passes multiple --network flags when network is an array", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman({ network: ["net1", "net2"] });
     const handle = await provider.create({
       worktreePath: "/tmp/worktree",
@@ -464,12 +427,6 @@ describe("podman()", () => {
   });
 
   it("does not pass --network flag when network is omitted", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman();
     const handle = await provider.create({
       worktreePath: "/tmp/worktree",
@@ -490,12 +447,6 @@ describe("podman()", () => {
   });
 
   it("does not run chown after container start", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman();
     const handle = await provider.create({
       worktreePath: "/tmp/worktree",
@@ -509,9 +460,7 @@ describe("podman()", () => {
     // Verify no chown exec call was made
     const chownCall = mockExecFile.mock.calls.find(
       ([cmd, args]) =>
-        cmd === "podman" &&
-        Array.isArray(args) &&
-        args.includes("chown"),
+        cmd === "podman" && Array.isArray(args) && args.includes("chown"),
     );
     expect(chownCall).toBeUndefined();
 
@@ -519,12 +468,6 @@ describe("podman()", () => {
   });
 
   it("copyFileIn calls podman cp with correct arguments", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman();
     const handle = await provider.create({
       worktreePath: "/tmp/worktree",
@@ -555,12 +498,6 @@ describe("podman()", () => {
   });
 
   it("copyFileOut calls podman cp with correct arguments", async () => {
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman();
     const handle = await provider.create({
       worktreePath: "/tmp/worktree",
@@ -593,7 +530,9 @@ describe("podman()", () => {
   it("copyFileIn rejects when podman cp fails", async () => {
     mockExecFile.mockImplementation((_command, args, ...rest: any[]) => {
       const callback = rest[rest.length - 1];
-      if (Array.isArray(args) && args[0] === "cp") {
+      if (Array.isArray(args) && args[0] === "machine") {
+        callback(null, JSON.stringify([{ Running: true }]), "");
+      } else if (Array.isArray(args) && args[0] === "cp") {
         callback(new Error("no such file"));
       } else {
         callback(null, "", "");
@@ -621,12 +560,6 @@ describe("podman()", () => {
 
   it("includes timeout on signal handler cleanup", async () => {
     // Allow image inspect + podman run to succeed
-    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
-      const callback = rest[rest.length - 1];
-      callback(null, "", "");
-      return undefined as any;
-    });
-
     const provider = podman();
     const handle = await provider.create({
       worktreePath: "/tmp/worktree",


### PR DESCRIPTION
## Summary
Allow the Docker sandbox provider to target any configured Docker context instead of always using Docker's active context.

This makes Sandcastle easier to use with Docker-compatible runtimes such as Colima, OrbStack, Docker Desktop contexts, and remote Docker contexts without hardcoding any runtime-specific behavior.

- add a generic `context` option to the Docker sandbox provider
- pass the selected Docker context through container lifecycle, exec, copy, cleanup, and image lifecycle commands
- fix Podman provider tests so they mock a running Podman Machine on macOS instead of requiring local Podman state

## Importance

The context option is important because Docker-compatible runtimes are increasingly context-driven. Developers may have Docker Desktop, Colima, OrbStack, Podman/Docker shims, or remote Docker daemons configured side-by-side, and the active Docker context is often incidental local state rather than project intent.

Without an explicit context option, Sandcastle inherits that ambient state. That can lead to confusing failures, containers starting in the wrong runtime, missing images because they were built in a different daemon, or accidental use of a remote/default Docker context.

With docker({ context: "colima" }) or docker({ context: "orbstack" }), the sandbox configuration becomes reproducible and portable: the runtime choice lives with the Sandcastle config instead of depending on a developer’s current shell state. This makes Sandcastle more broadly usable across Docker-compatible backends while avoiding any hardcoded preference for one runtime.

## Verification
- `npm test -- src/sandboxes/docker.test.ts`
- `npm test -- src/sandboxes/podman.test.ts`
- `npm run typecheck`
- `npm run build`

## Notes
Full-suite local `npm test` still has unrelated macOS/local-environment noise outside this PR's scope: CLI tests expect `dist/main.js` unless the build has already run, and several tests compare `/var/...` paths against macOS-resolved `/private/var/...` paths.
