### PR TITLE
Update InitService template commands to use placeholder syntax

### DIFF
--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -1142,6 +1142,12 @@ describe("InitService scaffold", () => {
       expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain(
         "gh issue close",
       );
+      expect(manager!.templateArgs.VIEW_TASK_COMMAND).not.toMatch(
+        /\{\{.+?\}\}/,
+      );
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).not.toMatch(
+        /\{\{.+?\}\}/,
+      );
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(
         "GitHub CLI",
       );
@@ -1155,6 +1161,12 @@ describe("InitService scaffold", () => {
       expect(manager!.templateArgs.LIST_TASKS_COMMAND).toBe("bd ready --json");
       expect(manager!.templateArgs.VIEW_TASK_COMMAND).toContain("bd show");
       expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain("bd close");
+      expect(manager!.templateArgs.VIEW_TASK_COMMAND).not.toMatch(
+        /\{\{.+?\}\}/,
+      );
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).not.toMatch(
+        /\{\{.+?\}\}/,
+      );
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain("beads");
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain("libicu72");
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -261,8 +261,8 @@ const BACKLOG_MANAGER_REGISTRY: BacklogManagerEntry[] = [
     label: "GitHub Issues",
     templateArgs: {
       LIST_TASKS_COMMAND: `gh issue list --state open --label Sandcastle --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`,
-      VIEW_TASK_COMMAND: "gh issue view {{TASK_ID}}",
-      CLOSE_TASK_COMMAND: `gh issue close {{TASK_ID}} --comment "Completed by Sandcastle"`,
+      VIEW_TASK_COMMAND: "gh issue view <TASK_ID>",
+      CLOSE_TASK_COMMAND: `gh issue close <TASK_ID> --comment "Completed by Sandcastle"`,
       BACKLOG_MANAGER_TOOLS: GITHUB_CLI_TOOLS,
     },
     envExample: `# GitHub personal access token
@@ -273,8 +273,8 @@ GH_TOKEN=`,
     label: "Beads",
     templateArgs: {
       LIST_TASKS_COMMAND: "bd ready --json",
-      VIEW_TASK_COMMAND: "bd show {{TASK_ID}}",
-      CLOSE_TASK_COMMAND: `bd close {{TASK_ID}} "Completed by Sandcastle"`,
+      VIEW_TASK_COMMAND: "bd show <TASK_ID>",
+      CLOSE_TASK_COMMAND: `bd close <TASK_ID> "Completed by Sandcastle"`,
       BACKLOG_MANAGER_TOOLS: BEADS_TOOLS,
     },
     envExample: "",


### PR DESCRIPTION
Fix scaffolded prompts crashing at runtime with `Prompt argument "{{TASK_ID}}" has no matching value in promptArgs`. The `init` command's `VIEW_TASK_COMMAND` and `CLOSE_TASK_COMMAND` templates now use `<TASK_ID>` (agent-facing placeholder) instead of `{{TASK_ID}}` (which collides with Sandcastle's runtime substitution syntax).