### PR TITLE
Add Gitea / Forgejo Issues backlog manager

### DIFF
--- a/.changeset/gitea-forgejo-tea-backlog.md
+++ b/.changeset/gitea-forgejo-tea-backlog.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add a Gitea / Forgejo Issues backlog manager for `sandcastle init`, powered by the `tea` CLI.

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Tell the agent to output your chosen string(s) in the prompt, and the orchestrat
 
 ### Templates
 
-`sandcastle init` prompts you to choose a sandbox provider (Docker or Podman), a backlog manager (GitHub Issues or Beads), and a template, which scaffolds a ready-to-use prompt and `main.mts` suited to a specific workflow. If your project's `package.json` has `"type": "module"`, the file will be named `main.ts` instead. Five templates are available:
+`sandcastle init` prompts you to choose a sandbox provider (Docker or Podman), a backlog manager (GitHub Issues, Gitea / Forgejo Issues, or Beads), and a template, which scaffolds a ready-to-use prompt and `main.mts` suited to a specific workflow. If your project's `package.json` has `"type": "module"`, the file will be named `main.ts` instead. Five templates are available:
 
 | Template                       | Description                                                               |
 | ------------------------------ | ------------------------------------------------------------------------- |
@@ -601,6 +601,12 @@ Tell the agent to output your chosen string(s) in the prompt, and the orchestrat
 | `sequential-reviewer`          | Implements issues one by one, with a code review step after each          |
 | `parallel-planner`             | Plans parallelizable issues, executes on separate branches, then merges   |
 | `parallel-planner-with-review` | Plans parallelizable issues, executes with per-branch review, then merges |
+
+Backlog manager env vars are generated in `.sandcastle/.env.example`:
+
+- GitHub Issues uses `GH_TOKEN`.
+- Gitea / Forgejo Issues uses `GITEA_SERVER_URL` and `GITEA_ACCESS_TOKEN`.
+- Beads stores backlog state locally and does not require a token.
 
 Select a template during `sandcastle init` when prompted, or re-run init in a fresh repo to try a different one.
 

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -1121,9 +1121,10 @@ describe("InitService scaffold", () => {
   // --- Backlog manager ---
 
   describe("Backlog manager registry", () => {
-    it("listBacklogManagers returns github-issues and beads", () => {
+    it("listBacklogManagers returns github-issues, gitea-issues, and beads", () => {
       const managers = listBacklogManagers();
       expect(managers.some((m) => m.name === "github-issues")).toBe(true);
+      expect(managers.some((m) => m.name === "gitea-issues")).toBe(true);
       expect(managers.some((m) => m.name === "beads")).toBe(true);
     });
 
@@ -1146,6 +1147,43 @@ describe("InitService scaffold", () => {
         "GitHub CLI",
       );
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain("gh");
+    });
+
+    it("getBacklogManager returns gitea-issues entry with expected templateArgs and setup", () => {
+      const manager = getBacklogManager("gitea-issues");
+      expect(manager).toBeDefined();
+      expect(manager!.label).toBe("Gitea / Forgejo Issues");
+      expect(manager!.envExample).toContain("GITEA_SERVER_URL=");
+      expect(manager!.envExample).toContain("GITEA_ACCESS_TOKEN=");
+      expect(manager!.envExample).not.toContain("GITEA_SERVER_TOKEN=");
+      expect(manager!.setupCommand).toContain("GITEA_SERVER_URL");
+      expect(manager!.setupCommand).toContain("GITEA_ACCESS_TOKEN");
+      expect(manager!.setupCommand).toContain("tea login add");
+      expect(manager!.createLabelCommand).toContain("tea label create");
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "tea issues list",
+      );
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "--labels Sandcastle",
+      );
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "--output json",
+      );
+      expect(manager!.templateArgs.VIEW_TASK_COMMAND).toContain("tea issue");
+      expect(manager!.templateArgs.VIEW_TASK_COMMAND).toContain("--comments");
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain("tea comment");
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain(
+        "tea issue close",
+      );
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(
+        "TEA_VERSION",
+      );
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(
+        "dl.gitea.com/tea",
+      );
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).not.toContain(
+        "go install",
+      );
     });
 
     it("getBacklogManager returns beads entry with expected templateArgs", () => {
@@ -1648,6 +1686,196 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(prompt).not.toContain("GitHub issue");
+    });
+
+    it("generates .env.example with Gitea / Forgejo env vars when backlog manager is gitea-issues", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        backlogManager: getBacklogManager("gitea-issues"),
+      });
+
+      const envExample = await readFile(
+        join(dir, ".sandcastle", ".env.example"),
+        "utf-8",
+      );
+      expect(envExample).toContain("GITEA_SERVER_URL=");
+      expect(envExample).toContain("GITEA_ACCESS_TOKEN=");
+      expect(envExample).not.toContain("GITEA_SERVER_TOKEN=");
+      expect(envExample).not.toContain("GH_TOKEN=");
+    });
+
+    it("scaffold with gitea-issues produces Dockerfile with tea install", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        backlogManager: getBacklogManager("gitea-issues"),
+      });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfile).toContain("ARG TEA_VERSION=0.14.0");
+      expect(dockerfile).toContain("dl.gitea.com/tea");
+      expect(dockerfile).toContain("linux-amd64");
+      expect(dockerfile).toContain("linux-arm64");
+      expect(dockerfile).toContain("/usr/local/bin/tea");
+      expect(dockerfile).not.toContain("GitHub CLI");
+      expect(dockerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
+    });
+
+    it("scaffold with gitea-issues + podman produces Containerfile with tea install", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        backlogManager: getBacklogManager("gitea-issues"),
+        sandboxProvider: getSandboxProvider("podman")!,
+      });
+
+      const containerfile = await readFile(
+        join(dir, ".sandcastle", "Containerfile"),
+        "utf-8",
+      );
+      expect(containerfile).toContain("ARG TEA_VERSION=0.14.0");
+      expect(containerfile).toContain("dl.gitea.com/tea");
+      expect(containerfile).not.toContain("GitHub CLI");
+      expect(containerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
+    });
+
+    it("simple-loop with gitea-issues produces prompt with tea commands", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("gitea-issues"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("tea issues list");
+      expect(prompt).toContain("--labels Sandcastle");
+      expect(prompt).toContain("tea comment");
+      expect(prompt).toContain("tea issue close");
+      expect(prompt).not.toContain("gh issue");
+      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+    });
+
+    it("parallel-planner with gitea-issues substitutes list/view/close tea commands", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner",
+        backlogManager: getBacklogManager("gitea-issues"),
+      });
+
+      const planPrompt = await readFile(
+        join(dir, ".sandcastle", "plan-prompt.md"),
+        "utf-8",
+      );
+      const implementPrompt = await readFile(
+        join(dir, ".sandcastle", "implement-prompt.md"),
+        "utf-8",
+      );
+      const mergePrompt = await readFile(
+        join(dir, ".sandcastle", "merge-prompt.md"),
+        "utf-8",
+      );
+
+      expect(planPrompt).toContain("tea issues list");
+      expect(implementPrompt).toContain(
+        "tea issue {{TASK_ID}} --comments --output json",
+      );
+      expect(mergePrompt).toContain("tea comment");
+      expect(mergePrompt).toContain("tea issue close");
+      expect(planPrompt + implementPrompt + mergePrompt).not.toContain(
+        "gh issue",
+      );
+    });
+
+    it("gitea-issues strips --labels Sandcastle when createLabel is false", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("gitea-issues"),
+        createLabel: false,
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("tea issues list");
+      expect(prompt).not.toContain("--labels Sandcastle");
+    });
+
+    it("gitea-issues injects ordered tea setup into simple-loop onSandboxReady hook", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("gitea-issues"),
+        createLabel: true,
+      });
+
+      const main = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      const npmIndex = main.indexOf("npm install");
+      const loginIndex = main.indexOf("tea login add");
+      const labelIndex = main.indexOf("tea label create");
+
+      expect(npmIndex).toBeGreaterThan(-1);
+      expect(loginIndex).toBeGreaterThan(npmIndex);
+      expect(labelIndex).toBeGreaterThan(loginIndex);
+      expect(main.match(/onSandboxReady:/g)?.length).toBe(1);
+    });
+
+    it("gitea-issues injects setup without label creation when createLabel is false", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("gitea-issues"),
+        createLabel: false,
+      });
+
+      const main = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      expect(main).toContain("tea login add");
+      expect(main).not.toContain("tea label create");
+    });
+
+    it("gitea-issues injects a minimal hook into blank main.mts", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "blank",
+        backlogManager: getBacklogManager("gitea-issues"),
+      });
+
+      const main = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      expect(main).toContain("hooks");
+      expect(main).toContain("onSandboxReady");
+      expect(main).toContain("tea login add");
+    });
+
+    it("github-issues does not inject runtime label setup", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("github-issues"),
+        createLabel: true,
+      });
+
+      const main = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      expect(main).toContain("npm install");
+      expect(main).not.toContain("gh label create");
+      expect(main).not.toContain("tea login add");
     });
 
     // --- Dockerfile backlog manager tools ---

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -229,6 +229,10 @@ export interface BacklogManagerEntry {
     readonly CLOSE_TASK_COMMAND: string;
     readonly BACKLOG_MANAGER_TOOLS: string;
   };
+  /** Runtime sandbox command that prepares auth or other backlog state before prompts run. */
+  readonly setupCommand?: string;
+  /** Runtime sandbox command that creates the Sandcastle label best-effort. */
+  readonly createLabelCommand?: string;
   /** Lines to append to `.env.example` for this backlog manager, or empty string if none needed. */
   readonly envExample: string;
 }
@@ -255,6 +259,17 @@ RUN curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/i
 
 RUN corepack enable`;
 
+const TEA_TOOLS = `# Install tea CLI for Gitea / Forgejo
+ARG TEA_VERSION=0.14.0
+RUN set -eux; \\
+  case "$(dpkg --print-architecture)" in \\
+    amd64) TEA_ARCH="linux-amd64" ;; \\
+    arm64) TEA_ARCH="linux-arm64" ;; \\
+    *) echo "Unsupported architecture for tea: $(dpkg --print-architecture)" >&2; exit 1 ;; \\
+  esac; \\
+  curl -fsSL -o /usr/local/bin/tea "https://dl.gitea.com/tea/\${TEA_VERSION}/tea-\${TEA_VERSION}-\${TEA_ARCH}"; \\
+  chmod +x /usr/local/bin/tea`;
+
 const BACKLOG_MANAGER_REGISTRY: BacklogManagerEntry[] = [
   {
     name: "github-issues",
@@ -267,6 +282,29 @@ const BACKLOG_MANAGER_REGISTRY: BacklogManagerEntry[] = [
     },
     envExample: `# GitHub personal access token
 GH_TOKEN=`,
+  },
+  {
+    name: "gitea-issues",
+    label: "Gitea / Forgejo Issues",
+    templateArgs: {
+      LIST_TASKS_COMMAND:
+        "tea issues list --state open --labels Sandcastle --fields index,title,body,labels,comments --output json",
+      VIEW_TASK_COMMAND: "tea issue {{TASK_ID}} --comments --output json",
+      CLOSE_TASK_COMMAND: `tea comment {{TASK_ID}} "Completed by Sandcastle" && tea issue close {{TASK_ID}}`,
+      BACKLOG_MANAGER_TOOLS: TEA_TOOLS,
+    },
+    setupCommand: `if [ -z "$GITEA_SERVER_URL" ] || [ -z "$GITEA_ACCESS_TOKEN" ]; then
+  echo "GITEA_SERVER_URL and GITEA_ACCESS_TOKEN must be set for Gitea / Forgejo backlog access" >&2
+  exit 1
+fi
+tea login add --name sandcastle --url "$GITEA_SERVER_URL" --token "$GITEA_ACCESS_TOKEN" --no-version-check 2>/dev/null || true
+tea login default sandcastle`,
+    createLabelCommand: `tea label create --name Sandcastle --color F9A825 --description "Issues for Sandcastle to work on" 2>/dev/null || true`,
+    envExample: `# Gitea / Forgejo server URL
+GITEA_SERVER_URL=
+
+# Gitea / Forgejo personal access token
+GITEA_ACCESS_TOKEN=`,
   },
   {
     name: "beads",
@@ -500,7 +538,9 @@ const rewritePromptFiles = (
           const content = yield* fs
             .readFileString(filePath)
             .pipe(Effect.mapError((e) => new Error(e.message)));
-          const updated = content.replace(/ --label Sandcastle/g, "");
+          const updated = content
+            .replace(/ --label Sandcastle/g, "")
+            .replace(/ --labels Sandcastle/g, "");
           if (updated !== content) {
             yield* fs
               .writeFileString(filePath, updated)
@@ -510,6 +550,77 @@ const rewritePromptFiles = (
       ),
       { concurrency: "unbounded" },
     );
+  });
+
+const joinShellCommands = (commands: readonly string[]): string =>
+  ["set -e", ...commands.filter((command) => command.trim().length > 0)].join(
+    "\n",
+  );
+
+const buildBacklogSetupCommand = (
+  backlogManager: BacklogManagerEntry,
+  createLabel: boolean,
+): string | undefined => {
+  const commands = [
+    backlogManager.setupCommand,
+    createLabel ? backlogManager.createLabelCommand : undefined,
+  ].filter((command): command is string => Boolean(command));
+
+  if (commands.length === 0) return undefined;
+  return joinShellCommands(commands);
+};
+
+const mergeBacklogSetupWithExistingCommand = (
+  existingCommand: string,
+  backlogSetupCommand: string,
+): string => joinShellCommands([existingCommand, backlogSetupCommand]);
+
+const rewriteMainTsHooks = (
+  configDir: string,
+  mainFilename: string,
+  backlogManager: BacklogManagerEntry,
+  createLabel: boolean,
+): Effect.Effect<void, Error, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const backlogSetupCommand = buildBacklogSetupCommand(
+      backlogManager,
+      createLabel,
+    );
+    if (!backlogSetupCommand) return;
+
+    const fs = yield* FileSystem.FileSystem;
+    const mainTsPath = join(configDir, mainFilename);
+    const exists = yield* fs
+      .exists(mainTsPath)
+      .pipe(Effect.mapError((e) => new Error(e.message)));
+    if (!exists) return;
+
+    const content = yield* fs
+      .readFileString(mainTsPath)
+      .pipe(Effect.mapError((e) => new Error(e.message)));
+
+    const npmInstallHook = `onSandboxReady: [{ command: "npm install" }]`;
+    const mergedHookCommand = mergeBacklogSetupWithExistingCommand(
+      "npm install",
+      backlogSetupCommand,
+    );
+    let updated = content.replace(
+      npmInstallHook,
+      `onSandboxReady: [{ command: ${JSON.stringify(mergedHookCommand)} }]`,
+    );
+
+    if (updated === content) {
+      updated = content.replace(
+        /(\n\s*sandbox: [a-zA-Z]+\(\),\n)/,
+        `$1  hooks: {\n    sandbox: {\n      onSandboxReady: [{ command: ${JSON.stringify(backlogSetupCommand)} }],\n    },\n  },\n`,
+      );
+    }
+
+    if (updated !== content) {
+      yield* fs
+        .writeFileString(mainTsPath, updated)
+        .pipe(Effect.mapError((e) => new Error(e.message)));
+    }
   });
 
 /** Text file extensions eligible for `{{KEY}}` template argument substitution. */
@@ -679,6 +790,13 @@ export const scaffold = (
 
     // Rewrite main file with the selected agent factory and model
     yield* rewriteMainTs(configDir, agent, model, mainFilename);
+
+    yield* rewriteMainTsHooks(
+      configDir,
+      mainFilename,
+      backlogManager,
+      createLabel,
+    );
 
     // Replace backlog manager template arguments in all text files (must run before label stripping)
     yield* substituteTemplateArgs(configDir, backlogManager);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -233,18 +233,24 @@ const initCommand = Command.make(
         selectedTemplate = selected as string;
       }
 
-      // Offer to create the "Sandcastle" label on the repo (skip for non-GitHub backlog managers)
+      // Offer to create the "Sandcastle" label for issue-backed backlog managers.
       let shouldCreateLabel: boolean | symbol = false;
-      if (selectedBacklogManager.name === "github-issues") {
+      if (
+        selectedBacklogManager.name === "github-issues" ||
+        selectedBacklogManager.createLabelCommand
+      ) {
         shouldCreateLabel = yield* Effect.promise(() =>
           clack.confirm({
             message:
-              'Create a "Sandcastle" GitHub label? (Templates filter issues by this label)',
+              'Create a "Sandcastle" label? (Templates filter issues by this label)',
             initialValue: true,
           }),
         );
 
-        if (shouldCreateLabel === true) {
+        if (
+          selectedBacklogManager.name === "github-issues" &&
+          shouldCreateLabel === true
+        ) {
           yield* Effect.try({
             try: () =>
               execSync(


### PR DESCRIPTION
## Summary

Adds a new `Gitea / Forgejo Issues` backlog manager for `sandcastle init`, powered by the `tea` CLI.

This lets users scaffold the existing Sandcastle issue-based workflows against Gitea-compatible forges, including Forgejo, without manually rewriting generated prompts or sandbox setup.

## What changed

- Adds a `gitea-issues` backlog manager option.
- Installs the `tea` CLI in generated Dockerfile/Containerfile output.
- Generates `.sandcastle/.env.example` entries for:

  ```env
  GITEA_SERVER_URL=
  GITEA_ACCESS_TOKEN=
  ```

- Runs `tea login` inside the sandbox at startup, after `.sandcastle/.env` has been loaded.
- Substitutes generated prompt commands for listing, viewing, commenting on, and closing issues via `tea`.
- Supports optional `Sandcastle` label creation for Gitea / Forgejo.
- Keeps the existing GitHub Issues and Beads flows intact.
- Documents the new backlog manager and adds a patch changeset.

## Setup note

After running `sandcastle init` with `Gitea / Forgejo Issues`, users need to set these values in `.sandcastle/.env`:

```env
GITEA_SERVER_URL=https://your-forgejo-or-gitea-instance
GITEA_ACCESS_TOKEN=your-personal-access-token
```

The generated sandbox setup uses those values to authenticate `tea` before the agent reads or updates issues.

## Manual testing

I manually tested this successfully against a project hosted on Forgejo. The generated setup was able to authenticate with `tea`, read issues from the Forgejo project, and use the generated workflow as the issue tracker backend.

## Test plan

- `npx vitest run src/InitService.test.ts`
- `npx prettier --check README.md src/InitService.ts src/InitService.test.ts src/cli.ts .changeset/gitea-forgejo-tea-backlog.md`
- `git diff --check origin/main..HEAD`

## Notes

I found no `CONTRIBUTING.md` or pull request template in the repository. I followed the local repository guidance in `CLAUDE.md` by adding a patch changeset and updating the README for the user-facing behavior.