### PR TITLE
Add ports option to docker() sandbox provider

### DIFF
--- a/.changeset/docker-ports-option.md
+++ b/.changeset/docker-ports-option.md
@@ -4,14 +4,26 @@
 
 Add `ports` option to the `docker()` sandbox provider.
 
-When an agent starts a web server inside the sandbox container, the container is created without port mappings by default, so the host cannot reach the service. The new `ports` option accepts a list of port numbers and maps each one as `-p <port>:<port>` in the `docker run` command.
+When an agent starts a web server inside the sandbox container, the container is created without port mappings by default, so the host cannot reach the service. The new `ports` option maps ports via `-p` flags in the `docker run` command.
+
+Each entry is either a `number` (symmetric `port:port`) or a `string` (explicit `hostPort:containerPort`):
 
 ```ts
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 
+// Symmetric — same port on host and in container
+// Works for any language/framework: Python, Rust, Ruby, Node, etc.
 await run({
   agent: claudeCode("claude-opus-4-7"),
-  sandbox: docker({ ports: [3000, 5173] }),
+  sandbox: docker({ ports: [3000, 8000, 4321] }),
+  promptFile: ".sandcastle/prompt.md",
+});
+
+// Asymmetric — host port 3001 maps to container port 3000
+await run({
+  agent: claudeCode("claude-opus-4-7"),
+  sandbox: docker({ ports: ["3001:3000"] }),
   promptFile: ".sandcastle/prompt.md",
 });
 ```
+

--- a/.changeset/docker-ports-option.md
+++ b/.changeset/docker-ports-option.md
@@ -2,17 +2,19 @@
 "@ai-hero/sandcastle": patch
 ---
 
-Add `ports` option to the `docker()` sandbox provider.
+Add `ports` option to the `docker()` and `podman()` sandbox providers.
 
-When an agent starts a web server inside the sandbox container, the container is created without port mappings by default, so the host cannot reach the service. The new `ports` option maps ports via `-p` flags in the `docker run` command.
+When an agent starts a web server inside the sandbox container, the container is created without port mappings by default, so the host cannot reach the service. The new `ports` option maps ports via `-p` flags in the container run command.
+
+Works for any language or framework — Python, Rust, Ruby, Angular, Astro, React, Vue, TanStack, Next.js, Express, and more.
 
 Each entry is either a `number` (symmetric `port:port`) or a `string` (explicit `hostPort:containerPort`):
 
 ```ts
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { podman } from "@ai-hero/sandcastle/sandboxes/podman";
 
 // Symmetric — same port on host and in container
-// Works for any language/framework: Python, Rust, Ruby, Node, etc.
 await run({
   agent: claudeCode("claude-opus-4-7"),
   sandbox: docker({ ports: [3000, 8000, 4321] }),
@@ -22,8 +24,9 @@ await run({
 // Asymmetric — host port 3001 maps to container port 3000
 await run({
   agent: claudeCode("claude-opus-4-7"),
-  sandbox: docker({ ports: ["3001:3000"] }),
+  sandbox: podman({ ports: ["3001:3000"] }),
   promptFile: ".sandcastle/prompt.md",
 });
 ```
+
 

--- a/.changeset/docker-ports-option.md
+++ b/.changeset/docker-ports-option.md
@@ -1,0 +1,17 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add `ports` option to the `docker()` sandbox provider.
+
+When an agent starts a web server inside the sandbox container, the container is created without port mappings by default, so the host cannot reach the service. The new `ports` option accepts a list of port numbers and maps each one as `-p <port>:<port>` in the `docker run` command.
+
+```ts
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+
+await run({
+  agent: claudeCode("claude-opus-4-7"),
+  sandbox: docker({ ports: [3000, 5173] }),
+  promptFile: ".sandcastle/prompt.md",
+});
+```

--- a/src/DockerLifecycle.test.ts
+++ b/src/DockerLifecycle.test.ts
@@ -72,4 +72,64 @@ describe("startContainer", () => {
     const runArgs = runCall![1] as string[];
     expect(runArgs).not.toContain("--network");
   });
+
+  it("passes -p flag when ports contains a single port", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer("ctr", "img", {}, { ports: [3000] }),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    expect(runCall).toBeDefined();
+    const runArgs = runCall![1] as string[];
+    const idx = runArgs.indexOf("-p");
+    expect(idx).toBeGreaterThan(-1);
+    expect(runArgs[idx + 1]).toBe("3000:3000");
+  });
+
+  it("passes multiple -p flags when ports has multiple values", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer("ctr", "img", {}, { ports: [3000, 5173] }),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    expect(runCall).toBeDefined();
+    const runArgs = runCall![1] as string[];
+
+    const firstIdx = runArgs.indexOf("-p");
+    expect(firstIdx).toBeGreaterThan(-1);
+    expect(runArgs[firstIdx + 1]).toBe("3000:3000");
+
+    const secondIdx = runArgs.indexOf("-p", firstIdx + 1);
+    expect(secondIdx).toBeGreaterThan(-1);
+    expect(runArgs[secondIdx + 1]).toBe("5173:5173");
+  });
+
+  it("does not pass -p when ports is omitted", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(startContainer("ctr", "img", {}));
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    expect(runArgs).not.toContain("-p");
+  });
 });

--- a/src/DockerLifecycle.test.ts
+++ b/src/DockerLifecycle.test.ts
@@ -132,4 +132,24 @@ describe("startContainer", () => {
     const runArgs = runCall![1] as string[];
     expect(runArgs).not.toContain("-p");
   });
+
+  it("passes string port entry as-is for asymmetric host:container mapping", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer("ctr", "img", {}, { ports: ["3001:3000"] }),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    expect(runCall).toBeDefined();
+    const runArgs = runCall![1] as string[];
+    const idx = runArgs.indexOf("-p");
+    expect(idx).toBeGreaterThan(-1);
+    expect(runArgs[idx + 1]).toBe("3001:3000");
+  });
 });

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -59,6 +59,11 @@ export interface StartContainerOptions {
   readonly user?: string;
   /** Docker network(s) to attach the container to. Passed as `--network` flags. */
   readonly network?: string | readonly string[];
+  /**
+   * Host ports to publish from the container.
+   * Each entry produces a `-p <port>:<port>` flag in the `docker run` command.
+   */
+  readonly ports?: readonly number[];
 }
 
 /**
@@ -108,6 +113,11 @@ export const startContainer = (
       : [];
     const networkFlags = networks.flatMap((n) => ["--network", n]);
 
+    const portFlags = (options?.ports ?? []).flatMap((p) => [
+      "-p",
+      `${p}:${p}`,
+    ]);
+
     yield* dockerExec([
       "run",
       "-d",
@@ -118,6 +128,7 @@ export const startContainer = (
       ...workdirFlags,
       ...userFlags,
       ...networkFlags,
+      ...portFlags,
       imageName,
     ]);
   });

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -61,9 +61,11 @@ export interface StartContainerOptions {
   readonly network?: string | readonly string[];
   /**
    * Host ports to publish from the container.
-   * Each entry produces a `-p <port>:<port>` flag in the `docker run` command.
+   *
+   * - `number` → symmetric mapping: `-p <port>:<port>`
+   * - `string` → pass-through: `-p <hostPort>:<containerPort>` (e.g. `"3001:3000"`)
    */
-  readonly ports?: readonly number[];
+  readonly ports?: readonly (number | string)[];
 }
 
 /**
@@ -115,7 +117,7 @@ export const startContainer = (
 
     const portFlags = (options?.ports ?? []).flatMap((p) => [
       "-p",
-      `${p}:${p}`,
+      typeof p === "number" ? `${p}:${p}` : p,
     ]);
 
     yield* dockerExec([

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -136,6 +136,16 @@ describe("docker()", () => {
     expect(provider.tag).toBe("bind-mount");
   });
 
+  it("accepts a ports option with string entries for asymmetric mapping", () => {
+    const provider = docker({ ports: ["3001:3000", "8081:8000"] });
+    expect(provider.tag).toBe("bind-mount");
+  });
+
+  it("accepts a ports option mixing numbers and strings", () => {
+    const provider = docker({ ports: [5173, "3001:3000"] });
+    expect(provider.tag).toBe("bind-mount");
+  });
+
   it("copyFileIn calls docker cp with correct arguments", async () => {
     mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
       const callback = rest[rest.length - 1];

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -126,6 +126,16 @@ describe("docker()", () => {
     expect(provider.tag).toBe("bind-mount");
   });
 
+  it("accepts a ports option", () => {
+    const provider = docker({ ports: [3000, 5173] });
+    expect(provider.tag).toBe("bind-mount");
+  });
+
+  it("accepts a ports option with a single port", () => {
+    const provider = docker({ ports: [8080] });
+    expect(provider.tag).toBe("bind-mount");
+  });
+
   it("copyFileIn calls docker cp with correct arguments", async () => {
     mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
       const callback = rest[rest.length - 1];

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -51,13 +51,19 @@ export interface DockerOptions {
   /**
    * Host ports to publish from the sandbox container.
    *
-   * Each port produces a `-p <port>:<port>` flag, making the port reachable
-   * from the host. Declare every port the agent may listen on upfront.
+   * Each entry is passed as a `-p` flag to `docker run`:
+   * - `number` → symmetric: `-p <port>:<port>` — use when host and container port are the same
+   * - `string` → explicit mapping: `-p <hostPort>:<containerPort>` — use when ports differ
    *
    * @example
-   *   docker({ ports: [3000, 5173] })
+   *   // Symmetric — same port on host and in container
+   *   docker({ ports: [3000, 8000, 4321] })
+   *
+   * @example
+   *   // Asymmetric — host port 3001 maps to container port 3000
+   *   docker({ ports: ["3001:3000"] })
    */
-  readonly ports?: readonly number[];
+  readonly ports?: readonly (number | string)[];
 }
 
 /**

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -48,6 +48,16 @@ export interface DockerOptions {
    * When omitted, Docker's default bridge network is used.
    */
   readonly network?: string | readonly string[];
+  /**
+   * Host ports to publish from the sandbox container.
+   *
+   * Each port produces a `-p <port>:<port>` flag, making the port reachable
+   * from the host. Declare every port the agent may listen on upfront.
+   *
+   * @example
+   *   docker({ ports: [3000, 5173] })
+   */
+  readonly ports?: readonly number[];
 }
 
 /**
@@ -105,6 +115,7 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
             workdir: worktreePath,
             user: `${hostUid}:${hostGid}`,
             network: options?.network,
+            ports: options?.ports,
           },
         ),
       );

--- a/src/sandboxes/podman.test.ts
+++ b/src/sandboxes/podman.test.ts
@@ -489,6 +489,135 @@ describe("podman()", () => {
     await handle.close();
   });
 
+  it("accepts a ports option", () => {
+    const provider = podman({ ports: [3000, 5173] });
+    expect(provider.tag).toBe("bind-mount");
+  });
+
+  it("accepts a ports option with string entries for asymmetric mapping", () => {
+    const provider = podman({ ports: ["3001:3000"] });
+    expect(provider.tag).toBe("bind-mount");
+  });
+
+  it("accepts a ports option mixing numbers and strings", () => {
+    const provider = podman({ ports: [5173, "3001:3000"] });
+    expect(provider.tag).toBe("bind-mount");
+  });
+
+  it("passes -p flag when ports contains a single port", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({ ports: [3000] });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1] as string[];
+
+    const idx = runArgs.indexOf("-p");
+    expect(idx).toBeGreaterThan(-1);
+    expect(runArgs[idx + 1]).toBe("3000:3000");
+
+    await handle.close();
+  });
+
+  it("passes multiple -p flags when ports has multiple values", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({ ports: [3000, 5173] });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1] as string[];
+
+    const firstIdx = runArgs.indexOf("-p");
+    expect(firstIdx).toBeGreaterThan(-1);
+    expect(runArgs[firstIdx + 1]).toBe("3000:3000");
+
+    const secondIdx = runArgs.indexOf("-p", firstIdx + 1);
+    expect(secondIdx).toBeGreaterThan(-1);
+    expect(runArgs[secondIdx + 1]).toBe("5173:5173");
+
+    await handle.close();
+  });
+
+  it("passes string port entry as-is for asymmetric host:container mapping", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({ ports: ["3001:3000"] });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1] as string[];
+
+    const idx = runArgs.indexOf("-p");
+    expect(idx).toBeGreaterThan(-1);
+    expect(runArgs[idx + 1]).toBe("3001:3000");
+
+    await handle.close();
+  });
+
+  it("does not pass -p when ports is omitted", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1] as string[];
+
+    expect(runArgs).not.toContain("-p");
+
+    await handle.close();
+  });
+
   it("does not run chown after container start", async () => {
     mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
       const callback = rest[rest.length - 1];
@@ -509,9 +638,7 @@ describe("podman()", () => {
     // Verify no chown exec call was made
     const chownCall = mockExecFile.mock.calls.find(
       ([cmd, args]) =>
-        cmd === "podman" &&
-        Array.isArray(args) &&
-        args.includes("chown"),
+        cmd === "podman" && Array.isArray(args) && args.includes("chown"),
     );
     expect(chownCall).toBeUndefined();
 

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -77,6 +77,19 @@ export interface PodmanOptions {
    * When omitted, Podman's default network is used.
    */
   readonly network?: string | readonly string[];
+  /**
+   * Host ports to publish from the sandbox container.
+   *
+   * Each entry is passed as a `-p` flag to `podman run`:
+   * - `number` → symmetric: `-p <port>:<port>`
+   * - `string` → explicit mapping: `-p <hostPort>:<containerPort>` (e.g. `"3001:3000"`)
+   *
+   * @example
+   *   podman({ ports: [3000, 8000, 4321] })
+   * @example
+   *   podman({ ports: ["3001:3000"] })
+   */
+  readonly ports?: readonly (number | string)[];
 }
 
 /**
@@ -146,6 +159,10 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
           : [options.network]
         : [];
       const networkArgs = networks.flatMap((n) => ["--network", n]);
+      const portArgs = (options?.ports ?? []).flatMap((p) => [
+        "-p",
+        typeof p === "number" ? `${p}:${p}` : p,
+      ]);
 
       // Start container via podman run
       await new Promise<void>((resolve, reject) => {
@@ -159,6 +176,7 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
             ...userArgs,
             ...usernsArgs,
             ...networkArgs,
+            ...portArgs,
             "-w",
             worktreePath,
             ...envArgs,


### PR DESCRIPTION
## Problem

When an agent starts a web server inside the sandbox container, the container is created without port mappings. The host cannot reach the service on any port the agent opens.

The workaround is a manual socat sidecar:

```bash
docker run -d --name port-forward -p 3000:3000 alpine/socat TCP-LISTEN:3000,fork,reuseaddr TCP:172.17.0.2:3000
```

This is not a viable option for end users.

## Solution

Add a `ports` option to the `docker()` sandbox provider. Each declared port is mapped as `-p <port>:<port>` in the `docker run` command, making the port reachable from the host.

```ts
import { docker } from "@ai-hero/sandcastle/sandboxes/docker";

await run({
  agent: claudeCode("claude-opus-4-7"),
  sandbox: docker({ ports: [3000, 5173] }),
  promptFile: ".sandcastle/prompt.md",
});
```

## Changes

| File | Change |
|------|--------|
| `src/DockerLifecycle.ts` | Add `ports?: readonly number[]` to `StartContainerOptions`, generate `-p <port>:<port>` flags |
| `src/sandboxes/docker.ts` | Add `ports?: readonly number[]` to `DockerOptions`, pass through to `startContainer` |
| `src/DockerLifecycle.test.ts` | 3 tests: single port, multiple ports, omitted |
| `src/sandboxes/docker.test.ts` | 2 acceptance tests |
| `.changeset/docker-ports-option.md` | Patch changeset |

## Test plan

- [x] `npm test -- src/DockerLifecycle.test.ts src/sandboxes/docker.test.ts` — 26/26 pass
- [x] All new tests pass, no regressions in the Docker test files
- [x] Type check: no new errors beyond the pre-existing `@daytona/sdk` peer dep issue