### PR TITLE
Add Linear backlog manager support

### DIFF
--- a/.changeset/fuzzy-linear-labels.md
+++ b/.changeset/fuzzy-linear-labels.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": minor
+---
+
+Add Linear as a backlog manager for `sandcastle init`, using Linear's official remote MCP server instead of recommending an unofficial CLI.

--- a/README.md
+++ b/README.md
@@ -592,17 +592,29 @@ Tell the agent to output your chosen string(s) in the prompt, and the orchestrat
 
 ### Templates
 
-`sandcastle init` prompts you to choose a sandbox provider (Docker or Podman), a backlog manager (GitHub Issues or Beads), and a template, which scaffolds a ready-to-use prompt and `main.mts` suited to a specific workflow. If your project's `package.json` has `"type": "module"`, the file will be named `main.ts` instead. Five templates are available:
+`sandcastle init` prompts you to choose a sandbox provider (Docker or Podman), a backlog manager (GitHub Issues, Beads, or Linear), and a template, which scaffolds a ready-to-use prompt and `main.mts` suited to a specific workflow. If your project's `package.json` has `"type": "module"`, the file will be named `main.ts` instead. Five templates are available:
 
-| Template                       | Description                                                               |
-| ------------------------------ | ------------------------------------------------------------------------- |
-| `blank`                        | Bare scaffold — write your own prompt and orchestration                   |
-| `simple-loop`                  | Picks GitHub issues one by one and closes them                            |
-| `sequential-reviewer`          | Implements issues one by one, with a code review step after each          |
-| `parallel-planner`             | Plans parallelizable issues, executes on separate branches, then merges   |
-| `parallel-planner-with-review` | Plans parallelizable issues, executes with per-branch review, then merges |
+| Template                       | Description                                                              |
+| ------------------------------ | ------------------------------------------------------------------------ |
+| `blank`                        | Bare scaffold — write your own prompt and orchestration                  |
+| `simple-loop`                  | Picks tasks one by one and closes them                                   |
+| `sequential-reviewer`          | Implements tasks one by one, with a code review step after each          |
+| `parallel-planner`             | Plans parallelizable tasks, executes on separate branches, then merges   |
+| `parallel-planner-with-review` | Plans parallelizable tasks, executes with per-branch review, then merges |
 
 Select a template during `sandcastle init` when prompted, or re-run init in a fresh repo to try a different one.
+
+### Backlog managers
+
+Templates are parameterized by the backlog manager selected during `sandcastle init`:
+
+- **GitHub Issues** installs `gh`, lists open issues with the `Sandcastle` label, views issues with `gh issue view`, and closes issues with a completion comment.
+- **Beads** installs `bd` and uses `bd ready`, `bd show`, and `bd close`.
+- **Linear** uses Linear's official remote MCP server at `https://mcp.linear.app/mcp`; generated prompts ask the agent to find `Sandcastle`-labelled Linear issues, inspect them with MCP tools, and complete them by adding a comment and moving them to the configured done state.
+
+GitHub Issues offers to create the `Sandcastle` label during init. If you decline, the generated prompts remove the `--label Sandcastle` filter.
+
+For Linear, configure your agent to use the official MCP endpoint before running Sandcastle. For Codex, run `codex mcp add linear --url https://mcp.linear.app/mcp`; for Claude Code, run `claude mcp add --transport http linear-server https://mcp.linear.app/mcp`. You can also set `LINEAR_API_KEY` in `.sandcastle/.env` and configure the MCP client to pass it as a bearer token. To use a different completion state, set `LINEAR_DONE_STATE`.
 
 ## CLI commands
 
@@ -1109,7 +1121,7 @@ The `.sandcastle/Dockerfile` controls the sandbox environment. The default templ
 
 - **Node.js 22** (base image)
 - **git**, **curl**, **jq** (system dependencies)
-- **GitHub CLI** (`gh`)
+- Backlog manager tooling for the selected backlog manager, such as **GitHub CLI** (`gh`) or **Beads** (`bd`); Linear uses the official remote MCP server instead of installing a CLI.
 - **Claude Code CLI**
 - A non-root `agent` user (required — Claude runs as this user)
 
@@ -1117,7 +1129,7 @@ When customizing the Dockerfile, ensure you keep:
 
 - A non-root user (the default `agent` user) for Claude to run as
 - `git` (required for commits and branch operations)
-- `gh` (required for issue fetching)
+- The selected backlog manager CLI (required for task fetching)
 - Claude Code CLI installed and on PATH
 
 Add your project-specific dependencies (e.g., language runtimes, build tools) to the Dockerfile as needed.

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -25,10 +25,10 @@ The `config.json` file controls how Sandcastle operates:
 
 ### Options
 
-| Option | Description | Default |
-| --- | --- | --- |
-| `agent` | The agent provider to use | `"claude-code"` |
-| `maxIterations` | Maximum iterations per run | `10` |
+| Option          | Description                | Default         |
+| --------------- | -------------------------- | --------------- |
+| `agent`         | The agent provider to use  | `"claude-code"` |
+| `maxIterations` | Maximum iterations per run | `10`            |
 
 ## Prompt
 
@@ -36,6 +36,16 @@ The `prompt.md` file is the instruction text passed to the agent at the start of
 
 - **Prompt arguments** -- `{{KEY}}` placeholders replaced with values from `promptArgs`
 - **Shell expressions** -- `` !`command` `` markers that evaluate shell commands inside the sandbox
+
+## Backlog Managers
+
+`sandcastle init` can scaffold prompts for GitHub Issues, Beads, or Linear.
+
+- **GitHub Issues** uses the `gh` CLI and filters open issues with the `Sandcastle` label by default.
+- **Beads** uses the `bd` CLI and reads ready tasks from Beads.
+- **Linear** uses Linear's official remote MCP server at `https://mcp.linear.app/mcp`; generated prompts ask the agent to work from `Sandcastle`-labelled Linear issues through MCP tools.
+
+For Linear, configure your agent with the official MCP endpoint before running Sandcastle. For Codex, run `codex mcp add linear --url https://mcp.linear.app/mcp`; for Claude Code, run `claude mcp add --transport http linear-server https://mcp.linear.app/mcp`. You can also set `LINEAR_API_KEY` in `.sandcastle/.env` and configure the MCP client to pass it as a bearer token. Set `LINEAR_DONE_STATE` if your completion state is not the default `Done`.
 
 ## Environment Variables
 

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -12,10 +12,15 @@ import {
   listTemplates,
   listBacklogManagers,
   getBacklogManager,
+  initializeBacklogManager,
   listSandboxProviders,
   getSandboxProvider,
 } from "./InitService.js";
-import type { AgentEntry, ScaffoldOptions } from "./InitService.js";
+import type {
+  AgentEntry,
+  BacklogManagerInitResult,
+  ScaffoldOptions,
+} from "./InitService.js";
 import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
 import { SKELETON_PROMPT } from "./templates.js";
 
@@ -37,6 +42,59 @@ const runScaffold = (repoDir: string, options?: Partial<ScaffoldOptions>) =>
       Effect.provide(NodeFileSystem.layer),
     ),
   );
+
+const stripSandcastleLabelInit: BacklogManagerInitResult = {
+  rewritePromptFile: (content) => content.replaceAll(" --label Sandcastle", ""),
+};
+
+const createFakeShell = (options?: { throwOnRun?: Error }) => {
+  const commands: string[] = [];
+  return {
+    commands,
+    shell: {
+      run: (command: string) => {
+        commands.push(command);
+        if (options?.throwOnRun) {
+          throw options.throwOnRun;
+        }
+      },
+    },
+  };
+};
+
+const runBacklogManagerInit = (
+  managerName: string,
+  options: {
+    confirm: boolean | symbol;
+    shell: {
+      run: (command: string) => void;
+    };
+  },
+) => {
+  const manager = getBacklogManager(managerName)!;
+  const prompts: string[] = [];
+
+  const result = Effect.runPromise(
+    initializeBacklogManager(manager, {
+      managerLabel: manager.label,
+      confirm: async ({ message }) => {
+        prompts.push(message);
+        return options.confirm;
+      },
+      shell: {
+        run: (command) => {
+          options.shell.run(command);
+        },
+      },
+    }),
+  );
+
+  return {
+    manager,
+    prompts,
+    result,
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Agent registry
@@ -198,6 +256,22 @@ describe("InitService scaffold", () => {
       join(dir, ".sandcastle", ".env.example"),
       "utf-8",
     );
+    expect(envExample).not.toContain("GH_TOKEN=");
+  });
+
+  it("generates .env.example with Linear env vars when backlog manager is linear", async () => {
+    const dir = await makeDir();
+    await runScaffold(dir, {
+      backlogManager: getBacklogManager("linear"),
+    });
+
+    const envExample = await readFile(
+      join(dir, ".sandcastle", ".env.example"),
+      "utf-8",
+    );
+    expect(envExample).toContain("LINEAR_API_KEY=");
+    expect(envExample).not.toContain("LINEAR_WORKSPACE=");
+    expect(envExample).toContain("LINEAR_DONE_STATE=Done");
     expect(envExample).not.toContain("GH_TOKEN=");
   });
 
@@ -695,11 +769,11 @@ describe("InitService scaffold", () => {
     expect(mainTs).not.toContain("claudeCode");
   });
 
-  // --- createLabel option ---
+  // --- backlogManagerInit option ---
 
-  it("simple-loop prompt.md retains --label Sandcastle when createLabel is true", async () => {
+  it("simple-loop prompt.md retains --label Sandcastle with default init result", async () => {
     const dir = await makeDir();
-    await runScaffold(dir, { templateName: "simple-loop", createLabel: true });
+    await runScaffold(dir, { templateName: "simple-loop" });
 
     const prompt = await readFile(
       join(dir, ".sandcastle", "prompt.md"),
@@ -708,9 +782,12 @@ describe("InitService scaffold", () => {
     expect(prompt).toContain("--label Sandcastle");
   });
 
-  it("simple-loop prompt.md strips --label Sandcastle when createLabel is false", async () => {
+  it("simple-loop prompt.md strips --label Sandcastle when init result rewrites prompts", async () => {
     const dir = await makeDir();
-    await runScaffold(dir, { templateName: "simple-loop", createLabel: false });
+    await runScaffold(dir, {
+      templateName: "simple-loop",
+      backlogManagerInit: stripSandcastleLabelInit,
+    });
 
     const prompt = await readFile(
       join(dir, ".sandcastle", "prompt.md"),
@@ -723,11 +800,11 @@ describe("InitService scaffold", () => {
     expect(prompt).not.toMatch(/gh issue list {2}/);
   });
 
-  it("parallel-planner plan-prompt.md strips --label Sandcastle when createLabel is false", async () => {
+  it("parallel-planner plan-prompt.md strips --label Sandcastle when init result rewrites prompts", async () => {
     const dir = await makeDir();
     await runScaffold(dir, {
       templateName: "parallel-planner",
-      createLabel: false,
+      backlogManagerInit: stripSandcastleLabelInit,
     });
 
     const prompt = await readFile(
@@ -738,11 +815,11 @@ describe("InitService scaffold", () => {
     expect(prompt).toContain("gh issue list");
   });
 
-  it("sequential-reviewer implement-prompt.md strips --label Sandcastle when createLabel is false", async () => {
+  it("sequential-reviewer implement-prompt.md strips --label Sandcastle when init result rewrites prompts", async () => {
     const dir = await makeDir();
     await runScaffold(dir, {
       templateName: "sequential-reviewer",
-      createLabel: false,
+      backlogManagerInit: stripSandcastleLabelInit,
     });
 
     const prompt = await readFile(
@@ -755,7 +832,7 @@ describe("InitService scaffold", () => {
 
   it("scaffolded prompts that lack a runtime TASK_ID do not contain {{TASK_ID}}", async () => {
     // Regression test for #477: the {{TASK_ID}} placeholder inside
-    // VIEW_TASK_COMMAND / CLOSE_TASK_COMMAND used to leak into prompts
+    // VIEW_TASK_SOURCE / CLOSE_TASK_SOURCE used to leak into prompts
     // whose runtime promptArgs do not include TASK_ID (simple-loop,
     // sequential-reviewer's implement, parallel-planner*'s merge),
     // causing PromptArgumentSubstitution to throw on every iteration.
@@ -773,7 +850,7 @@ describe("InitService scaffold", () => {
     }
   });
 
-  it("createLabel defaults to true (label retained when not specified)", async () => {
+  it("backlogManagerInit defaults to retaining generated prompts", async () => {
     const dir = await makeDir();
     await runScaffold(dir, { templateName: "simple-loop" });
 
@@ -1141,25 +1218,24 @@ describe("InitService scaffold", () => {
   // --- Backlog manager ---
 
   describe("Backlog manager registry", () => {
-    it("listBacklogManagers returns github-issues and beads", () => {
+    it("listBacklogManagers returns github-issues, beads, and linear", () => {
       const managers = listBacklogManagers();
       expect(managers.some((m) => m.name === "github-issues")).toBe(true);
       expect(managers.some((m) => m.name === "beads")).toBe(true);
+      expect(managers.some((m) => m.name === "linear")).toBe(true);
     });
 
     it("getBacklogManager returns github-issues entry with expected templateArgs", () => {
       const manager = getBacklogManager("github-issues");
       expect(manager).toBeDefined();
       expect(manager!.label).toBe("GitHub Issues");
-      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+      expect(manager!.templateArgs.LIST_TASKS_SOURCE).toContain(
         "gh issue list",
       );
-      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain("labels");
-      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain("comments");
-      expect(manager!.templateArgs.VIEW_TASK_COMMAND).toContain(
-        "gh issue view",
-      );
-      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain(
+      expect(manager!.templateArgs.LIST_TASKS_SOURCE).toContain("labels");
+      expect(manager!.templateArgs.LIST_TASKS_SOURCE).toContain("comments");
+      expect(manager!.templateArgs.VIEW_TASK_SOURCE).toContain("gh issue view");
+      expect(manager!.templateArgs.CLOSE_TASK_SOURCE).toContain(
         "gh issue close",
       );
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(
@@ -1172,9 +1248,11 @@ describe("InitService scaffold", () => {
       const manager = getBacklogManager("beads");
       expect(manager).toBeDefined();
       expect(manager!.label).toBe("Beads");
-      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toBe("bd ready --json");
-      expect(manager!.templateArgs.VIEW_TASK_COMMAND).toContain("bd show");
-      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain("bd close");
+      expect(manager!.templateArgs.LIST_TASKS_SOURCE).toBe(
+        "!`bd ready --json`",
+      );
+      expect(manager!.templateArgs.VIEW_TASK_SOURCE).toContain("bd show");
+      expect(manager!.templateArgs.CLOSE_TASK_SOURCE).toContain("bd close");
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain("beads");
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain("libicu72");
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(
@@ -1189,12 +1267,174 @@ describe("InitService scaffold", () => {
       );
     });
 
+    it("getBacklogManager returns linear entry with expected templateArgs", () => {
+      const manager = getBacklogManager("linear");
+      expect(manager).toBeDefined();
+      expect(manager!.label).toBe("Linear");
+      expect(manager!.templateArgs.LIST_TASKS_SOURCE).toContain(
+        "official Linear MCP server",
+      );
+      expect(manager!.templateArgs.LIST_TASKS_SOURCE).toContain(
+        "https://mcp.linear.app/mcp",
+      );
+      expect(manager!.templateArgs.LIST_TASKS_SOURCE).toContain("Sandcastle");
+      expect(manager!.templateArgs.VIEW_TASK_SOURCE).toContain("Linear MCP");
+      expect(manager!.templateArgs.CLOSE_TASK_SOURCE).toContain("Linear MCP");
+      expect(manager!.templateArgs.CLOSE_TASK_SOURCE).toContain(
+        "LINEAR_DONE_STATE",
+      );
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(
+        "https://mcp.linear.app/mcp",
+      );
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).not.toContain(
+        "@schpet/linear-cli",
+      );
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).not.toContain("gh");
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).not.toContain(
+        "beads",
+      );
+    });
+
     it("getBacklogManager returns undefined for unknown manager", () => {
       expect(getBacklogManager("nonexistent")).toBeUndefined();
     });
   });
 
   describe("Backlog manager scaffold", () => {
+    it("label-based managers create their backlog labels and keep prompt filters when accepted", async () => {
+      const cases = [
+        {
+          name: "github-issues",
+          command:
+            'gh label create "Sandcastle" --description "Issues for Sandcastle to work on" --color "F9A825" 2>/dev/null',
+          promptCommand: "gh issue list",
+        },
+      ];
+
+      for (const testCase of cases) {
+        const dir = await makeDir();
+        const fakeShell = createFakeShell();
+        const init = runBacklogManagerInit(testCase.name, {
+          confirm: true,
+          shell: fakeShell.shell,
+        });
+        const backlogManagerInit = await init.result;
+
+        await runScaffold(dir, {
+          templateName: "simple-loop",
+          backlogManager: init.manager,
+          backlogManagerInit,
+        });
+
+        const prompt = await readFile(
+          join(dir, ".sandcastle", "prompt.md"),
+          "utf-8",
+        );
+        expect(init.prompts, testCase.name).toEqual([
+          `Create a "Sandcastle" ${init.manager.label} label? (Templates filter tasks by this label)`,
+        ]);
+        expect(fakeShell.commands, testCase.name).toEqual([testCase.command]);
+        expect(prompt, testCase.name).toContain(testCase.promptCommand);
+        expect(prompt, testCase.name).toContain("--label Sandcastle");
+      }
+    });
+
+    it("label-based managers remove prompt filters when label setup is declined", async () => {
+      const cases = [{ name: "github-issues", promptCommand: "gh issue list" }];
+
+      for (const testCase of cases) {
+        const dir = await makeDir();
+        const fakeShell = createFakeShell();
+        const init = runBacklogManagerInit(testCase.name, {
+          confirm: false,
+          shell: fakeShell.shell,
+        });
+        const backlogManagerInit = await init.result;
+
+        await runScaffold(dir, {
+          templateName: "simple-loop",
+          backlogManager: init.manager,
+          backlogManagerInit,
+        });
+
+        const prompt = await readFile(
+          join(dir, ".sandcastle", "prompt.md"),
+          "utf-8",
+        );
+        expect(fakeShell.commands, testCase.name).toEqual([]);
+        expect(prompt, testCase.name).toContain(testCase.promptCommand);
+        expect(prompt, testCase.name).not.toContain("--label Sandcastle");
+      }
+    });
+
+    it("linear init does not prompt or run shell commands", async () => {
+      const fakeShell = createFakeShell();
+      const init = runBacklogManagerInit("linear", {
+        confirm: true,
+        shell: fakeShell.shell,
+      });
+      const backlogManagerInit = await init.result;
+
+      expect(init.prompts).toEqual([]);
+      expect(fakeShell.commands).toEqual([]);
+      expect(backlogManagerInit.rewritePromptFile("Use Linear MCP")).toBe(
+        "Use Linear MCP",
+      );
+    });
+
+    it("label command failures do not prevent scaffolded prompts from using the label filter", async () => {
+      const dir = await makeDir();
+      const fakeShell = createFakeShell({
+        throwOnRun: new Error("label already exists"),
+      });
+      const init = runBacklogManagerInit("github-issues", {
+        confirm: true,
+        shell: fakeShell.shell,
+      });
+      const backlogManagerInit = await init.result;
+
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: init.manager,
+        backlogManagerInit,
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(fakeShell.commands).toEqual([
+        'gh label create "Sandcastle" --description "Issues for Sandcastle to work on" --color "F9A825" 2>/dev/null',
+      ]);
+      expect(prompt).toContain("gh issue list");
+      expect(prompt).toContain("--label Sandcastle");
+    });
+
+    it("beads scaffolds without backlog manager setup prompts or commands", async () => {
+      const dir = await makeDir();
+      const fakeShell = createFakeShell();
+      const init = runBacklogManagerInit("beads", {
+        confirm: true,
+        shell: fakeShell.shell,
+      });
+      const backlogManagerInit = await init.result;
+
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: init.manager,
+        backlogManagerInit,
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(init.prompts).toEqual([]);
+      expect(fakeShell.commands).toEqual([]);
+      expect(prompt).toContain("bd ready --json");
+      expect(prompt).not.toContain("--label Sandcastle");
+    });
+
     it("simple-loop with github-issues produces prompt with gh issue commands (richer version)", async () => {
       const dir = await makeDir();
       await runScaffold(dir, {
@@ -1210,8 +1450,8 @@ describe("InitService scaffold", () => {
       expect(prompt).toContain("labels");
       expect(prompt).toContain("comments");
       expect(prompt).toContain("gh issue close");
-      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
-      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{LIST_TASKS_SOURCE}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
     });
 
     it("simple-loop with beads produces prompt with bd commands", async () => {
@@ -1228,8 +1468,32 @@ describe("InitService scaffold", () => {
       expect(prompt).toContain("bd ready --json");
       expect(prompt).toContain("bd close");
       expect(prompt).not.toContain("gh issue");
-      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
-      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{LIST_TASKS_SOURCE}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
+    });
+
+    it("simple-loop with linear produces prompt with Linear MCP instructions", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("linear"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("official Linear MCP server");
+      expect(prompt).toContain("Sandcastle");
+      expect(prompt).toContain("https://mcp.linear.app/mcp");
+      expect(prompt).toContain("Completed by Sandcastle");
+      expect(prompt).toContain("LINEAR_DONE_STATE");
+      expect(prompt).not.toContain("linear issue");
+      expect(prompt).not.toContain("@schpet/linear-cli");
+      expect(prompt).not.toContain("gh issue");
+      expect(prompt).not.toContain("bd ");
+      expect(prompt).not.toContain("{{LIST_TASKS_SOURCE}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
     });
 
     it("simple-loop with beads skips --label Sandcastle (no label to strip)", async () => {
@@ -1246,12 +1510,27 @@ describe("InitService scaffold", () => {
       expect(prompt).not.toContain("--label Sandcastle");
     });
 
-    it("simple-loop with github-issues retains --label Sandcastle when createLabel is true", async () => {
+    it("simple-loop with linear leaves MCP instructions unchanged by default init", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("linear"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("official Linear MCP server");
+      expect(prompt).toContain("Sandcastle");
+      expect(prompt).not.toContain("linear issue");
+    });
+
+    it("simple-loop with github-issues retains --label Sandcastle with default init result", async () => {
       const dir = await makeDir();
       await runScaffold(dir, {
         templateName: "simple-loop",
         backlogManager: getBacklogManager("github-issues"),
-        createLabel: true,
       });
 
       const prompt = await readFile(
@@ -1261,12 +1540,12 @@ describe("InitService scaffold", () => {
       expect(prompt).toContain("--label Sandcastle");
     });
 
-    it("simple-loop with github-issues strips --label Sandcastle when createLabel is false", async () => {
+    it("simple-loop with github-issues strips --label Sandcastle when init result rewrites prompts", async () => {
       const dir = await makeDir();
       await runScaffold(dir, {
         templateName: "simple-loop",
         backlogManager: getBacklogManager("github-issues"),
-        createLabel: false,
+        backlogManagerInit: stripSandcastleLabelInit,
       });
 
       const prompt = await readFile(
@@ -1287,7 +1566,7 @@ describe("InitService scaffold", () => {
       );
       // Should default to github-issues and replace placeholders
       expect(prompt).toContain("gh issue list");
-      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(prompt).not.toContain("{{LIST_TASKS_SOURCE}}");
     });
 
     // --- sequential-reviewer ---
@@ -1307,8 +1586,8 @@ describe("InitService scaffold", () => {
       expect(prompt).toContain("labels");
       expect(prompt).toContain("comments");
       expect(prompt).toContain("gh issue close");
-      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
-      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{LIST_TASKS_SOURCE}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
     });
 
     it("sequential-reviewer with beads produces implement-prompt with bd commands", async () => {
@@ -1325,8 +1604,29 @@ describe("InitService scaffold", () => {
       expect(prompt).toContain("bd ready --json");
       expect(prompt).toContain("bd close");
       expect(prompt).not.toContain("gh issue");
-      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
-      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{LIST_TASKS_SOURCE}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
+    });
+
+    it("sequential-reviewer with linear produces implement-prompt with Linear MCP instructions", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "sequential-reviewer",
+        backlogManager: getBacklogManager("linear"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "implement-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("official Linear MCP server");
+      expect(prompt).toContain("Sandcastle");
+      expect(prompt).toContain("Completed by Sandcastle");
+      expect(prompt).toContain("LINEAR_DONE_STATE");
+      expect(prompt).not.toContain("linear issue");
+      expect(prompt).not.toContain("gh issue");
+      expect(prompt).not.toContain("{{LIST_TASKS_SOURCE}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
     });
 
     // --- blank ---
@@ -1343,7 +1643,7 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(prompt).toContain("gh issue list");
-      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(prompt).not.toContain("{{LIST_TASKS_SOURCE}}");
     });
 
     it("blank with beads produces prompt with bd ready example", async () => {
@@ -1359,7 +1659,25 @@ describe("InitService scaffold", () => {
       );
       expect(prompt).toContain("bd ready --json");
       expect(prompt).not.toContain("gh issue");
-      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(prompt).not.toContain("{{LIST_TASKS_SOURCE}}");
+    });
+
+    it("blank with linear produces prompt with official Linear MCP server example", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "blank",
+        backlogManager: getBacklogManager("linear"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("official Linear MCP server");
+      expect(prompt).toContain("Sandcastle");
+      expect(prompt).not.toContain("linear issue");
+      expect(prompt).not.toContain("gh issue");
+      expect(prompt).not.toContain("{{LIST_TASKS_SOURCE}}");
     });
 
     // --- parallel-planner ---
@@ -1378,7 +1696,7 @@ describe("InitService scaffold", () => {
       expect(planPrompt).toContain("gh issue list");
       expect(planPrompt).toContain("labels");
       expect(planPrompt).toContain("comments");
-      expect(planPrompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(planPrompt).not.toContain("{{LIST_TASKS_SOURCE}}");
     });
 
     it("parallel-planner with beads produces plan-prompt with bd commands", async () => {
@@ -1394,7 +1712,26 @@ describe("InitService scaffold", () => {
       );
       expect(planPrompt).toContain("bd ready --json");
       expect(planPrompt).not.toContain("gh issue");
-      expect(planPrompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(planPrompt).not.toContain("{{LIST_TASKS_SOURCE}}");
+    });
+
+    it("parallel-planner with linear produces plan-prompt with Linear MCP instructions", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner",
+        backlogManager: getBacklogManager("linear"),
+      });
+
+      const planPrompt = await readFile(
+        join(dir, ".sandcastle", "plan-prompt.md"),
+        "utf-8",
+      );
+      expect(planPrompt).toContain("official Linear MCP server");
+      expect(planPrompt).toContain("Sandcastle");
+      expect(planPrompt).toContain("https://mcp.linear.app/mcp");
+      expect(planPrompt).not.toContain("linear issue");
+      expect(planPrompt).not.toContain("gh issue");
+      expect(planPrompt).not.toContain("{{LIST_TASKS_SOURCE}}");
     });
 
     it("parallel-planner main.mts uses id:string and TASK_ID", async () => {
@@ -1440,7 +1777,7 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(prompt).toContain("gh issue view");
-      expect(prompt).not.toContain("{{VIEW_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{VIEW_TASK_SOURCE}}");
     });
 
     it("parallel-planner with beads produces implement-prompt with bd show", async () => {
@@ -1456,7 +1793,23 @@ describe("InitService scaffold", () => {
       );
       expect(prompt).toContain("bd show");
       expect(prompt).not.toContain("gh issue");
-      expect(prompt).not.toContain("{{VIEW_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{VIEW_TASK_SOURCE}}");
+    });
+
+    it("parallel-planner with linear produces implement-prompt with Linear MCP tools", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner",
+        backlogManager: getBacklogManager("linear"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "implement-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("Linear MCP tools");
+      expect(prompt).not.toContain("gh issue");
+      expect(prompt).not.toContain("{{VIEW_TASK_SOURCE}}");
     });
 
     it("parallel-planner with github-issues produces merge-prompt with gh issue close", async () => {
@@ -1471,7 +1824,7 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(prompt).toContain("gh issue close");
-      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
     });
 
     it("parallel-planner with beads produces merge-prompt with bd close", async () => {
@@ -1487,7 +1840,24 @@ describe("InitService scaffold", () => {
       );
       expect(prompt).toContain("bd close");
       expect(prompt).not.toContain("gh issue");
-      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
+    });
+
+    it("parallel-planner with linear produces merge-prompt with Linear MCP completion instructions", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner",
+        backlogManager: getBacklogManager("linear"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "merge-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("Completed by Sandcastle");
+      expect(prompt).toContain("LINEAR_DONE_STATE");
+      expect(prompt).not.toContain("gh issue");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
     });
 
     it("parallel-planner implement-prompt does not contain close-issue instruction", async () => {
@@ -1499,7 +1869,7 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(prompt).not.toContain("close the issue when done");
-      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
     });
 
     it("parallel-planner implement-prompt uses backlog-agnostic language", async () => {
@@ -1531,7 +1901,7 @@ describe("InitService scaffold", () => {
       expect(planPrompt).toContain("gh issue list");
       expect(planPrompt).toContain("labels");
       expect(planPrompt).toContain("comments");
-      expect(planPrompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(planPrompt).not.toContain("{{LIST_TASKS_SOURCE}}");
     });
 
     it("parallel-planner-with-review with beads produces plan-prompt with bd commands", async () => {
@@ -1547,7 +1917,26 @@ describe("InitService scaffold", () => {
       );
       expect(planPrompt).toContain("bd ready --json");
       expect(planPrompt).not.toContain("gh issue");
-      expect(planPrompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(planPrompt).not.toContain("{{LIST_TASKS_SOURCE}}");
+    });
+
+    it("parallel-planner-with-review with linear produces plan-prompt with Linear MCP instructions", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner-with-review",
+        backlogManager: getBacklogManager("linear"),
+      });
+
+      const planPrompt = await readFile(
+        join(dir, ".sandcastle", "plan-prompt.md"),
+        "utf-8",
+      );
+      expect(planPrompt).toContain("official Linear MCP server");
+      expect(planPrompt).toContain("Sandcastle");
+      expect(planPrompt).toContain("https://mcp.linear.app/mcp");
+      expect(planPrompt).not.toContain("linear issue");
+      expect(planPrompt).not.toContain("gh issue");
+      expect(planPrompt).not.toContain("{{LIST_TASKS_SOURCE}}");
     });
 
     it("parallel-planner-with-review main.mts uses id:string and TASK_ID", async () => {
@@ -1578,7 +1967,7 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(prompt).not.toContain("close the issue when done");
-      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
     });
 
     it("parallel-planner-with-review implement-prompt uses TASK_ID placeholder", async () => {
@@ -1607,7 +1996,7 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(prompt).toContain("gh issue view");
-      expect(prompt).not.toContain("{{VIEW_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{VIEW_TASK_SOURCE}}");
     });
 
     it("parallel-planner-with-review with beads produces implement-prompt with bd show", async () => {
@@ -1623,7 +2012,23 @@ describe("InitService scaffold", () => {
       );
       expect(prompt).toContain("bd show");
       expect(prompt).not.toContain("gh issue");
-      expect(prompt).not.toContain("{{VIEW_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{VIEW_TASK_SOURCE}}");
+    });
+
+    it("parallel-planner-with-review with linear produces implement-prompt with Linear MCP tools", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner-with-review",
+        backlogManager: getBacklogManager("linear"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "implement-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("Linear MCP tools");
+      expect(prompt).not.toContain("gh issue");
+      expect(prompt).not.toContain("{{VIEW_TASK_SOURCE}}");
     });
 
     it("parallel-planner-with-review with github-issues produces merge-prompt with gh issue close", async () => {
@@ -1638,7 +2043,7 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(prompt).toContain("gh issue close");
-      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
     });
 
     it("parallel-planner-with-review with beads produces merge-prompt with bd close", async () => {
@@ -1654,7 +2059,24 @@ describe("InitService scaffold", () => {
       );
       expect(prompt).toContain("bd close");
       expect(prompt).not.toContain("gh issue");
-      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
+    });
+
+    it("parallel-planner-with-review with linear produces merge-prompt with Linear MCP completion instructions", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner-with-review",
+        backlogManager: getBacklogManager("linear"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "merge-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("Completed by Sandcastle");
+      expect(prompt).toContain("LINEAR_DONE_STATE");
+      expect(prompt).not.toContain("gh issue");
+      expect(prompt).not.toContain("{{CLOSE_TASK_SOURCE}}");
     });
 
     it("parallel-planner-with-review implement-prompt uses backlog-agnostic language", async () => {
@@ -1706,6 +2128,24 @@ describe("InitService scaffold", () => {
       expect(dockerfile).toContain("dpkg-architecture -qDEB_HOST_MULTIARCH");
     });
 
+    it("scaffold with linear produces Dockerfile with official MCP guidance (no Linear CLI)", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        backlogManager: getBacklogManager("linear"),
+      });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfile).toContain("https://mcp.linear.app/mcp");
+      expect(dockerfile).not.toContain("@schpet/linear-cli");
+      expect(dockerfile).not.toContain("linear-cli");
+      expect(dockerfile).not.toContain("GitHub CLI");
+      expect(dockerfile).not.toContain("beads");
+      expect(dockerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
+    });
+
     it("scaffold with beads + podman produces Containerfile with beads install", async () => {
       const dir = await makeDir();
       const podmanProvider = getSandboxProvider("podman")!;
@@ -1724,6 +2164,26 @@ describe("InitService scaffold", () => {
       expect(containerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
       expect(containerfile).not.toContain("x86_64-linux-gnu");
       expect(containerfile).toContain("dpkg-architecture -qDEB_HOST_MULTIARCH");
+    });
+
+    it("scaffold with linear + podman produces Containerfile with official MCP guidance", async () => {
+      const dir = await makeDir();
+      const podmanProvider = getSandboxProvider("podman")!;
+      await runScaffold(dir, {
+        backlogManager: getBacklogManager("linear"),
+        sandboxProvider: podmanProvider,
+      });
+
+      const containerfile = await readFile(
+        join(dir, ".sandcastle", "Containerfile"),
+        "utf-8",
+      );
+      expect(containerfile).toContain("https://mcp.linear.app/mcp");
+      expect(containerfile).not.toContain("@schpet/linear-cli");
+      expect(containerfile).not.toContain("linear-cli");
+      expect(containerfile).not.toContain("GitHub CLI");
+      expect(containerfile).not.toContain("beads");
+      expect(containerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
     });
 
     it("scaffold with beads + pi agent produces Dockerfile with beads install and pi agent", async () => {

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -224,13 +224,35 @@ export interface BacklogManagerEntry {
   readonly name: string;
   readonly label: string;
   readonly templateArgs: {
-    readonly LIST_TASKS_COMMAND: string;
-    readonly VIEW_TASK_COMMAND: string;
-    readonly CLOSE_TASK_COMMAND: string;
+    readonly LIST_TASKS_SOURCE: string;
+    readonly VIEW_TASK_SOURCE: string;
+    readonly CLOSE_TASK_SOURCE: string;
     readonly BACKLOG_MANAGER_TOOLS: string;
   };
   /** Lines to append to `.env.example` for this backlog manager, or empty string if none needed. */
   readonly envExample: string;
+  readonly init: BacklogManagerInitWorkflow;
+}
+
+export interface BacklogManagerInitWorkflow {
+  readonly run: (
+    context: BacklogManagerInitContext,
+  ) => Effect.Effect<BacklogManagerInitResult, never>;
+}
+
+export interface BacklogManagerInitContext {
+  readonly managerLabel: string;
+  readonly confirm: (options: {
+    message: string;
+    initialValue: boolean;
+  }) => Promise<boolean | symbol>;
+  readonly shell: {
+    readonly run: (command: string) => void;
+  };
+}
+
+export interface BacklogManagerInitResult {
+  readonly rewritePromptFile: (content: string) => string;
 }
 
 const GITHUB_CLI_TOOLS = `# Install GitHub CLI
@@ -255,29 +277,96 @@ RUN curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/i
 
 RUN corepack enable`;
 
+const LINEAR_MCP_SERVER_URL = "https://mcp.linear.app/mcp";
+
+const LINEAR_MCP_TOOLS = `# Linear uses the official remote MCP server.
+# Configure your agent with ${LINEAR_MCP_SERVER_URL} before running Sandcastle.`;
+
+const identityBacklogManagerInitResult: BacklogManagerInitResult = {
+  rewritePromptFile: (content) => content,
+};
+
+const noBacklogManagerInit: BacklogManagerInitWorkflow = {
+  run: () => Effect.succeed(identityBacklogManagerInitResult),
+};
+
+const labelBacklogManagerInit = (options: {
+  labelName: string;
+  createCommand: string;
+  removeFilter: (content: string) => string;
+}): BacklogManagerInitWorkflow => ({
+  run: ({ managerLabel, confirm, shell }) =>
+    Effect.gen(function* () {
+      const shouldCreateLabel = yield* Effect.promise(() =>
+        confirm({
+          message: `Create a "${options.labelName}" ${managerLabel} label? (Templates filter tasks by this label)`,
+          initialValue: true,
+        }),
+      );
+
+      if (shouldCreateLabel === true) {
+        yield* Effect.try({
+          try: () => shell.run(options.createCommand),
+          catch: () => undefined,
+        }).pipe(Effect.ignore);
+
+        return identityBacklogManagerInitResult;
+      }
+
+      return {
+        rewritePromptFile: options.removeFilter,
+      };
+    }),
+});
+
 const BACKLOG_MANAGER_REGISTRY: BacklogManagerEntry[] = [
   {
     name: "github-issues",
     label: "GitHub Issues",
     templateArgs: {
-      LIST_TASKS_COMMAND: `gh issue list --state open --label Sandcastle --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`,
-      VIEW_TASK_COMMAND: "gh issue view <ID>",
-      CLOSE_TASK_COMMAND: `gh issue close <ID> --comment "Completed by Sandcastle"`,
+      LIST_TASKS_SOURCE: `!\`gh issue list --state open --label Sandcastle --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'\``,
+      VIEW_TASK_SOURCE: "`gh issue view <ID>`",
+      CLOSE_TASK_SOURCE:
+        '`gh issue close <ID> --comment "Completed by Sandcastle"`',
       BACKLOG_MANAGER_TOOLS: GITHUB_CLI_TOOLS,
     },
     envExample: `# GitHub personal access token
 GH_TOKEN=`,
+    init: labelBacklogManagerInit({
+      labelName: "Sandcastle",
+      createCommand:
+        'gh label create "Sandcastle" --description "Issues for Sandcastle to work on" --color "F9A825" 2>/dev/null',
+      removeFilter: (content) => content.replaceAll(" --label Sandcastle", ""),
+    }),
   },
   {
     name: "beads",
     label: "Beads",
     templateArgs: {
-      LIST_TASKS_COMMAND: "bd ready --json",
-      VIEW_TASK_COMMAND: "bd show <ID>",
-      CLOSE_TASK_COMMAND: `bd close <ID> "Completed by Sandcastle"`,
+      LIST_TASKS_SOURCE: "!`bd ready --json`",
+      VIEW_TASK_SOURCE: "`bd show <ID>`",
+      CLOSE_TASK_SOURCE: '`bd close <ID> "Completed by Sandcastle"`',
       BACKLOG_MANAGER_TOOLS: BEADS_TOOLS,
     },
     envExample: "",
+    init: noBacklogManagerInit,
+  },
+  {
+    name: "linear",
+    label: "Linear",
+    templateArgs: {
+      LIST_TASKS_SOURCE: `Use the official Linear MCP server (${LINEAR_MCP_SERVER_URL}) to find actionable Linear issues with the "Sandcastle" label in triage, backlog, unstarted, or started states. If the "Sandcastle" label does not exist, create it with the Linear MCP tools before listing issues.`,
+      VIEW_TASK_SOURCE: "the Linear MCP tools to read issue <ID>",
+      CLOSE_TASK_SOURCE:
+        'the Linear MCP tools to add a "Completed by Sandcastle" comment and move the issue to the `LINEAR_DONE_STATE` value, defaulting to "Done"',
+      BACKLOG_MANAGER_TOOLS: LINEAR_MCP_TOOLS,
+    },
+    envExample: `# Linear personal API key
+LINEAR_API_KEY=
+
+# Optional Linear workflow state used when Sandcastle completes an issue
+LINEAR_DONE_STATE=Done`,
+    init: noBacklogManagerInit,
   },
 ];
 
@@ -288,6 +377,12 @@ export const getBacklogManager = (
   name: string,
 ): BacklogManagerEntry | undefined =>
   BACKLOG_MANAGER_REGISTRY.find((b) => b.name === name);
+
+export const initializeBacklogManager = (
+  backlogManager: BacklogManagerEntry,
+  context: BacklogManagerInitContext,
+): Effect.Effect<BacklogManagerInitResult, never> =>
+  backlogManager.init.run(context);
 
 export const getAgent = (name: string): AgentEntry | undefined =>
   AGENT_REGISTRY.find((a) => a.name === name);
@@ -480,12 +575,11 @@ const rewriteMainTs = (
   });
 
 /**
- * When the user opted out of the Sandcastle label, strip ` --label Sandcastle`
- * from all `.md` files in the scaffolded config directory so that `gh issue list`
- * commands work without a label filter.
+ * Let the selected backlog manager's init result adjust scaffolded `.md` files.
  */
 const rewritePromptFiles = (
   configDir: string,
+  backlogManagerInit: BacklogManagerInitResult,
 ): Effect.Effect<void, Error, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
@@ -500,7 +594,7 @@ const rewritePromptFiles = (
           const content = yield* fs
             .readFileString(filePath)
             .pipe(Effect.mapError((e) => new Error(e.message)));
-          const updated = content.replace(/ --label Sandcastle/g, "");
+          const updated = backlogManagerInit.rewritePromptFile(content);
           if (updated !== content) {
             yield* fs
               .writeFileString(filePath, updated)
@@ -582,8 +676,8 @@ export interface ScaffoldOptions {
   agent: AgentEntry;
   model: string;
   templateName?: string;
-  createLabel?: boolean;
   backlogManager?: BacklogManagerEntry;
+  backlogManagerInit?: BacklogManagerInitResult;
   sandboxProvider?: SandboxProviderEntry;
 }
 
@@ -625,8 +719,8 @@ export const scaffold = (
       agent,
       model,
       templateName = "blank",
-      createLabel = true,
       backlogManager = BACKLOG_MANAGER_REGISTRY[0]!, // default: github-issues
+      backlogManagerInit = identityBacklogManagerInitResult,
       sandboxProvider = SANDBOX_PROVIDER_REGISTRY[0]!, // default: docker
     } = options;
     const fs = yield* FileSystem.FileSystem;
@@ -683,10 +777,8 @@ export const scaffold = (
     // Replace backlog manager template arguments in all text files (must run before label stripping)
     yield* substituteTemplateArgs(configDir, backlogManager);
 
-    // Strip --label Sandcastle from prompt files when the user declined label creation
-    if (!createLabel) {
-      yield* rewritePromptFiles(configDir);
-    }
+    // Let the selected backlog manager's init result adjust generated prompt files.
+    yield* rewritePromptFiles(configDir, backlogManagerInit);
 
     return { mainFilename };
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import {
   listTemplates,
   listAgents,
   getAgent,
+  initializeBacklogManager,
   listBacklogManagers,
   getBacklogManager,
   listSandboxProviders,
@@ -233,28 +234,18 @@ const initCommand = Command.make(
         selectedTemplate = selected as string;
       }
 
-      // Offer to create the "Sandcastle" label on the repo (skip for non-GitHub backlog managers)
-      let shouldCreateLabel: boolean | symbol = false;
-      if (selectedBacklogManager.name === "github-issues") {
-        shouldCreateLabel = yield* Effect.promise(() =>
-          clack.confirm({
-            message:
-              'Create a "Sandcastle" GitHub label? (Templates filter issues by this label)',
-            initialValue: true,
-          }),
-        );
-
-        if (shouldCreateLabel === true) {
-          yield* Effect.try({
-            try: () =>
-              execSync(
-                'gh label create "Sandcastle" --description "Issues for Sandcastle to work on" --color "F9A825" 2>/dev/null',
-                { cwd, stdio: "ignore" },
-              ),
-            catch: () => undefined,
-          }).pipe(Effect.ignore);
-        }
-      }
+      const backlogManagerInit = yield* initializeBacklogManager(
+        selectedBacklogManager,
+        {
+          managerLabel: selectedBacklogManager.label,
+          confirm: clack.confirm,
+          shell: {
+            run: (command) => {
+              execSync(command, { cwd, stdio: "ignore" });
+            },
+          },
+        },
+      );
 
       const scaffoldResult = yield* d.spinner(
         "Scaffolding .sandcastle/ config directory...",
@@ -262,8 +253,8 @@ const initCommand = Command.make(
           agent: selectedAgent,
           model: selectedModel,
           templateName: selectedTemplate,
-          createLabel: shouldCreateLabel === true,
           backlogManager: selectedBacklogManager,
+          backlogManagerInit,
           sandboxProvider: selectedSandboxProvider,
         }).pipe(
           Effect.mapError(

--- a/src/templates/blank/prompt.md
+++ b/src/templates/blank/prompt.md
@@ -1,7 +1,7 @@
 # Context
 
 <!-- Use !`command` to pull in dynamic context. Commands run inside the sandbox. -->
-<!-- Example: !`git log --oneline -10` or !`{{LIST_TASKS_COMMAND}}` -->
+<!-- Example: !`git log --oneline -10` or {{LIST_TASKS_SOURCE}} -->
 
 # Task
 

--- a/src/templates/parallel-planner-with-review/implement-prompt.md
+++ b/src/templates/parallel-planner-with-review/implement-prompt.md
@@ -2,7 +2,7 @@
 
 Fix issue {{TASK_ID}}: {{ISSUE_TITLE}}
 
-Pull in the issue using `{{VIEW_TASK_COMMAND}}`. If it has a parent PRD, pull that in too.
+Pull in the issue using {{VIEW_TASK_SOURCE}}. If it has a parent PRD, pull that in too.
 
 Only work on the issue specified.
 

--- a/src/templates/parallel-planner-with-review/merge-prompt.md
+++ b/src/templates/parallel-planner-with-review/merge-prompt.md
@@ -17,7 +17,7 @@ After all branches are merged, make a single commit summarizing the merge.
 
 For each branch that was merged, close its issue using the following command:
 
-`{{CLOSE_TASK_COMMAND}}`
+{{CLOSE_TASK_SOURCE}}
 
 Here are all the issues:
 

--- a/src/templates/parallel-planner-with-review/plan-prompt.md
+++ b/src/templates/parallel-planner-with-review/plan-prompt.md
@@ -1,12 +1,8 @@
 # ISSUES
 
-Here are the open issues in the repo:
+Use the configured backlog source to find open issues:
 
-<issues-json>
-
-!`{{LIST_TASKS_COMMAND}}`
-
-</issues-json>
+{{LIST_TASKS_SOURCE}}
 
 # TASK
 

--- a/src/templates/parallel-planner/implement-prompt.md
+++ b/src/templates/parallel-planner/implement-prompt.md
@@ -2,7 +2,7 @@
 
 Fix issue {{TASK_ID}}: {{ISSUE_TITLE}}
 
-Pull in the issue using `{{VIEW_TASK_COMMAND}}`. If it has a parent PRD, pull that in too.
+Pull in the issue using {{VIEW_TASK_SOURCE}}. If it has a parent PRD, pull that in too.
 
 Only work on the issue specified.
 

--- a/src/templates/parallel-planner/merge-prompt.md
+++ b/src/templates/parallel-planner/merge-prompt.md
@@ -17,7 +17,7 @@ After all branches are merged, make a single commit summarizing the merge.
 
 For each branch that was merged, close its issue using the following command:
 
-`{{CLOSE_TASK_COMMAND}}`
+{{CLOSE_TASK_SOURCE}}
 
 Here are all the issues:
 

--- a/src/templates/parallel-planner/plan-prompt.md
+++ b/src/templates/parallel-planner/plan-prompt.md
@@ -1,12 +1,8 @@
 # ISSUES
 
-Here are the open issues in the repo:
+Use the configured backlog source to find open issues:
 
-<issues-json>
-
-!`{{LIST_TASKS_COMMAND}}`
-
-</issues-json>
+{{LIST_TASKS_SOURCE}}
 
 # TASK
 

--- a/src/templates/sequential-reviewer/implement-prompt.md
+++ b/src/templates/sequential-reviewer/implement-prompt.md
@@ -2,7 +2,7 @@
 
 ## Open issues
 
-!`{{LIST_TASKS_COMMAND}}`
+{{LIST_TASKS_SOURCE}}
 
 ## Recent RALPH commits (last 10)
 
@@ -35,7 +35,7 @@ Pick the highest-priority open issue that is not blocked by another open issue.
    - List key decisions made
    - List files changed
    - Note any blockers for the next iteration
-6. **Close** — close the issue with `{{CLOSE_TASK_COMMAND}}` explaining what was done.
+6. **Close** — close the issue with {{CLOSE_TASK_SOURCE}} explaining what was done.
 
 ## Rules
 

--- a/src/templates/simple-loop/prompt.md
+++ b/src/templates/simple-loop/prompt.md
@@ -2,7 +2,7 @@
 
 ## Open issues
 
-!`{{LIST_TASKS_COMMAND}}`
+{{LIST_TASKS_SOURCE}}
 
 ## Recent RALPH commits (last 10)
 
@@ -35,7 +35,7 @@ Pick the highest-priority open issue that is not blocked by another open issue.
    - List key decisions made
    - List files changed
    - Note any blockers for the next iteration
-6. **Close** — close the issue with `{{CLOSE_TASK_COMMAND}}` explaining what was done.
+6. **Close** — close the issue with {{CLOSE_TASK_SOURCE}} explaining what was done.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

Fixes #518.

Adds Linear as a `sandcastle init` backlog manager while keeping the backlog-manager surface provider-owned. This started as a Linear CLI integration, but the issue discussion raised a good concern that Sandcastle should not recommend an unofficial Linear CLI as the default. This version uses Linear's official remote MCP server instead:

https://mcp.linear.app/mcp

Relevant discussion: https://github.com/mattpocock/sandcastle/issues/518#issuecomment-4366748664

## Problem

Sandcastle templates already support GitHub Issues and Beads, but Linear users had no built-in way to point agents at their backlog. The initial Linear implementation mirrored GitHub by shelling out to a CLI and creating a shared `Sandcastle` label. That worked, but it had two design problems:

- Linear does not have a first-party CLI, so recommending an unofficial CLI as the default is a weak dependency choice.
- Treating every backlog manager as shell commands does not map well to MCP-backed providers and would make future provider additions more special-case heavy.

## Solution

Linear now uses provider-owned MCP instructions instead of CLI commands.

- GitHub Issues still injects `gh` shell snippets and owns the label-creation init workflow.
- Beads still injects `bd` shell snippets and uses a no-op init workflow.
- Linear injects instructions to use the official Linear MCP server to list, inspect, and complete issues.
- Linear no longer installs `@schpet/linear-cli`, no longer scaffolds `linear issue ...` commands, and no longer asks Sandcastle init to create a label through a shell command.

The template placeholders were renamed from command-specific names to source-specific names:

- `LIST_TASKS_SOURCE`
- `VIEW_TASK_SOURCE`
- `CLOSE_TASK_SOURCE`

That lets shell-backed providers inject executable command blocks while MCP-backed providers inject agent instructions without pretending MCP is a shell.

## Implementation Notes

- Linear prompts ask the agent to find actionable Linear issues with the `Sandcastle` label in triage/backlog/unstarted/started states.
- If the `Sandcastle` label does not exist, the Linear prompt tells the agent to create it through MCP before listing issues.
- Completion uses Linear MCP tools to add a `Completed by Sandcastle` comment and move the issue to `LINEAR_DONE_STATE`, defaulting to `Done`.
- `.env.example` for Linear keeps `LINEAR_API_KEY` and `LINEAR_DONE_STATE`; `LINEAR_WORKSPACE` was removed because it was specific to the old CLI approach.
- README and docs now point users to the official MCP endpoint and show setup commands for Codex and Claude Code.

## Testing

Passed:

```sh
npm run test -- src/InitService.test.ts
```

Result: 165 tests passed.

Also checked:

```sh
git diff --check
```

Known unrelated failures:

```sh
npm run typecheck
```

still fails on the pre-existing Daytona SDK type mismatch:

```text
src/sandboxes/daytona.ts(116,42): error TS2339: Property 'cmdId' does not exist on type 'SessionExecuteResponse'.
```

I also ran the full test suite. It currently fails for environment/existing reasons outside this change:

- Podman tests require a running Podman Machine.
- Some macOS tests compare `/private/tmp` or `/private/var` against `/tmp` or `/var`.
- CLI tests fail in this local checkout because the repo path contains a space (`Documents/New project`) and the built CLI path is split.
- A few worktree reuse tests report existing branch checkout collisions.
