### PR TITLE
fix: call patchGitMountsForWindows in createSandbox (ADR-0006)

### DIFF
--- a/.changeset/fix-windows-mounts-create-sandbox.md
+++ b/.changeset/fix-windows-mounts-create-sandbox.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix `createSandbox` and `createSandboxFromWorktree` missing `patchGitMountsForWindows` call (ADR-0006). On Windows + Docker Desktop, the parent `.git` mount kept a `C:/...` `sandboxPath`, which the Linux daemon parsed on `:` and rejected with `invalid mode: /dev/.../.git`. The two `createSandbox` paths now mirror the wiring already present in `SandboxFactory.ts` (head + worktree).

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -49,6 +49,8 @@ import { syncOut } from "./syncOut.js";
 import * as WorktreeManager from "./WorktreeManager.js";
 import { copyToWorktree } from "./CopyToWorktree.js";
 import { resolveCwd } from "./resolveCwd.js";
+import { patchGitMountsForWindows } from "./mountUtils.js";
+import { WorktreeError } from "./errors.js";
 
 export interface CreateSandboxOptions {
   /** Explicit branch for the worktree (required). */
@@ -527,7 +529,12 @@ export const createSandboxFromWorktree = async (
     options.sandbox.tag !== "isolated"
   ) {
     await Effect.runPromise(
-      copyToWorktree(options.copyToWorktree, hostRepoDir, worktreePath, options.timeouts?.copyToWorktreeMs),
+      copyToWorktree(
+        options.copyToWorktree,
+        hostRepoDir,
+        worktreePath,
+        options.timeouts?.copyToWorktreeMs,
+      ),
     );
   }
 
@@ -567,6 +574,21 @@ export const createSandboxFromWorktree = async (
       startEffect = resolveGitMounts(join(hostRepoDir, ".git")).pipe(
         Effect.provide(NodeFileSystem.layer),
         Effect.catchAll(() => Effect.succeed([])),
+        // Patch git mounts for Windows worktree compatibility (ADR-0006)
+        Effect.flatMap((gitMounts) =>
+          Effect.tryPromise({
+            try: () =>
+              patchGitMountsForWindows(
+                gitMounts,
+                worktreePath,
+                SANDBOX_REPO_DIR,
+              ),
+            catch: (e) =>
+              new WorktreeError({
+                message: `Failed to patch git mounts: ${e instanceof Error ? e.message : String(e)}`,
+              }),
+          }),
+        ),
         Effect.flatMap((gitMounts) =>
           startSandbox({
             provider,
@@ -681,7 +703,12 @@ export const createSandbox = async (
     options.sandbox.tag !== "isolated"
   ) {
     await Effect.runPromise(
-      copyToWorktree(options.copyToWorktree, hostRepoDir, worktreePath, options.timeouts?.copyToWorktreeMs),
+      copyToWorktree(
+        options.copyToWorktree,
+        hostRepoDir,
+        worktreePath,
+        options.timeouts?.copyToWorktreeMs,
+      ),
     );
   }
 
@@ -729,6 +756,21 @@ export const createSandbox = async (
       startEffect = resolveGitMounts(join(hostRepoDir, ".git")).pipe(
         Effect.provide(NodeFileSystem.layer),
         Effect.catchAll(() => Effect.succeed([])),
+        // Patch git mounts for Windows worktree compatibility (ADR-0006)
+        Effect.flatMap((gitMounts) =>
+          Effect.tryPromise({
+            try: () =>
+              patchGitMountsForWindows(
+                gitMounts,
+                worktreePath,
+                SANDBOX_REPO_DIR,
+              ),
+            catch: (e) =>
+              new WorktreeError({
+                message: `Failed to patch git mounts: ${e instanceof Error ? e.message : String(e)}`,
+              }),
+          }),
+        ),
         Effect.flatMap((gitMounts) =>
           startSandbox({
             provider,


### PR DESCRIPTION
1. `createSandbox` and `createSandboxFromWorktree` currently call `resolveGitMounts` → `startSandbox` directly, skipping the `patchGitMountsForWindows` step that ADR-0006 introduced.
2. Effect: on Windows + Docker Desktop (Linux engine) + bind-mount provider, the parent `.git` mount keeps a `C:/...` `sandboxPath`, which the Linux daemon parses on `:` and rejects with `docker: Error response from daemon: invalid mode: /dev/.../.git`. `sandcastle.run(...)` is unaffected because it goes through `SandboxFactory.ts`, which is already patched.
3. Fix mirrors the existing `Effect.tryPromise` block in `SandboxFactory.ts` (head + worktree paths from #423) at the two analogous sites in `createSandbox.ts`. Adds the `patchGitMountsForWindows` and `WorktreeError` imports.

Reproduces with the parallel-planner template on Windows. Related to #479 (btodd22's comment shows the identical `invalid mode` error).

Local checks: `npm run typecheck` passes. `npm test` was not run on a clean Linux environment locally; existing `patchGitMountsForWindows` unit tests in `mountUtils.test.ts` still cover the function. CI (ubuntu-latest) will verify the integration.
