### PR TITLE
fix: pre-flight container runtime in sandcastle init

### DIFF
--- a/.changeset/init-build-recover.md
+++ b/.changeset/init-build-recover.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+`sandcastle init` no longer aborts the wizard when the container build can't reach Docker/Podman. Before kicking off the build, it now probes the daemon: if it's not running, the user is prompted to start it and retry without re-answering any of the wizard prompts; if the binary isn't installed, `init` reports that and points to the standalone `sandcastle <provider> build-image` command. A build that fails after a healthy pre-flight is also surfaced inline (with the same retry hint) instead of crashing the process. The scaffolded `.sandcastle/` directory is preserved in every failure path.

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -25,6 +25,36 @@ const dockerExec = (args: string[]): Effect.Effect<string, DockerError> =>
     );
   });
 
+export type DockerHealth = "ok" | "not-installed" | "not-running";
+
+/**
+ * Probe whether the docker CLI is on PATH and the daemon is reachable.
+ *
+ * Returns "not-installed" if the binary is missing, "not-running" if the
+ * daemon is unreachable, "ok" otherwise.
+ */
+export const checkDockerHealth: Effect.Effect<DockerHealth> = Effect.async(
+  (resume) => {
+    execFile(
+      "docker",
+      ["info", "--format", "{{.ServerVersion}}"],
+      { maxBuffer: 1024 * 1024 },
+      (error) => {
+        if (!error) {
+          resume(Effect.succeed("ok"));
+          return;
+        }
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          resume(Effect.succeed("not-installed"));
+          return;
+        }
+        resume(Effect.succeed("not-running"));
+      },
+    );
+  },
+);
+
 /**
  * Build the sandcastle Docker image.
  *

--- a/src/PodmanLifecycle.ts
+++ b/src/PodmanLifecycle.ts
@@ -25,6 +25,36 @@ const podmanExec = (args: string[]): Effect.Effect<string, PodmanError> =>
     );
   });
 
+export type PodmanHealth = "ok" | "not-installed" | "not-running";
+
+/**
+ * Probe whether the podman CLI is on PATH and the machine/daemon is reachable.
+ *
+ * Returns "not-installed" if the binary is missing, "not-running" if the
+ * machine is unreachable, "ok" otherwise.
+ */
+export const checkPodmanHealth: Effect.Effect<PodmanHealth> = Effect.async(
+  (resume) => {
+    execFile(
+      "podman",
+      ["info", "--format", "{{.Version.Version}}"],
+      { maxBuffer: 1024 * 1024 },
+      (error) => {
+        if (!error) {
+          resume(Effect.succeed("ok"));
+          return;
+        }
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          resume(Effect.succeed("not-installed"));
+          return;
+        }
+        resume(Effect.succeed("not-running"));
+      },
+    );
+  },
+);
+
 /**
  * Build the sandcastle Podman image.
  *

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,11 +8,17 @@ import { join } from "node:path";
 import { styleText } from "node:util";
 
 import { Display } from "./Display.js";
-import { buildImage, removeImage } from "./DockerLifecycle.js";
+import {
+  buildImage,
+  checkDockerHealth,
+  removeImage,
+} from "./DockerLifecycle.js";
 import {
   buildImage as podmanBuildImage,
+  checkPodmanHealth,
   removeImage as podmanRemoveImage,
 } from "./PodmanLifecycle.js";
+import { formatErrorMessage } from "./ErrorHandler.js";
 import {
   scaffold,
   listTemplates,
@@ -30,6 +36,7 @@ import type {
   BacklogManagerEntry,
   SandboxProviderEntry,
 } from "./InitService.js";
+import type { SandboxError } from "./errors.js";
 import { ConfigDirError, InitError } from "./errors.js";
 
 const require = createRequire(import.meta.url);
@@ -277,6 +284,9 @@ const initCommand = Command.make(
 
       // Prompt user before building image
       const providerLabel = selectedSandboxProvider.label;
+      const providerNamespace = selectedSandboxProvider.cliNamespace;
+      const skipBuildMessage = `Init complete! Run \`sandcastle ${providerNamespace} build-image\` to build the ${providerLabel} image later.`;
+
       const shouldBuild = yield* Effect.promise(() =>
         clack.confirm({
           message: `Build the default ${providerLabel} image now?`,
@@ -285,24 +295,77 @@ const initCommand = Command.make(
       );
 
       if (shouldBuild === true) {
-        const containerfileDir = join(cwd, CONFIG_DIR);
-        if (selectedSandboxProvider.name === "podman") {
-          yield* d.spinner(
+        // Pre-flight the container runtime; loop on retry if the daemon is down
+        const checkHealth =
+          selectedSandboxProvider.name === "podman"
+            ? checkPodmanHealth
+            : checkDockerHealth;
+
+        let outcome: "build" | "skip" | "not-installed" = "skip";
+        let resolved = false;
+        while (!resolved) {
+          const health = yield* checkHealth;
+          if (health === "ok") {
+            outcome = "build";
+            resolved = true;
+          } else if (health === "not-installed") {
+            outcome = "not-installed";
+            resolved = true;
+          } else {
+            const choice = yield* Effect.promise(() =>
+              clack.select({
+                message: `${providerLabel} doesn't seem to be running. Start it, then choose what to do.`,
+                options: [
+                  {
+                    value: "retry",
+                    label: `I started ${providerLabel} — retry`,
+                  },
+                  {
+                    value: "skip",
+                    label: "Skip the build, I'll run it later",
+                  },
+                ],
+              }),
+            );
+            if (clack.isCancel(choice) || choice === "skip") {
+              outcome = "skip";
+              resolved = true;
+            }
+          }
+        }
+
+        if (outcome === "build") {
+          const containerfileDir = join(cwd, CONFIG_DIR);
+          const containerBuild: Effect.Effect<void, SandboxError> =
+            selectedSandboxProvider.name === "podman"
+              ? podmanBuildImage(imageName, containerfileDir)
+              : buildImage(imageName, containerfileDir);
+
+          // Catch locally so a build failure doesn't trip the global exit handler — scaffolded .sandcastle/ is preserved
+          const buildResult = yield* d.spinner(
             `Building ${providerLabel} image '${imageName}'...`,
-            podmanBuildImage(imageName, containerfileDir),
+            Effect.either(containerBuild),
+          );
+
+          if (buildResult._tag === "Right") {
+            yield* d.status(
+              "Init complete! Image built successfully.",
+              "success",
+            );
+          } else {
+            yield* d.status(formatErrorMessage(buildResult.left), "error");
+            yield* d.status(skipBuildMessage, "info");
+          }
+        } else if (outcome === "not-installed") {
+          yield* d.status(
+            `${providerLabel} doesn't appear to be installed. Install it, then run \`sandcastle ${providerNamespace} build-image\` to build the image.`,
+            "warn",
           );
         } else {
-          yield* d.spinner(
-            `Building ${providerLabel} image '${imageName}'...`,
-            buildImage(imageName, containerfileDir),
-          );
+          yield* d.status(skipBuildMessage, "success");
         }
-        yield* d.status("Init complete! Image built successfully.", "success");
       } else {
-        yield* d.status(
-          `Init complete! Run \`sandcastle ${selectedSandboxProvider.cliNamespace} build-image\` to build the ${providerLabel} image later.`,
-          "success",
-        );
+        yield* d.status(skipBuildMessage, "success");
       }
 
       // Show template-specific next steps


### PR DESCRIPTION
Had an exception thrown when I was running sandcastle init because docker wasnt running. Had to clean up (remove .sandcastle/) and then start it again after opening docker.

PR adds helpful message if docker/podman isnt in PATH or isnt running. And prompts user to resolve that before continuing the base image build