### PR TITLE
Fix/codex sandbox auth init

### DIFF
--- a/.changeset/fix-codex-sandbox-auth.md
+++ b/.changeset/fix-codex-sandbox-auth.md
@@ -1,0 +1,7 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix generated Docker and Podman Sandcastle configs for Codex auth. `sandcastle init` now lets Codex users choose API-key auth or subscription auth, keeps API-key auth as the default, and generates subscription auth by mounting only `~/.codex/auth.json` read-only before copying it into a writable sandbox-local `CODEX_HOME`.
+
+Generated templates now share a sandbox config across all run/createSandbox calls and set `GIT_CONFIG_GLOBAL` inside `.sandcastle/` so Git global config writes do not fail when Docker runs with a host UID that does not own `/home/agent`.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ npx sandcastle init
 cp .sandcastle/.env.example .sandcastle/.env
 ```
 
+When selecting Codex during `sandcastle init`, Sandcastle asks whether to use API-key auth or a Codex subscription. API-key auth remains the default. Subscription auth expects you to run `codex login` on the host first; generated Docker/Podman configs mount only `~/.codex/auth.json` read-only and copy it into a sandbox-local `CODEX_HOME`.
+
 4. Run the `.sandcastle/main.ts` (or `main.mts`) file with `npx tsx`
 
 ```bash

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -231,9 +231,9 @@ describe("InitService scaffold", () => {
     );
     expect(gitignore).toContain(".env");
     expect(gitignore).toContain(".gitconfig");
-    expect(gitignore).toContain("codex-home/");
     expect(gitignore).toContain("logs/");
     expect(gitignore).toContain("worktrees/");
+    expect(gitignore).not.toContain("codex-home/");
     expect(gitignore).not.toContain("patches/");
   });
 
@@ -645,6 +645,17 @@ describe("InitService scaffold", () => {
       const joined = lines.join("\n");
       expect(joined).not.toContain("CODING_STANDARDS.md");
     });
+
+    it("codex subscription next steps do not mention Claude subscription auth", () => {
+      const lines = getNextStepsLines("simple-loop", "main.mts", {
+        agent: codexAgent,
+        codexAuthMode: "subscription",
+      });
+      const joined = lines.join("\n");
+      expect(joined).toContain("Codex subscription auth");
+      expect(joined).not.toContain("Claude subscription");
+      expect(joined).not.toContain("issues/191");
+    });
   });
 
   it("scaffolds pi agent with pi Dockerfile", async () => {
@@ -746,6 +757,12 @@ describe("InitService scaffold", () => {
     expect(mainTs).toContain("cp /mnt/codex-auth/auth.json");
     expect(envExample).toContain("Run `codex login`");
     expect(envExample).not.toContain("OPENAI_KEY=");
+
+    const gitignore = await readFile(
+      join(dir, ".sandcastle", ".gitignore"),
+      "utf-8",
+    );
+    expect(gitignore).toContain("codex-home/");
   });
 
   // --- createLabel option ---

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -230,6 +230,8 @@ describe("InitService scaffold", () => {
       "utf-8",
     );
     expect(gitignore).toContain(".env");
+    expect(gitignore).toContain(".gitconfig");
+    expect(gitignore).toContain("codex-home/");
     expect(gitignore).toContain("logs/");
     expect(gitignore).toContain("worktrees/");
     expect(gitignore).not.toContain("patches/");
@@ -693,6 +695,57 @@ describe("InitService scaffold", () => {
     );
     expect(mainTs).toContain('codex("gpt-5.4-mini")');
     expect(mainTs).not.toContain("claudeCode");
+  });
+
+  it("scaffolds codex API-key auth mode without subscription auth mounts", async () => {
+    const dir = await makeDir();
+    await runScaffold(dir, {
+      agent: codexAgent,
+      model: "gpt-5.4-mini",
+      codexAuthMode: "api-key",
+    });
+
+    const mainTs = await readFile(
+      join(dir, ".sandcastle", "main.mts"),
+      "utf-8",
+    );
+    const envExample = await readFile(
+      join(dir, ".sandcastle", ".env.example"),
+      "utf-8",
+    );
+    expect(mainTs).toContain(
+      'GIT_CONFIG_GLOBAL: "/home/agent/workspace/.sandcastle/.gitconfig"',
+    );
+    expect(mainTs).not.toContain("~/.codex/auth.json");
+    expect(mainTs).not.toContain("CODEX_HOME");
+    expect(envExample).toContain("OPENAI_KEY=");
+  });
+
+  it("scaffolds codex subscription auth mode with a read-only auth source and writable CODEX_HOME", async () => {
+    const dir = await makeDir();
+    await runScaffold(dir, {
+      agent: codexAgent,
+      model: "gpt-5.4-mini",
+      codexAuthMode: "subscription",
+    });
+
+    const mainTs = await readFile(
+      join(dir, ".sandcastle", "main.mts"),
+      "utf-8",
+    );
+    const envExample = await readFile(
+      join(dir, ".sandcastle", ".env.example"),
+      "utf-8",
+    );
+    expect(mainTs).toContain('hostPath: "~/.codex/auth.json"');
+    expect(mainTs).toContain('sandboxPath: "/mnt/codex-auth/auth.json"');
+    expect(mainTs).toContain("readonly: true");
+    expect(mainTs).toContain(
+      'CODEX_HOME: "/home/agent/workspace/.sandcastle/codex-home"',
+    );
+    expect(mainTs).toContain("cp /mnt/codex-auth/auth.json");
+    expect(envExample).toContain("Run `codex login`");
+    expect(envExample).not.toContain("OPENAI_KEY=");
   });
 
   // --- createLabel option ---
@@ -1891,6 +1944,22 @@ describe("InitService scaffold", () => {
       );
       expect(containerfile).toContain("FROM node:22-bookworm");
       expect(containerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
+    });
+
+    it("selecting podman rewrites generated main file to use podman", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, { sandboxProvider: podmanProvider });
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain(
+        'import { podman } from "@ai-hero/sandcastle/sandboxes/podman";',
+      );
+      expect(mainTs).toContain("sandbox: podman(sandboxConfig)");
+      expect(mainTs).not.toContain("sandboxes/docker");
+      expect(mainTs).not.toContain("docker(");
     });
 
     it("selecting podman does not write Dockerfile", async () => {

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -6,9 +6,11 @@ import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
 
 const GITIGNORE = `.env
 .gitconfig
-codex-home/
 logs/
 worktrees/
+`;
+
+const CODEX_SUBSCRIPTION_GITIGNORE = `codex-home/
 `;
 
 export interface TemplateMetadata {
@@ -301,8 +303,6 @@ export const getAgent = (name: string): AgentEntry | undefined =>
 export interface SandboxProviderEntry {
   readonly name: string;
   readonly label: string;
-  readonly factoryImport: string;
-  readonly importPath: string;
   /** Filename written to .sandcastle/ (e.g. "Dockerfile" or "Containerfile") */
   readonly containerfileName: string;
   /** CLI namespace for build/remove commands (e.g. "docker" or "podman") */
@@ -313,16 +313,12 @@ const SANDBOX_PROVIDER_REGISTRY: SandboxProviderEntry[] = [
   {
     name: "docker",
     label: "Docker",
-    factoryImport: "docker",
-    importPath: "@ai-hero/sandcastle/sandboxes/docker",
     containerfileName: "Dockerfile",
     cliNamespace: "docker",
   },
   {
     name: "podman",
     label: "Podman",
-    factoryImport: "podman",
-    importPath: "@ai-hero/sandcastle/sandboxes/podman",
     containerfileName: "Containerfile",
     cliNamespace: "podman",
   },
@@ -356,6 +352,14 @@ export const listCodexAuthModes = (): Array<{
   },
 ];
 
+const sandboxProviderFactoryImport = (
+  sandboxProvider: SandboxProviderEntry,
+): string => sandboxProvider.name;
+
+const sandboxProviderImportPath = (
+  sandboxProvider: SandboxProviderEntry,
+): string => `@ai-hero/sandcastle/sandboxes/${sandboxProvider.name}`;
+
 // ---------------------------------------------------------------------------
 // Next steps
 // ---------------------------------------------------------------------------
@@ -363,12 +367,28 @@ export const listCodexAuthModes = (): Array<{
 export function getNextStepsLines(
   template: string,
   mainFilename: string,
+  options?: {
+    readonly agent?: AgentEntry;
+    readonly codexAuthMode?: CodexAuthMode;
+  },
 ): string[] {
+  const envStep =
+    options?.agent?.name === "codex" &&
+    options?.codexAuthMode === "subscription"
+      ? "Set any required backlog manager env vars in .sandcastle/.env (see .sandcastle/.env.example). Codex subscription auth uses your host `codex login` session"
+      : "Set the required env vars in .sandcastle/.env (see .sandcastle/.env.example)";
+  const claudeSubscriptionNote =
+    options?.agent?.name === undefined || options.agent.name === "claude-code"
+      ? [
+          "   If you want to use your Claude subscription instead of an API key, see https://github.com/mattpocock/sandcastle/issues/191",
+        ]
+      : [];
+
   if (template === "blank") {
     return [
       "Next steps:",
-      `1. Set the required env vars in .sandcastle/.env (see .sandcastle/.env.example)`,
-      "   If you want to use your Claude subscription instead of an API key, see https://github.com/mattpocock/sandcastle/issues/191",
+      `1. ${envStep}`,
+      ...claudeSubscriptionNote,
       "2. Read and customize .sandcastle/prompt.md to describe what you want the agent to do",
       `3. Customize .sandcastle/${mainFilename} — it uses the JS API (\`run()\`) to control how the agent runs`,
       `4. Add "sandcastle": "npx tsx .sandcastle/${mainFilename}" to your package.json scripts`,
@@ -379,8 +399,8 @@ export function getNextStepsLines(
     let step = 1;
     const lines: string[] = [
       "Next steps:",
-      `${step++}. Set the required env vars in .sandcastle/.env (see .sandcastle/.env.example)`,
-      "   If you want to use your Claude subscription instead of an API key, see https://github.com/mattpocock/sandcastle/issues/191",
+      `${step++}. ${envStep}`,
+      ...claudeSubscriptionNote,
       `${step++}. Add "sandcastle": "npx tsx .sandcastle/${mainFilename}" to your package.json scripts`,
       `${step++}. Templates use \`copyToWorktree: ["node_modules"]\` to copy your host node_modules into the sandbox for fast startup — the \`npm install\` in the onSandboxReady hook is a safety net for platform-specific binaries. Adjust both if you use a different package manager`,
       `${step++}. Read and customize the prompt files in .sandcastle/ — they shape what the agent does`,
@@ -494,14 +514,12 @@ const rewriteMainTs = (
     // and all factory calls with the correct model.
     // Templates always use claudeCode as the placeholder factory.
     content = content.replace(/\bclaudeCode\b/g, agent.factoryImport);
+    const sandboxFactoryImport = sandboxProviderFactoryImport(sandboxProvider);
     content = content.replace(
       /import \{ docker \} from "@ai-hero\/sandcastle\/sandboxes\/docker";/,
-      `import { ${sandboxProvider.factoryImport} } from "${sandboxProvider.importPath}";`,
+      `import { ${sandboxFactoryImport} } from "${sandboxProviderImportPath(sandboxProvider)}";`,
     );
-    content = content.replace(
-      /\bdocker\(/g,
-      `${sandboxProvider.factoryImport}(`,
-    );
+    content = content.replace(/\bdocker\(/g, `${sandboxFactoryImport}(`);
     // Replace model strings in factory calls: factoryImport("any-model")
     const factoryCallRe = new RegExp(
       `${agent.factoryImport}\\(["']([^"']+)["']\\)`,
@@ -693,6 +711,8 @@ export const scaffold = (
     } = options;
     const fs = yield* FileSystem.FileSystem;
     const configDir = join(repoDir, ".sandcastle");
+    const usesCodexSubscription =
+      agent.name === "codex" && codexAuthMode === "subscription";
 
     const exists = yield* fs
       .exists(configDir)
@@ -715,7 +735,7 @@ export const scaffold = (
 
     // Build .env.example from agent + backlog manager env blocks
     const envExampleParts = [
-      agent.name === "codex" && codexAuthMode === "subscription"
+      usesCodexSubscription
         ? `# Codex subscription auth
 # Run \`codex login\` on your host machine first. Sandcastle will mount ~/.codex/auth.json read-only
 # and copy it into a sandbox-local CODEX_HOME at startup.`
@@ -735,7 +755,11 @@ export const scaffold = (
           )
           .pipe(Effect.mapError((e) => new Error(e.message))),
         fs
-          .writeFileString(join(configDir, ".gitignore"), GITIGNORE)
+          .writeFileString(
+            join(configDir, ".gitignore"),
+            GITIGNORE +
+              (usesCodexSubscription ? CODEX_SUBSCRIPTION_GITIGNORE : ""),
+          )
           .pipe(Effect.mapError((e) => new Error(e.message))),
         fs
           .writeFileString(join(configDir, ".env.example"), envExampleContent)

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -5,6 +5,8 @@ import { fileURLToPath } from "node:url";
 import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
 
 const GITIGNORE = `.env
+.gitconfig
+codex-home/
 logs/
 worktrees/
 `;
@@ -299,6 +301,8 @@ export const getAgent = (name: string): AgentEntry | undefined =>
 export interface SandboxProviderEntry {
   readonly name: string;
   readonly label: string;
+  readonly factoryImport: string;
+  readonly importPath: string;
   /** Filename written to .sandcastle/ (e.g. "Dockerfile" or "Containerfile") */
   readonly containerfileName: string;
   /** CLI namespace for build/remove commands (e.g. "docker" or "podman") */
@@ -309,12 +313,16 @@ const SANDBOX_PROVIDER_REGISTRY: SandboxProviderEntry[] = [
   {
     name: "docker",
     label: "Docker",
+    factoryImport: "docker",
+    importPath: "@ai-hero/sandcastle/sandboxes/docker",
     containerfileName: "Dockerfile",
     cliNamespace: "docker",
   },
   {
     name: "podman",
     label: "Podman",
+    factoryImport: "podman",
+    importPath: "@ai-hero/sandcastle/sandboxes/podman",
     containerfileName: "Containerfile",
     cliNamespace: "podman",
   },
@@ -327,6 +335,26 @@ export const getSandboxProvider = (
   name: string,
 ): SandboxProviderEntry | undefined =>
   SANDBOX_PROVIDER_REGISTRY.find((p) => p.name === name);
+
+export type CodexAuthMode = "api-key" | "subscription";
+
+export const listCodexAuthModes = (): Array<{
+  readonly name: CodexAuthMode;
+  readonly label: string;
+  readonly description: string;
+}> => [
+  {
+    name: "api-key",
+    label: "API key",
+    description: "Use OPENAI_KEY from .sandcastle/.env",
+  },
+  {
+    name: "subscription",
+    label: "Codex subscription",
+    description:
+      "Mount host Codex auth.json into a writable sandbox CODEX_HOME",
+  },
+];
 
 // ---------------------------------------------------------------------------
 // Next steps
@@ -440,6 +468,8 @@ const rewriteMainTs = (
   agent: AgentEntry,
   model: string,
   mainFilename: string,
+  sandboxProvider: SandboxProviderEntry,
+  codexAuthMode: CodexAuthMode,
 ): Effect.Effect<void, Error, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
@@ -464,6 +494,14 @@ const rewriteMainTs = (
     // and all factory calls with the correct model.
     // Templates always use claudeCode as the placeholder factory.
     content = content.replace(/\bclaudeCode\b/g, agent.factoryImport);
+    content = content.replace(
+      /import \{ docker \} from "@ai-hero\/sandcastle\/sandboxes\/docker";/,
+      `import { ${sandboxProvider.factoryImport} } from "${sandboxProvider.importPath}";`,
+    );
+    content = content.replace(
+      /\bdocker\(/g,
+      `${sandboxProvider.factoryImport}(`,
+    );
     // Replace model strings in factory calls: factoryImport("any-model")
     const factoryCallRe = new RegExp(
       `${agent.factoryImport}\\(["']([^"']+)["']\\)`,
@@ -473,6 +511,28 @@ const rewriteMainTs = (
       factoryCallRe,
       `${agent.factoryImport}("${model}")`,
     );
+
+    const usesCodexSubscription =
+      agent.name === "codex" && codexAuthMode === "subscription";
+    content = content
+      .replace(
+        /\/\* {{SANDBOX_ENV_ENTRIES}} \*\//g,
+        usesCodexSubscription
+          ? `CODEX_HOME: "/home/agent/workspace/.sandcastle/codex-home",`
+          : "",
+      )
+      .replace(
+        /\/\* {{SANDBOX_MOUNT_ENTRIES}} \*\//g,
+        usesCodexSubscription
+          ? `{\n    hostPath: "~/.codex/auth.json",\n    sandboxPath: "/mnt/codex-auth/auth.json",\n    readonly: true,\n  },`
+          : "",
+      )
+      .replace(
+        /\/\* {{CODEX_AUTH_READY_HOOK}} \*\//g,
+        usesCodexSubscription
+          ? `{ command: 'mkdir -p "$CODEX_HOME" && cp /mnt/codex-auth/auth.json "$CODEX_HOME/auth.json"' },`
+          : "",
+      );
 
     yield* fs
       .writeFileString(mainTsPath, content)
@@ -585,6 +645,7 @@ export interface ScaffoldOptions {
   createLabel?: boolean;
   backlogManager?: BacklogManagerEntry;
   sandboxProvider?: SandboxProviderEntry;
+  codexAuthMode?: CodexAuthMode;
 }
 
 export interface ScaffoldResult {
@@ -628,6 +689,7 @@ export const scaffold = (
       createLabel = true,
       backlogManager = BACKLOG_MANAGER_REGISTRY[0]!, // default: github-issues
       sandboxProvider = SANDBOX_PROVIDER_REGISTRY[0]!, // default: docker
+      codexAuthMode = "api-key",
     } = options;
     const fs = yield* FileSystem.FileSystem;
     const configDir = join(repoDir, ".sandcastle");
@@ -652,7 +714,13 @@ export const scaffold = (
     const templateDir = yield* getTemplateDir(templateName);
 
     // Build .env.example from agent + backlog manager env blocks
-    const envExampleParts = [agent.envExample];
+    const envExampleParts = [
+      agent.name === "codex" && codexAuthMode === "subscription"
+        ? `# Codex subscription auth
+# Run \`codex login\` on your host machine first. Sandcastle will mount ~/.codex/auth.json read-only
+# and copy it into a sandbox-local CODEX_HOME at startup.`
+        : agent.envExample,
+    ];
     if (backlogManager.envExample) {
       envExampleParts.push(backlogManager.envExample);
     }
@@ -678,7 +746,14 @@ export const scaffold = (
     );
 
     // Rewrite main file with the selected agent factory and model
-    yield* rewriteMainTs(configDir, agent, model, mainFilename);
+    yield* rewriteMainTs(
+      configDir,
+      agent,
+      model,
+      mainFilename,
+      sandboxProvider,
+      codexAuthMode,
+    );
 
     // Replace backlog manager template arguments in all text files (must run before label stripping)
     yield* substituteTemplateArgs(configDir, backlogManager);

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -83,6 +83,11 @@ describe("sandcastle CLI", () => {
     expect(stdout).toContain("--model");
   });
 
+  it("init --help exposes --codex-auth flag", async () => {
+    const { stdout } = await runCli("init --help", process.cwd());
+    expect(stdout).toContain("--codex-auth");
+  });
+
   it("init --template nonexistent produces error listing available templates", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "cli-host-"));
     await initRepo(hostDir);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -365,6 +365,10 @@ const initCommand = Command.make(
       const nextSteps = getNextStepsLines(
         selectedTemplate,
         scaffoldResult.mainFilename,
+        {
+          agent: selectedAgent,
+          codexAuthMode: selectedCodexAuthMode,
+        },
       );
       for (const [i, line] of nextSteps.entries()) {
         yield* d.text(i === 0 ? line : styleText("dim", line));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,12 +22,14 @@ import {
   getBacklogManager,
   listSandboxProviders,
   getSandboxProvider,
+  listCodexAuthModes,
   getNextStepsLines,
 } from "./InitService.js";
 import { defaultImageName } from "./sandboxes/docker.js";
 import type {
   AgentEntry,
   BacklogManagerEntry,
+  CodexAuthMode,
   SandboxProviderEntry,
 } from "./InitService.js";
 import { ConfigDirError, InitError } from "./errors.js";
@@ -89,6 +91,13 @@ const initModelOption = Options.text("model").pipe(
   Options.optional,
 );
 
+const codexAuthOption = Options.text("codex-auth").pipe(
+  Options.withDescription(
+    "Codex auth mode: api-key or subscription. Defaults to api-key",
+  ),
+  Options.optional,
+);
+
 const initCommand = Command.make(
   "init",
   {
@@ -96,12 +105,14 @@ const initCommand = Command.make(
     template: templateOption,
     agent: agentOption,
     model: initModelOption,
+    codexAuth: codexAuthOption,
   },
   ({
     imageName: imageNameFlag,
     template,
     agent: agentFlag,
     model: modelFlag,
+    codexAuth,
   }) =>
     Effect.gen(function* () {
       const d = yield* Display;
@@ -161,6 +172,50 @@ const initCommand = Command.make(
         modelFlag._tag === "Some"
           ? modelFlag.value
           : selectedAgent.defaultModel;
+
+      let selectedCodexAuthMode: CodexAuthMode = "api-key";
+      if (selectedAgent.name === "codex") {
+        const codexAuthModes = listCodexAuthModes();
+        if (codexAuth._tag === "Some") {
+          const valid = codexAuthModes.find((m) => m.name === codexAuth.value);
+          if (!valid) {
+            const names = codexAuthModes.map((m) => m.name).join(", ");
+            yield* Effect.fail(
+              new InitError({
+                message: `Unknown Codex auth mode "${codexAuth.value}". Available: ${names}`,
+              }),
+            );
+          } else {
+            selectedCodexAuthMode = valid.name;
+          }
+        } else if (agentFlag._tag === "None") {
+          const selected = yield* Effect.promise(() =>
+            clack.select({
+              message: "Select Codex auth mode:",
+              initialValue: "api-key",
+              options: codexAuthModes.map((m) => ({
+                value: m.name,
+                label: m.label,
+                hint: m.description,
+              })),
+            }),
+          );
+          if (clack.isCancel(selected)) {
+            yield* Effect.fail(
+              new InitError({
+                message: "Codex auth mode selection cancelled.",
+              }),
+            );
+          }
+          selectedCodexAuthMode = selected as CodexAuthMode;
+        }
+      } else if (codexAuth._tag === "Some") {
+        yield* Effect.fail(
+          new InitError({
+            message: "--codex-auth can only be used with --agent codex",
+          }),
+        );
+      }
 
       // Resolve sandbox provider: interactive select (no default — user must choose)
       const sandboxProviders = listSandboxProviders();
@@ -265,6 +320,7 @@ const initCommand = Command.make(
           createLabel: shouldCreateLabel === true,
           backlogManager: selectedBacklogManager,
           sandboxProvider: selectedSandboxProvider,
+          codexAuthMode: selectedCodexAuthMode,
         }).pipe(
           Effect.mapError(
             (e) =>

--- a/src/templates/blank/main.mts
+++ b/src/templates/blank/main.mts
@@ -5,8 +5,27 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 // Run this with: npx tsx .sandcastle/main.mts
 // Or add to package.json scripts: "sandcastle": "npx tsx .sandcastle/main.mts"
 
+const sandboxConfig = {
+  env: {
+    GIT_CONFIG_GLOBAL: "/home/agent/workspace/.sandcastle/.gitconfig",
+    /* {{SANDBOX_ENV_ENTRIES}} */
+  },
+  mounts: [
+    /* {{SANDBOX_MOUNT_ENTRIES}} */
+  ],
+};
+
+const hooks = {
+  sandbox: {
+    onSandboxReady: [
+      /* {{CODEX_AUTH_READY_HOOK}} */
+    ],
+  },
+};
+
 await run({
   agent: claudeCode("claude-opus-4-6"),
-  sandbox: docker(),
+  sandbox: docker(sandboxConfig),
+  hooks,
   promptFile: "./.sandcastle/prompt.md",
 });

--- a/src/templates/parallel-planner-with-review/main.mts
+++ b/src/templates/parallel-planner-with-review/main.mts
@@ -32,10 +32,24 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 // Raise this if your backlog is large; lower it for a quick smoke-test run.
 const MAX_ITERATIONS = 10;
 
+const sandboxConfig = {
+  env: {
+    GIT_CONFIG_GLOBAL: "/home/agent/workspace/.sandcastle/.gitconfig",
+    /* {{SANDBOX_ENV_ENTRIES}} */
+  },
+  mounts: [
+    /* {{SANDBOX_MOUNT_ENTRIES}} */
+  ],
+};
+
 // Hooks run inside the sandbox before the agent starts each iteration.
 // npm install ensures the sandbox always has fresh dependencies.
 const hooks = {
-  sandbox: { onSandboxReady: [{ command: "npm install" }] },
+  sandbox: {
+    onSandboxReady: [
+      /* {{CODEX_AUTH_READY_HOOK}} */ { command: "npm install" },
+    ],
+  },
 };
 
 // Copy node_modules from the host into the worktree before each sandbox
@@ -61,7 +75,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   // -------------------------------------------------------------------------
   const plan = await sandcastle.run({
     hooks,
-    sandbox: docker(),
+    sandbox: docker(sandboxConfig),
     name: "planner",
     // One iteration is enough: the planner just needs to read and reason,
     // not write code.
@@ -111,7 +125,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     issues.map(async (issue) => {
       const sandbox = await sandcastle.createSandbox({
         branch: issue.branch,
-        sandbox: docker(),
+        sandbox: docker(sandboxConfig),
         hooks,
         copyToWorktree,
       });
@@ -203,7 +217,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   // -------------------------------------------------------------------------
   await sandcastle.run({
     hooks,
-    sandbox: docker(),
+    sandbox: docker(sandboxConfig),
     name: "merger",
     maxIterations: 1,
     agent: sandcastle.claudeCode("claude-sonnet-4-6"),
@@ -212,9 +226,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
       // A markdown list of branch names, one per line.
       BRANCHES: completedBranches.map((b) => `- ${b}`).join("\n"),
       // A markdown list of issue IDs and titles, one per line.
-      ISSUES: completedIssues
-        .map((i) => `- ${i.id}: ${i.title}`)
-        .join("\n"),
+      ISSUES: completedIssues.map((i) => `- ${i.id}: ${i.title}`).join("\n"),
     },
   });
 

--- a/src/templates/parallel-planner/main.mts
+++ b/src/templates/parallel-planner/main.mts
@@ -27,10 +27,24 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 // Raise this if your backlog is large; lower it for a quick smoke-test run.
 const MAX_ITERATIONS = 10;
 
+const sandboxConfig = {
+  env: {
+    GIT_CONFIG_GLOBAL: "/home/agent/workspace/.sandcastle/.gitconfig",
+    /* {{SANDBOX_ENV_ENTRIES}} */
+  },
+  mounts: [
+    /* {{SANDBOX_MOUNT_ENTRIES}} */
+  ],
+};
+
 // Hooks run inside the sandbox before the agent starts each iteration.
 // npm install ensures the sandbox always has fresh dependencies.
 const hooks = {
-  sandbox: { onSandboxReady: [{ command: "npm install" }] },
+  sandbox: {
+    onSandboxReady: [
+      /* {{CODEX_AUTH_READY_HOOK}} */ { command: "npm install" },
+    ],
+  },
 };
 
 // Copy node_modules from the host into the worktree before each sandbox
@@ -56,7 +70,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   // -------------------------------------------------------------------------
   const plan = await sandcastle.run({
     hooks,
-    sandbox: docker(),
+    sandbox: docker(sandboxConfig),
     name: "planner",
     // One iteration is enough: the planner just needs to read and reason,
     // not write code.
@@ -107,7 +121,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
         hooks,
         copyToWorktree,
         // Each agent starts on its own branch via branchStrategy on run().
-        sandbox: docker(),
+        sandbox: docker(sandboxConfig),
         branchStrategy: { type: "branch", branch: issue.branch },
         name: "implementer",
         // Give each agent plenty of room to implement and iterate on tests.
@@ -180,7 +194,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   // -------------------------------------------------------------------------
   await sandcastle.run({
     hooks,
-    sandbox: docker(),
+    sandbox: docker(sandboxConfig),
     name: "merger",
     maxIterations: 1,
     // Sonnet is sufficient for merge conflict resolution.
@@ -190,9 +204,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
       // A markdown list of branch names, one per line.
       BRANCHES: completedBranches.map((b) => `- ${b}`).join("\n"),
       // A markdown list of issue IDs and titles, one per line.
-      ISSUES: completedIssues
-        .map((i) => `- ${i.id}: ${i.title}`)
-        .join("\n"),
+      ISSUES: completedIssues.map((i) => `- ${i.id}: ${i.title}`).join("\n"),
     },
   });
 

--- a/src/templates/sequential-reviewer/main.mts
+++ b/src/templates/sequential-reviewer/main.mts
@@ -27,10 +27,24 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 // Each cycle works on one issue. Raise this to process more issues per run.
 const MAX_ITERATIONS = 10;
 
+const sandboxConfig = {
+  env: {
+    GIT_CONFIG_GLOBAL: "/home/agent/workspace/.sandcastle/.gitconfig",
+    /* {{SANDBOX_ENV_ENTRIES}} */
+  },
+  mounts: [
+    /* {{SANDBOX_MOUNT_ENTRIES}} */
+  ],
+};
+
 // Hooks run inside the sandbox before the agent starts each iteration.
 // npm install ensures the sandbox always has fresh dependencies.
 const hooks = {
-  sandbox: { onSandboxReady: [{ command: "npm install" }] },
+  sandbox: {
+    onSandboxReady: [
+      /* {{CODEX_AUTH_READY_HOOK}} */ { command: "npm install" },
+    ],
+  },
 };
 
 // Copy node_modules from the host into the worktree before each sandbox
@@ -58,7 +72,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   const implement = await sandcastle.run({
     hooks,
     copyToWorktree,
-    sandbox: docker(),
+    sandbox: docker(sandboxConfig),
     branchStrategy: { type: "merge-to-head" },
     name: "implementer",
     maxIterations: 100,
@@ -87,7 +101,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   await sandcastle.run({
     hooks,
     copyToWorktree,
-    sandbox: docker(),
+    sandbox: docker(sandboxConfig),
     branchStrategy: { type: "branch", branch },
     name: "reviewer",
     maxIterations: 1,

--- a/src/templates/simple-loop/main.mts
+++ b/src/templates/simple-loop/main.mts
@@ -5,12 +5,22 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 // Run this with: npx tsx .sandcastle/main.mts
 // Or add to package.json scripts: "sandcastle": "npx tsx .sandcastle/main.mts"
 
+const sandboxConfig = {
+  env: {
+    GIT_CONFIG_GLOBAL: "/home/agent/workspace/.sandcastle/.gitconfig",
+    /* {{SANDBOX_ENV_ENTRIES}} */
+  },
+  mounts: [
+    /* {{SANDBOX_MOUNT_ENTRIES}} */
+  ],
+};
+
 await run({
   // A name for this run, shown as a prefix in log output.
   name: "worker",
 
   // Sandbox provider — Docker is the default runtime.
-  sandbox: docker(),
+  sandbox: docker(sandboxConfig),
 
   // The agent provider. Pass a model string to claudeCode() — sonnet balances
   // capability and speed for most tasks. Switch to claude-opus-4-6 for harder
@@ -44,7 +54,9 @@ await run({
       // onSandboxReady runs once after the sandbox is initialised and the repo is
       // synced in, before the agent starts. Use it to install dependencies or run
       // any other setup steps your project needs.
-      onSandboxReady: [{ command: "npm install" }],
+      onSandboxReady: [
+        /* {{CODEX_AUTH_READY_HOOK}} */ { command: "npm install" },
+      ],
     },
   },
 });


### PR DESCRIPTION
### Summary

Fixes Codex subscription auth in generated Docker/Podman Sandcastle setups.

This PR updates `sandcastle init` so Codex users can choose between API-key auth and subscription auth. API-key auth remains the default.

### Problem

  Before this PR, Codex-generated Sandcastle configs assumed API-key
  usage. Users who wanted to use their Codex subscription had to
  manually patch the generated sandbox config.

  The manual workaround was also easy to make too broad: mounting the
  full `~/.codex` directory into the sandbox works, but it gives the
  container access to more local Codex state than it needs.

  There was also a Docker/Podman UID issue in some setups. Sandcastle
  containers can run as the host UID/GID, while `/home/agent` is owned
  by the image user. In that case, Git may fail when it tries to write
  global config to `/home/agent/.gitconfig`.

### What Changed

  - Added a Codex auth mode prompt during Sandcastle init.
  - Added `--codex-auth api-key|subscription` options.
  - Generated Docker/Podman template config (`sandboxConfig`) and pass it to every Docker/Podman sandbox.
  - Added `GIT_CONFIG_GLOBAL` so Git writes global config to a writable
  workspace-local file instead of `/home/agent/.gitconfig`
  - For Codex subscription auth, generated configs mount only `~/.codex/auth.json` read-only and copy it into a writable sandbox-local
  `CODEX_HOME`.
  - Added ignore entries for generated local config/auth files.
  - Kept `GH_TOKEN` as the GitHub Issues auth path.
  - Kept Codex model defaults unchanged.
  
Fixes #488, also addresses #499