### PR TITLE
Add persistent Pi session support

### DIFF
--- a/.changeset/persistent-pi-sessions.md
+++ b/.changeset/persistent-pi-sessions.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add persistent session capture and resume support for the Pi agent provider.

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ await sandbox.close();
 | `hooks`              | SandboxHooks           | —       | Lifecycle hooks (`host.*`, `sandbox.*`)                                                                                             |
 | `promptArgs`         | PromptArgs             | —       | Key-value map for `{{KEY}}` placeholder substitution                                                                                |
 | `env`                | Record<string, string> | —       | Environment variables to inject into the sandbox                                                                                    |
-| `resumeSession`      | string                 | —       | Resume a prior Claude Code session by ID. Incompatible with `maxIterations > 1`. Session file must exist on host.                   |
+| `resumeSession`      | string                 | —       | Resume a prior Claude Code or Pi session by ID. Incompatible with `maxIterations > 1`. Session file must exist on host.             |
 | `signal`             | AbortSignal            | —       | Cancel the run when aborted. Kills the in-flight agent subprocess; the worktree is preserved on disk. Rejects with `signal.reason`. |
 
 #### `WorktreeRunResult`
@@ -681,7 +681,7 @@ Removes the Podman image.
 | `logging`            | object             | file (auto-generated)         | `{ type: 'file', path }` or `{ type: 'stdout' }`                                                                                                                |
 | `completionSignal`   | string \| string[] | `<promise>COMPLETE</promise>` | String or array of strings the agent emits to stop the iteration loop early                                                                                     |
 | `idleTimeoutSeconds` | number             | `600`                         | Idle timeout in seconds — resets on each agent output event                                                                                                     |
-| `resumeSession`      | string             | —                             | Resume a prior Claude Code session by ID. Incompatible with `maxIterations > 1`. Session file must exist on host.                                               |
+| `resumeSession`      | string             | —                             | Resume a prior Claude Code or Pi session by ID. Incompatible with `maxIterations > 1`. Session file must exist on host.                                         |
 | `signal`             | AbortSignal        | —                             | Cancel the run when aborted. Kills the in-flight agent subprocess and cancels lifecycle hooks; the worktree is preserved on disk. Rejects with `signal.reason`. |
 | `timeouts`           | Timeouts           | —                             | Override default timeouts for built-in lifecycle steps. Currently supports `{ copyToWorktreeMs?: number }` (default: 60 000).                                   |
 
@@ -700,7 +700,7 @@ Removes the Podman image.
 
 | Field             | Type              | Description                                                                                                                         |
 | ----------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `sessionId`       | string?           | Claude Code session ID from the init line, or `undefined` for non-Claude agents                                                     |
+| `sessionId`       | string?           | Captured Claude Code or Pi session ID, or `undefined` for providers without session support                                         |
 | `sessionFilePath` | string?           | Absolute host path to the captured session JSONL, or `undefined` when capture is off                                                |
 | `usage`           | `IterationUsage`? | Token usage snapshot from the last assistant message, or `undefined` when capture is off or provider does not support usage parsing |
 
@@ -715,13 +715,13 @@ Removes the Podman image.
 
 ### Session capture
 
-After each Claude Code iteration, Sandcastle automatically captures the agent's session JSONL from the sandbox to the host at `~/.claude/projects/<encoded-path>/sessions/<session-id>.jsonl`. The `cwd` fields inside each JSONL entry are rewritten to match the host repo root, so `claude --resume` works natively.
+After each Claude Code or Pi iteration, Sandcastle automatically captures the agent's session JSONL from the sandbox to the host at `~/.claude/projects/<encoded-path>/<session-id>.jsonl`. The `cwd` fields inside each JSONL entry are rewritten to match the host repo root, so supported providers can resume natively.
 
-Session capture is enabled by default for `claudeCode()` and can be opted out via `captureSessions: false`. Non-Claude agent providers never attempt capture. Capture failure fails the run.
+Session capture is enabled by default for `claudeCode()` and `pi()`. Claude Code can be opted out via `captureSessions: false`. Providers without session support never attempt capture. Capture failure fails the run.
 
 ### Session resume
 
-Pass `resumeSession` to `run()` to continue a prior Claude Code conversation inside a new sandbox:
+Pass `resumeSession` to `run()` to continue a prior Claude Code or Pi conversation inside a new sandbox:
 
 ```typescript
 const result = await run({
@@ -732,14 +732,14 @@ const result = await run({
 });
 ```
 
-Before the sandbox starts, Sandcastle validates that the session file exists on the host and transfers it into the sandbox with `cwd` fields rewritten to match the sandbox-side path. The Claude Code agent receives `--resume <id>` on its print command for iteration 1.
+Before the sandbox starts, Sandcastle validates that the session file exists on the host and transfers it into the sandbox with `cwd` fields rewritten to match the sandbox-side path. Claude Code receives `--resume <id>`; Pi receives `--session <id>` plus Sandcastle's sandbox session directory.
 
 Constraints:
 
 - `resumeSession` is incompatible with `maxIterations > 1` (throws before sandbox creation).
-- The session file must exist at `~/.claude/projects/<encoded-path>/sessions/<id>.jsonl` (throws before sandbox creation).
+- The session file must exist at `~/.claude/projects/<encoded-path>/<id>.jsonl` (throws before sandbox creation).
 - Only iteration 1 receives the resume flag; subsequent iterations (if any) start fresh.
-- Non-Claude agent providers ignore `resumeSession`.
+- Providers without session support ignore `resumeSession`.
 
 ### `ClaudeCodeOptions`
 
@@ -749,11 +749,11 @@ The `claudeCode()` factory accepts an optional second argument for provider-spec
 agent: claudeCode("claude-opus-4-6", { effort: "high" });
 ```
 
-| Option            | Type                                         | Default | Description                                               |
-| ----------------- | -------------------------------------------- | ------- | --------------------------------------------------------- |
-| `effort`          | `"low"` \| `"medium"` \| `"high"` \| `"max"` | —       | Claude Code reasoning effort level (`max` is Opus only)   |
-| `env`             | `Record<string, string>`                     | `{}`    | Environment variables injected by this agent provider     |
-| `captureSessions` | `boolean`                                    | `true`  | Capture agent session JSONL to host for `claude --resume` |
+| Option            | Type                                         | Default | Description                                             |
+| ----------------- | -------------------------------------------- | ------- | ------------------------------------------------------- |
+| `effort`          | `"low"` \| `"medium"` \| `"high"` \| `"max"` | —       | Claude Code reasoning effort level (`max` is Opus only) |
+| `env`             | `Record<string, string>`                     | `{}`    | Environment variables injected by this agent provider   |
+| `captureSessions` | `boolean`                                    | `true`  | Capture Claude Code session JSONL to host for resume    |
 
 ### `CodexOptions`
 

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -251,7 +251,7 @@ describe("pi factory", () => {
     const { command } = provider.buildPrintCommand(opts("do something"));
     expect(command).toContain("claude-sonnet-4-6");
     expect(command).toContain("--mode json");
-    expect(command).toContain("--no-session");
+    expect(command).not.toContain("--no-session");
     expect(command).toContain("-p");
   });
 
@@ -266,6 +266,43 @@ describe("pi factory", () => {
     const provider = pi("claude-sonnet-4-6");
     const { command } = provider.buildPrintCommand(opts("do something"));
     expect(command).toContain("--model 'claude-sonnet-4-6'");
+  });
+
+  it("buildPrintCommand passes sessionDir to pi", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const { command } = provider.buildPrintCommand({
+      ...opts("do something"),
+      sessionDir: "/home/agent/.claude/projects/-workspace-repo",
+    });
+    expect(command).toContain(
+      "--session-dir '/home/agent/.claude/projects/-workspace-repo'",
+    );
+  });
+
+  it("buildPrintCommand passes resumeSession via --session", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const { command } = provider.buildPrintCommand({
+      ...opts("do something"),
+      resumeSession: "abc-123",
+    });
+    expect(command).toContain("--session 'abc-123'");
+    expect(command).not.toContain("--resume");
+  });
+
+  it("parseStreamLine emits session_id from Pi session header", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const line = JSON.stringify({
+      type: "session",
+      version: 3,
+      id: "019df133-2c28-710f-9bd0-40e8a550cb6c",
+      cwd: "/workspace",
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      {
+        type: "session_id",
+        sessionId: "019df133-2c28-710f-9bd0-40e8a550cb6c",
+      },
+    ]);
   });
 
   it("parseStreamLine extracts text from message_update event", () => {
@@ -777,18 +814,7 @@ describe("opencode factory", () => {
   });
 });
 
-describe("resumeSession on non-Claude providers", () => {
-  it("pi ignores resumeSession in buildPrintCommand", () => {
-    const provider = pi("claude-sonnet-4-6");
-    const { command } = provider.buildPrintCommand({
-      prompt: "test",
-      dangerouslySkipPermissions: true,
-      resumeSession: "abc-123",
-    });
-    expect(command).not.toContain("--resume");
-    expect(command).not.toContain("abc-123");
-  });
-
+describe("resumeSession on providers without session support", () => {
   it("codex ignores resumeSession in buildPrintCommand", () => {
     const provider = codex("gpt-5.4-mini");
     const { command } = provider.buildPrintCommand({
@@ -928,8 +954,8 @@ describe("captureSessions flag", () => {
     ).toBe(false);
   });
 
-  it("pi has captureSessions false", () => {
-    expect(pi("pi-model").captureSessions).toBe(false);
+  it("pi has captureSessions true", () => {
+    expect(pi("pi-model").captureSessions).toBe(true);
   });
 
   it("codex has captureSessions false", () => {

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -21,7 +21,11 @@ const TOOL_ARG_FIELDS: Record<string, string> = {
 const extractErrorMessage = (obj: any): string | undefined => {
   const err = obj.error;
   if (typeof err === "string") return err;
-  if (typeof err === "object" && err !== null && typeof err.message === "string") {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    typeof err.message === "string"
+  ) {
     return err.message;
   }
   if (typeof obj.message === "string") return obj.message;
@@ -90,6 +94,8 @@ export interface AgentCommandOptions {
   readonly dangerouslySkipPermissions: boolean;
   /** When set, the agent should resume the given session ID instead of starting fresh. */
   readonly resumeSession?: string;
+  /** Directory where the agent should persist session files, when supported. */
+  readonly sessionDir?: string;
 }
 
 /** Return type of buildPrintCommand — command string plus optional stdin content.
@@ -112,12 +118,12 @@ export interface AgentProvider {
   readonly name: string;
   /** Environment variables injected by this agent provider. Merged at launch time with env resolver and sandbox provider env. */
   readonly env: Record<string, string>;
-  /** When true, session capture is enabled for this provider. Default: true for Claude Code, false for others. */
+  /** When true, session capture is enabled for this provider. */
   readonly captureSessions: boolean;
   buildPrintCommand(options: AgentCommandOptions): PrintCommand;
   buildInteractiveArgs?(options: AgentCommandOptions): string[];
   parseStreamLine(line: string): ParsedStreamEvent[];
-  /** Parse token usage from the captured session JSONL content. Only implemented by Claude Code. */
+  /** Parse token usage from the captured session JSONL content. */
   parseSessionUsage?(content: string): IterationUsage | undefined;
 }
 
@@ -131,6 +137,10 @@ const parsePiStreamLine = (line: string): ParsedStreamEvent[] => {
   if (!line.startsWith("{")) return [];
   try {
     const obj = JSON.parse(line);
+    // Pi JSON mode emits the session header as its first stdout line.
+    if (obj.type === "session" && typeof obj.id === "string") {
+      return [{ type: "session_id", sessionId: obj.id }];
+    }
     if (obj.type === "message_update" && obj.assistantMessageEvent) {
       const evt = obj.assistantMessageEvent as {
         type: string;
@@ -196,11 +206,21 @@ export interface PiOptions {
 export const pi = (model: string, options?: PiOptions): AgentProvider => ({
   name: "pi",
   env: options?.env ?? {},
-  captureSessions: false,
+  captureSessions: true,
 
-  buildPrintCommand({ prompt }: AgentCommandOptions): PrintCommand {
+  buildPrintCommand({
+    prompt,
+    resumeSession,
+    sessionDir,
+  }: AgentCommandOptions): PrintCommand {
+    const sessionDirFlag = sessionDir
+      ? ` --session-dir ${shellEscape(sessionDir)}`
+      : "";
+    const sessionFlag = resumeSession
+      ? ` --session ${shellEscape(resumeSession)}`
+      : "";
     return {
-      command: `pi -p --mode json --no-session --model ${shellEscape(model)}`,
+      command: `pi -p --mode json --model ${shellEscape(model)}${sessionDirFlag}${sessionFlag}`,
       stdin: prompt,
     };
   },

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -1594,36 +1594,34 @@ describe("Orchestrator error handling", () => {
     await commitFile(hostDir, "hello.txt", "hello", "initial commit");
 
     const opencodeProvider = opencodeFactory("test-model");
-    const stdoutContent = "Setting up environment...\nLoading model...\nError: API key is invalid\nPlease check your credentials";
+    const stdoutContent =
+      "Setting up environment...\nLoading model...\nError: API key is invalid\nPlease check your credentials";
 
-    const { factoryLayer } = makeTestSandboxFactory(
-      hostDir,
-      (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
-          exec: (command, options) => {
-            if (command.startsWith("opencode ")) {
-              return Effect.succeed({
-                stdout: stdoutContent,
-                stderr: "",
-                exitCode: 1,
-              });
-            }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
-          },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
-          copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
-      },
-    );
+    const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
+      const fsLayer = makeLocalSandboxLayer(dir);
+      return Layer.succeed(Sandbox, {
+        exec: (command, options) => {
+          if (command.startsWith("opencode ")) {
+            return Effect.succeed({
+              stdout: stdoutContent,
+              stderr: "",
+              exitCode: 1,
+            });
+          }
+          return Effect.flatMap(Sandbox, (real) =>
+            real.exec(command, options),
+          ).pipe(Effect.provide(fsLayer));
+        },
+        copyIn: (hostPath, sandboxPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyIn(hostPath, sandboxPath),
+          ).pipe(Effect.provide(fsLayer)),
+        copyFileOut: (sandboxPath, hostPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyFileOut(sandboxPath, hostPath),
+          ).pipe(Effect.provide(fsLayer)),
+      });
+    });
 
     const exit = await Effect.runPromiseExit(
       orchestrate({
@@ -1657,35 +1655,32 @@ describe("Orchestrator error handling", () => {
       result: "Rate limit exceeded, please retry later",
     });
 
-    const { factoryLayer } = makeTestSandboxFactory(
-      hostDir,
-      (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
-          exec: (command, options) => {
-            if (command.startsWith("claude ") && options?.onLine) {
-              options.onLine(errorLine);
-              return Effect.succeed({
-                stdout: errorLine,
-                stderr: "",
-                exitCode: 1,
-              });
-            }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
-          },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
-          copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
-      },
-    );
+    const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
+      const fsLayer = makeLocalSandboxLayer(dir);
+      return Layer.succeed(Sandbox, {
+        exec: (command, options) => {
+          if (command.startsWith("claude ") && options?.onLine) {
+            options.onLine(errorLine);
+            return Effect.succeed({
+              stdout: errorLine,
+              stderr: "",
+              exitCode: 1,
+            });
+          }
+          return Effect.flatMap(Sandbox, (real) =>
+            real.exec(command, options),
+          ).pipe(Effect.provide(fsLayer));
+        },
+        copyIn: (hostPath, sandboxPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyIn(hostPath, sandboxPath),
+          ).pipe(Effect.provide(fsLayer)),
+        copyFileOut: (sandboxPath, hostPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyFileOut(sandboxPath, hostPath),
+          ).pipe(Effect.provide(fsLayer)),
+      });
+    });
 
     const exit = await Effect.runPromiseExit(
       orchestrate({
@@ -1702,7 +1697,9 @@ describe("Orchestrator error handling", () => {
       expect(err).toBeInstanceOf(AgentError);
       if (err instanceof AgentError) {
         expect(err.message).toContain("claude-code exited with code 1:");
-        expect(err.message).toContain("Rate limit exceeded, please retry later");
+        expect(err.message).toContain(
+          "Rate limit exceeded, please retry later",
+        );
       }
     }
   });
@@ -1715,34 +1712,31 @@ describe("Orchestrator error handling", () => {
 
     const opencodeProvider = opencodeFactory("test-model");
 
-    const { factoryLayer } = makeTestSandboxFactory(
-      hostDir,
-      (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
-          exec: (command, options) => {
-            if (command.startsWith("opencode ")) {
-              return Effect.succeed({
-                stdout: "some stdout output",
-                stderr: "fatal error from stderr",
-                exitCode: 1,
-              });
-            }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
-          },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
-          copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
-      },
-    );
+    const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
+      const fsLayer = makeLocalSandboxLayer(dir);
+      return Layer.succeed(Sandbox, {
+        exec: (command, options) => {
+          if (command.startsWith("opencode ")) {
+            return Effect.succeed({
+              stdout: "some stdout output",
+              stderr: "fatal error from stderr",
+              exitCode: 1,
+            });
+          }
+          return Effect.flatMap(Sandbox, (real) =>
+            real.exec(command, options),
+          ).pipe(Effect.provide(fsLayer));
+        },
+        copyIn: (hostPath, sandboxPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyIn(hostPath, sandboxPath),
+          ).pipe(Effect.provide(fsLayer)),
+        copyFileOut: (sandboxPath, hostPath) =>
+          Effect.flatMap(Sandbox, (real) =>
+            real.copyFileOut(sandboxPath, hostPath),
+          ).pipe(Effect.provide(fsLayer)),
+      });
+    });
 
     const exit = await Effect.runPromiseExit(
       orchestrate({
@@ -3411,7 +3405,7 @@ describe("Session capture integration", () => {
     expect(secondEntry.text).toBe("hello");
   });
 
-  it("skips capture for non-Claude agents (captureSessions: false)", async () => {
+  it("skips capture when captureSessions is false", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "orch-nocapture-host-"));
 
     await initRepo(hostDir);

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -1,3 +1,4 @@
+import { dirname } from "node:path";
 import { Deferred, Effect } from "effect";
 import { AgentStreamEmitter } from "./AgentStreamEmitter.js";
 import { Display } from "./Display.js";
@@ -36,6 +37,7 @@ const invokeAgent = (
   idleWarningIntervalMs: number = IDLE_WARNING_INTERVAL_MS,
   resumeSession?: string,
   signal?: AbortSignal,
+  sessionDir?: string,
 ): Effect.Effect<{ result: string; sessionId?: string }, SandboxError> =>
   Effect.gen(function* () {
     let resultText = "";
@@ -99,6 +101,7 @@ const invokeAgent = (
         prompt,
         dangerouslySkipPermissions: true,
         resumeSession,
+        sessionDir,
       });
       const execResult = yield* sandbox.exec(printCmd.command, {
         onLine: (line) => {
@@ -127,9 +130,7 @@ const invokeAgent = (
           errorDetail = resultText;
         }
         if (!errorDetail.trim()) {
-          const lines = execResult.stdout
-            .split("\n")
-            .filter((l) => l.trim());
+          const lines = execResult.stdout.split("\n").filter((l) => l.trim());
           errorDetail = lines.slice(-20).join("\n");
         }
         return yield* Effect.fail(
@@ -189,7 +190,7 @@ export interface OrchestrateOptions {
   readonly name?: string;
   /** @internal Test-only override for the idle warning interval in milliseconds. Default: 60000 (1 minute). */
   readonly _idleWarningIntervalMs?: number;
-  /** Resume a prior Claude Code session by ID. Applied to iteration 1 only. */
+  /** Resume a prior agent session by ID. Applied to iteration 1 only. */
   readonly resumeSession?: string;
   /** An AbortSignal that cancels the orchestration when aborted. */
   readonly signal?: AbortSignal;
@@ -199,9 +200,9 @@ export interface OrchestrateOptions {
 
 /** Per-iteration result carrying an optional session ID. */
 export interface IterationResult {
-  /** Claude Code session ID extracted from the init line, or undefined for non-Claude agents. */
+  /** Agent session ID extracted from the stream, or undefined when unavailable. */
   readonly sessionId?: string;
-  /** Absolute host path to the captured session JSONL, or undefined when capture is disabled or provider is non-Claude. */
+  /** Absolute host path to the captured session JSONL, or undefined when capture is disabled or unavailable. */
   readonly sessionFilePath?: string;
   /** Token usage snapshot from the last assistant message in the session, or undefined when capture is disabled or provider does not support usage parsing. */
   readonly usage?: IterationUsage;
@@ -279,13 +280,21 @@ export const orchestrate = (
                 // Resume session: transfer JSONL from host to sandbox before iteration 1
                 const iterationResumeSession =
                   i === 1 ? options.resumeSession : undefined;
-                if (iterationResumeSession && bindMountHandle) {
+                const sbStore =
+                  bindMountHandle &&
+                  (provider.captureSessions || iterationResumeSession)
+                    ? sandboxSessionStore(
+                        ctx.sandboxRepoDir,
+                        bindMountHandle,
+                        sandboxProjectsDir,
+                      )
+                    : undefined;
+                const sessionDir = sbStore
+                  ? dirname(sbStore.sessionFilePath("__sandcastle__"))
+                  : undefined;
+
+                if (iterationResumeSession && sbStore) {
                   yield* display.status(label("Resuming session"), "info");
-                  const sbStore = sandboxSessionStore(
-                    ctx.sandboxRepoDir,
-                    bindMountHandle,
-                    sandboxProjectsDir,
-                  );
                   const hStore = hostSessionStore(hostRepoDir, hostProjectsDir);
                   yield* Effect.tryPromise({
                     try: () =>
@@ -358,6 +367,7 @@ export const orchestrate = (
                   options._idleWarningIntervalMs,
                   iterationResumeSession,
                   options.signal,
+                  sessionDir,
                 );
 
                 // Flush any remaining buffered text deltas
@@ -368,13 +378,8 @@ export const orchestrate = (
                 // Capture session while sandbox is still alive
                 let sessionFilePath: string | undefined;
                 let usage: IterationUsage | undefined;
-                if (provider.captureSessions && sessionId && bindMountHandle) {
+                if (provider.captureSessions && sessionId && sbStore) {
                   yield* display.status(label("Capturing session"), "info");
-                  const sbStore = sandboxSessionStore(
-                    ctx.sandboxRepoDir,
-                    bindMountHandle,
-                    sandboxProjectsDir,
-                  );
                   const hStore = hostSessionStore(hostRepoDir, hostProjectsDir);
                   yield* Effect.tryPromise({
                     try: () => transferSession(sbStore, hStore, sessionId),

--- a/src/SessionPaths.ts
+++ b/src/SessionPaths.ts
@@ -2,15 +2,15 @@ import { join } from "node:path";
 import { Context, Layer } from "effect";
 
 /**
- * Host- and sandbox-side Claude `projects` directories used by the
- * orchestrator when capturing and resuming agent sessions.
+ * Host- and sandbox-side `projects` directories used by the orchestrator when
+ * capturing and resuming agent sessions.
  */
 export class SessionPaths extends Context.Tag("SessionPaths")<
   SessionPaths,
   {
-    /** Host path to the Claude Code projects directory. */
+    /** Host path to the agent session projects directory. */
     readonly hostProjectsDir: string;
-    /** Sandbox path to the Claude Code projects directory. */
+    /** Sandbox path to the agent session projects directory. */
     readonly sandboxProjectsDir: string;
   }
 >() {}
@@ -22,9 +22,9 @@ export const sessionPathsLayer = (config: {
 }): Layer.Layer<SessionPaths> => Layer.succeed(SessionPaths, config);
 
 /**
- * Default `SessionPaths` layer using Claude Code's conventional locations:
- * `~/.claude/projects` on the host and `/home/agent/.claude/projects` in the
- * sandbox.
+ * Default `SessionPaths` layer using Sandcastle's conventional session
+ * locations: `~/.claude/projects` on the host and
+ * `/home/agent/.claude/projects` in the sandbox.
  */
 export const defaultSessionPathsLayer: Layer.Layer<SessionPaths> = Layer.sync(
   SessionPaths,

--- a/src/SessionStore.test.ts
+++ b/src/SessionStore.test.ts
@@ -82,9 +82,7 @@ describe("encodeProjectPath", () => {
   });
 
   it("strips multiple trailing backslashes", () => {
-    expect(encodeProjectPath("D:\\projekts\\app\\\\")).toBe(
-      "D-projekts-app",
-    );
+    expect(encodeProjectPath("D:\\projekts\\app\\\\")).toBe("D-projekts-app");
   });
 });
 
@@ -241,6 +239,24 @@ describe("hostSessionStore", () => {
     }
   });
 
+  it("reads Pi-style timestamp-prefixed session files by ID", async () => {
+    const dir = await setup();
+    try {
+      const store = hostSessionStore("/my/repo", dir);
+      const encoded = encodeProjectPath("/my/repo");
+      const projectDir = join(dir, encoded);
+      const jsonl = JSON.stringify({ type: "session", id: "s1" });
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(join(projectDir, "2026-01-01T00-00-00_s1.jsonl"), jsonl);
+
+      const result = await store.readSession("s1");
+
+      expect(result).toBe(jsonl);
+    } finally {
+      await teardown();
+    }
+  });
+
   it("throws on read of non-existent session", async () => {
     const dir = await setup();
     try {
@@ -306,6 +322,51 @@ describe("sandboxSessionStore", () => {
 
       expect(copyFileOutCalls.length).toBe(1);
       expect(copyFileOutCalls[0]!.from).toContain("s1.jsonl");
+      expect(result).toBe(jsonl);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads Pi-style timestamp-prefixed sandbox session files by ID", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "sandcastle-sbx-store-"));
+    try {
+      const jsonl = JSON.stringify({ type: "session", id: "s1" });
+      const sandboxCwd = "/workspace";
+      const encoded = encodeProjectPath(sandboxCwd);
+      const sandboxProjectDir = join(tempDir, ".claude", "projects", encoded);
+      const sandboxSessionPath = join(
+        sandboxProjectDir,
+        "2026-01-01T00-00-00_s1.jsonl",
+      );
+      await mkdir(sandboxProjectDir, { recursive: true });
+      await writeFile(sandboxSessionPath, jsonl);
+
+      const handle: Pick<
+        BindMountSandboxHandle,
+        "copyFileIn" | "copyFileOut" | "exec"
+      > = {
+        copyFileIn: async () => {},
+        copyFileOut: async (sandboxPath: string, hostPath: string) => {
+          const content = await readFile(sandboxPath, "utf-8");
+          await mkdir(join(hostPath, ".."), { recursive: true });
+          await writeFile(hostPath, content);
+        },
+        exec: async () => ({
+          stdout: `${sandboxSessionPath}\n`,
+          stderr: "",
+          exitCode: 0,
+        }),
+      };
+
+      const store = sandboxSessionStore(
+        sandboxCwd,
+        handle as BindMountSandboxHandle,
+        join(tempDir, ".claude", "projects"),
+      );
+
+      const result = await store.readSession("s1");
+
       expect(result).toBe(jsonl);
     } finally {
       await rm(tempDir, { recursive: true, force: true });

--- a/src/SessionStore.ts
+++ b/src/SessionStore.ts
@@ -1,14 +1,14 @@
 /**
  * SessionStore — keyed collection of agent session JSONLs.
  *
- * Provides read/write access to Claude Code session files, with two
- * implementations: host-backed (filesystem) and sandbox-backed (via
- * bind-mount handle file-transfer primitives). The `transferSession`
+ * Provides read/write access to agent session files, with two implementations:
+ * host-backed (filesystem) and sandbox-backed (via bind-mount handle
+ * file-transfer primitives). The `transferSession`
  * function copies a session between stores, rewriting `cwd` fields in
  * the JSONL entries from source cwd to target cwd.
  */
 
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { BindMountSandboxHandle } from "./SandboxProvider.js";
@@ -34,7 +34,7 @@ export interface SessionStore {
 // ---------------------------------------------------------------------------
 
 /**
- * Encode a cwd into the Claude Code `~/.claude/projects/<encoded>/` layout.
+ * Encode a cwd into Sandcastle's `projects/<encoded>/` session layout.
  * Replaces path separators with hyphens, matching Claude Code's convention.
  */
 export const encodeProjectPath = (cwd: string): string => {
@@ -43,13 +43,31 @@ export const encodeProjectPath = (cwd: string): string => {
   return normalized.replace(/^([A-Za-z]):/, "$1").replace(/[\\/]/g, "-");
 };
 
+const shellEscape = (s: string): string => "'" + s.replace(/'/g, "'\\''") + "'";
+
+const findHostSessionFile = async (
+  projectDir: string,
+  id: string,
+): Promise<string> => {
+  const exactFile = `${id}.jsonl`;
+  const exactPath = join(projectDir, exactFile);
+  try {
+    const files = await readdir(projectDir);
+    if (files.includes(exactFile)) return exactPath;
+    const suffix = `_${id}.jsonl`;
+    const match = files.find((file) => file.endsWith(suffix));
+    if (match) return join(projectDir, match);
+  } catch {}
+  return exactPath;
+};
+
 // ---------------------------------------------------------------------------
 // Host-backed SessionStore
 // ---------------------------------------------------------------------------
 
 /**
  * Create a host-backed SessionStore that reads/writes session JSONLs on the
- * host filesystem using Claude Code's `~/.claude/projects/<encoded>/` layout.
+ * host filesystem using Sandcastle's `projects/<encoded>/` layout.
  *
  * @param cwd - The host repo directory this store is associated with.
  * @param projectsDir - Override for the projects directory (default: `~/.claude/projects`).
@@ -67,7 +85,7 @@ export const hostSessionStore = (
     cwd,
     sessionFilePath: (id: string): string => join(projectDir, `${id}.jsonl`),
     readSession: async (id: string): Promise<string> => {
-      return await readFile(join(projectDir, `${id}.jsonl`), "utf-8");
+      return await readFile(await findHostSessionFile(projectDir, id), "utf-8");
     },
     writeSession: async (id: string, content: string): Promise<void> => {
       await mkdir(projectDir, { recursive: true });
@@ -96,11 +114,20 @@ export const sandboxSessionStore = (
   const encoded = encodeProjectPath(cwd);
   const projectDir = join(projectsDir, encoded);
 
+  const findSandboxSessionFile = async (id: string): Promise<string> => {
+    const exactPath = join(projectDir, `${id}.jsonl`);
+    const result = await handle.exec(
+      `find ${shellEscape(projectDir)} -maxdepth 1 -type f \\( -name ${shellEscape(`${id}.jsonl`)} -o -name ${shellEscape(`*_${id}.jsonl`)} \\) -print -quit`,
+    );
+    const match = result.stdout.trim().split("\n")[0];
+    return match || exactPath;
+  };
+
   return {
     cwd,
     sessionFilePath: (id: string): string => join(projectDir, `${id}.jsonl`),
     readSession: async (id: string): Promise<string> => {
-      const sandboxPath = join(projectDir, `${id}.jsonl`);
+      const sandboxPath = await findSandboxSessionFile(id);
       const tmpPath = join(
         tmpdir(),
         `sandcastle-session-${id}-${Date.now()}.jsonl`,

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -138,7 +138,7 @@ export interface WorktreeRunOptions {
   readonly hooks?: SandboxHooks;
   /** Environment variables to inject into the sandbox. */
   readonly env?: Record<string, string>;
-  /** Resume a prior Claude Code session by ID. The session JSONL must exist on the host. Incompatible with maxIterations > 1. */
+  /** Resume a prior agent session by ID. The session JSONL must exist on the host. Incompatible with maxIterations > 1. */
   readonly resumeSession?: string;
   /**
    * An `AbortSignal` that cancels the run when aborted.
@@ -231,7 +231,12 @@ export const createWorktree = async (
       baseBranch,
     });
     if (options.copyToWorktree && options.copyToWorktree.length > 0) {
-      yield* copyToWorktree(options.copyToWorktree, hostRepoDir, info.path, options.timeouts?.copyToWorktreeMs);
+      yield* copyToWorktree(
+        options.copyToWorktree,
+        hostRepoDir,
+        info.path,
+        options.timeouts?.copyToWorktreeMs,
+      );
     }
     // Run host.onWorktreeReady hooks after copyToWorktree, before sandbox creation
     if (options.hooks?.host?.onWorktreeReady?.length) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -242,7 +242,7 @@ export interface RunOptions {
   /** Branch strategy — controls how the agent's changes relate to branches.
    * Defaults to { type: "head" } for bind-mount providers and { type: "merge-to-head" } for isolated providers. */
   readonly branchStrategy?: BranchStrategy;
-  /** Resume a prior Claude Code session by ID. The session JSONL must exist on the host. Incompatible with maxIterations > 1. */
+  /** Resume a prior agent session by ID. The session JSONL must exist on the host. Incompatible with maxIterations > 1. */
   readonly resumeSession?: string;
   /**
    * An `AbortSignal` that cancels the run when aborted.


### PR DESCRIPTION
## Summary
- enable session capture for the Pi provider and remove `--no-session`
- capture Pi session IDs from JSON session headers and pass `--session`/`--session-dir` for resume
- extend session store lookup for Pi timestamp-prefixed JSONL files
- update docs, tests, and add a patch changeset

## Tests
- `npm run typecheck`
- `npm test -- --run src/AgentProvider.test.ts src/SessionStore.test.ts src/Orchestrator.test.ts`