### PR TITLE
fix(templates): prevent planner from querying unfiltered issues

### DIFF
--- a/src/templates/parallel-planner-with-review/plan-prompt.md
+++ b/src/templates/parallel-planner-with-review/plan-prompt.md
@@ -1,12 +1,16 @@
 # ISSUES
 
-Here are the open issues in the repo:
+Here are the **only** issues that are ready for agent implementation:
 
 <issues-json>
 
 !`{{LIST_TASKS_COMMAND}}`
 
 </issues-json>
+
+# CONSTRAINT
+
+You MUST ONLY return issues from the JSON list above. Do NOT query for additional issues. Do NOT include any issue that is not in the provided JSON.
 
 # TASK
 

--- a/src/templates/parallel-planner/plan-prompt.md
+++ b/src/templates/parallel-planner/plan-prompt.md
@@ -1,12 +1,16 @@
 # ISSUES
 
-Here are the open issues in the repo:
+Here are the **only** issues that are ready for agent implementation:
 
 <issues-json>
 
 !`{{LIST_TASKS_COMMAND}}`
 
 </issues-json>
+
+# CONSTRAINT
+
+You MUST ONLY return issues from the JSON list above. Do NOT query for additional issues. Do NOT include any issue that is not in the provided JSON.
 
 # TASK
 


### PR DESCRIPTION
## Problem

The planner agent has shell access inside the sandbox and can run its own shell commands. To build an accurate dependency graph, it may query all open issues instead of respecting the filter in `{{LIST_TASKS_COMMAND}}`.

This causes the agent to implement issues that are NOT labeled `ready-for-agent`, such as issues tagged `needs-info` or `ready-for-human`.

## Solution

Add a CONSTRAINT section to both parallel planner templates telling the agent it MUST ONLY return issues from the provided JSON list.

## Changes

- `src/templates/parallel-planner/plan-prompt.md`
- `src/templates/parallel-planner-with-review/plan-prompt.md`

## Testing

This is a prompt-level fix. The agent's behavior should be verified by:
1. Running `sandcastle init` with the parallel-planner template
2. Checking that the generated `plan-prompt.md` includes the CONSTRAINT section
3. Running the planner against a repo with mixed-label issues and verifying only `ready-for-agent` issues are selected

## Related

Closes #546