### PR TITLE
Implement stream parsing for the opencode agent provider

### DIFF
--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -703,20 +703,29 @@ describe("opencode factory", () => {
     expect(provider).not.toHaveProperty("dockerfileTemplate");
   });
 
-  it("buildPrintCommand includes the model and prompt in command (no stdin)", () => {
+  it("buildPrintCommand includes --format json, the model, and the prompt (no stdin)", () => {
     const provider = opencode("opencode/big-pickle");
     const { command, stdin } = provider.buildPrintCommand(opts("do something"));
     expect(command).toContain("opencode run");
+    expect(command).toContain("--format json");
     expect(command).toContain("opencode/big-pickle");
     expect(command).toContain("'do something'");
     expect(stdin).toBeUndefined();
   });
 
-  it("buildPrintCommand does not include --format json", () => {
+  it("buildPrintCommand includes --dangerously-skip-permissions when requested", () => {
     const provider = opencode("opencode/big-pickle");
     const { command } = provider.buildPrintCommand(opts("do something"));
-    expect(command).not.toContain("--format json");
-    expect(command).not.toContain("--format");
+    expect(command).toContain("--dangerously-skip-permissions");
+  });
+
+  it("buildPrintCommand omits --dangerously-skip-permissions when not requested", () => {
+    const provider = opencode("opencode/big-pickle");
+    const { command } = provider.buildPrintCommand({
+      prompt: "do something",
+      dangerouslySkipPermissions: false,
+    });
+    expect(command).not.toContain("--dangerously-skip-permissions");
   });
 
   it("buildPrintCommand shell-escapes the prompt", () => {
@@ -731,13 +740,232 @@ describe("opencode factory", () => {
     expect(command).toContain("--model 'opencode/big-pickle'");
   });
 
-  it("parseStreamLine returns empty array for all input (raw passthrough)", () => {
+  // --- parseStreamLine: text events ---
+
+  it("parseStreamLine extracts text from a text event", () => {
     const provider = opencode("opencode/big-pickle");
-    expect(provider.parseStreamLine("some output text")).toEqual([]);
-    expect(provider.parseStreamLine("")).toEqual([]);
-    expect(
-      provider.parseStreamLine(JSON.stringify({ type: "text", text: "hi" })),
-    ).toEqual([]);
+    const line = JSON.stringify({
+      type: "text",
+      timestamp: 1778000000000,
+      sessionID: "ses_abc",
+      part: { type: "text", text: "hello world" },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "text", text: "hello world" },
+    ]);
+  });
+
+  // --- parseStreamLine: tool_use events ---
+
+  it("parseStreamLine extracts tool call for bash tool with command arg", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: {
+        tool: "bash",
+        state: { status: "completed", input: { command: "npm test" } },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "bash", args: "npm test" },
+    ]);
+  });
+
+  it("parseStreamLine extracts tool call for read tool with filePath arg", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: {
+        tool: "read",
+        state: { status: "completed", input: { filePath: "/src/index.ts" } },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "read", args: "/src/index.ts" },
+    ]);
+  });
+
+  it("parseStreamLine extracts tool call for write tool with filePath arg", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: {
+        tool: "write",
+        state: {
+          status: "completed",
+          input: { filePath: "/src/new.ts", content: "export {}" },
+        },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "write", args: "/src/new.ts" },
+    ]);
+  });
+
+  it("parseStreamLine extracts tool call for edit tool with filePath arg", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: {
+        tool: "edit",
+        state: {
+          status: "completed",
+          input: { filePath: "/src/index.ts", oldString: "a", newString: "b" },
+        },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "edit", args: "/src/index.ts" },
+    ]);
+  });
+
+  it("parseStreamLine extracts tool call for glob tool with pattern arg", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: {
+        tool: "glob",
+        state: { status: "completed", input: { pattern: "**/*.ts" } },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "glob", args: "**/*.ts" },
+    ]);
+  });
+
+  it("parseStreamLine extracts tool call for grep tool with pattern arg", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: {
+        tool: "grep",
+        state: {
+          status: "completed",
+          input: { pattern: "TODO", include: "*.ts" },
+        },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "grep", args: "TODO" },
+    ]);
+  });
+
+  it("parseStreamLine extracts tool call for webfetch tool with url arg", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: {
+        tool: "webfetch",
+        state: {
+          status: "completed",
+          input: { url: "https://example.com" },
+        },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "webfetch", args: "https://example.com" },
+    ]);
+  });
+
+  it("parseStreamLine extracts tool call for task tool with prompt arg", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: {
+        tool: "task",
+        state: {
+          status: "completed",
+          input: { prompt: "explore the codebase" },
+        },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "task", args: "explore the codebase" },
+    ]);
+  });
+
+  it("parseStreamLine falls back to JSON.stringify for unknown tools", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: {
+        tool: "custom_tool",
+        state: {
+          status: "completed",
+          input: { foo: "bar", baz: 42 },
+        },
+      },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      {
+        type: "tool_call",
+        name: "custom_tool",
+        args: JSON.stringify({ foo: "bar", baz: 42 }),
+      },
+    ]);
+  });
+
+  it("parseStreamLine emits tool call with empty args when input is missing", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "tool_use",
+      part: { tool: "bash", state: { status: "completed" } },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "bash", args: "" },
+    ]);
+  });
+
+  // --- parseStreamLine: error events ---
+
+  it("parseStreamLine extracts error with nested error.data.message", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "error",
+      timestamp: 1778000000000,
+      sessionID: "ses_abc",
+      error: { name: "UnknownError", data: { message: "Model not found" } },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "result", result: "Model not found" },
+    ]);
+  });
+
+  it("parseStreamLine extracts error with string error", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "error",
+      error: "something went wrong",
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "result", result: "something went wrong" },
+    ]);
+  });
+
+  // --- parseStreamLine: session_id from step_start ---
+
+  it("parseStreamLine extracts session_id from step_start", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "step_start",
+      timestamp: 1778000000000,
+      sessionID: "ses_abc123",
+      part: { type: "step-start" },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "session_id", sessionId: "ses_abc123" },
+    ]);
+  });
+
+  // --- parseStreamLine: ignored events ---
+
+  it("parseStreamLine returns empty array for step_finish events", () => {
+    const provider = opencode("opencode/big-pickle");
+    const line = JSON.stringify({
+      type: "step_finish",
+      part: { reason: "stop", tokens: { total: 100 } },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([]);
   });
 
   it("parseStreamLine returns empty array for non-JSON lines", () => {
@@ -749,6 +977,13 @@ describe("opencode factory", () => {
     const provider = opencode("opencode/big-pickle");
     expect(provider.parseStreamLine("{bad json")).toEqual([]);
   });
+
+  it("parseStreamLine returns empty array for empty string", () => {
+    const provider = opencode("opencode/big-pickle");
+    expect(provider.parseStreamLine("")).toEqual([]);
+  });
+
+  // --- general factory tests ---
 
   it("bakes model into each provider instance independently", () => {
     const provider1 = opencode("model-a");

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -21,7 +21,11 @@ const TOOL_ARG_FIELDS: Record<string, string> = {
 const extractErrorMessage = (obj: any): string | undefined => {
   const err = obj.error;
   if (typeof err === "string") return err;
-  if (typeof err === "object" && err !== null && typeof err.message === "string") {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    typeof err.message === "string"
+  ) {
     return err.message;
   }
   if (typeof obj.message === "string") return obj.message;
@@ -302,6 +306,74 @@ export const codex = (
 // OpenCode agent provider
 // ---------------------------------------------------------------------------
 
+/**
+ * Maps OpenCode tool names (lowercase) to the input field containing the
+ * primary display argument.  Tools not listed here are still emitted — with
+ * a best-effort summary of their input — so that the stream callback always
+ * surfaces every tool invocation.
+ */
+const OPENCODE_TOOL_ARG_FIELDS: Record<string, string> = {
+  bash: "command",
+  read: "filePath",
+  write: "filePath",
+  edit: "filePath",
+  glob: "pattern",
+  grep: "pattern",
+  webfetch: "url",
+  task: "prompt",
+};
+
+const parseOpenCodeStreamLine = (line: string): ParsedStreamEvent[] => {
+  if (!line.startsWith("{")) return [];
+  try {
+    const obj = JSON.parse(line);
+
+    // Text event — agent prose output
+    if (obj.type === "text" && typeof obj.part?.text === "string") {
+      return [{ type: "text", text: obj.part.text }];
+    }
+
+    // Tool use event — every tool invocation, not just an allowlist
+    if (obj.type === "tool_use" && typeof obj.part?.tool === "string") {
+      const toolName = obj.part.tool as string;
+      const input = obj.part.state?.input as
+        | Record<string, unknown>
+        | undefined;
+
+      let displayArg = "";
+      const knownField = OPENCODE_TOOL_ARG_FIELDS[toolName];
+      if (knownField && input && typeof input[knownField] === "string") {
+        displayArg = input[knownField] as string;
+      } else if (input) {
+        // Fallback: stringify the full input for visibility
+        displayArg = JSON.stringify(input);
+      }
+
+      return [{ type: "tool_call", name: toolName, args: displayArg }];
+    }
+
+    // Error event — surface as result so orchestrator fallback picks it up.
+    // OpenCode errors use { error: { name, data: { message } } }.
+    if (obj.type === "error") {
+      const msg =
+        extractErrorMessage(obj) ??
+        extractErrorMessage(obj.error ?? {}) ??
+        (typeof obj.error?.data?.message === "string"
+          ? obj.error.data.message
+          : undefined);
+      return msg ? [{ type: "result", result: msg }] : [];
+    }
+
+    // Session ID — captured from the first event
+    if (typeof obj.sessionID === "string" && obj.type === "step_start") {
+      return [{ type: "session_id", sessionId: obj.sessionID }];
+    }
+  } catch {
+    // Not valid JSON — skip
+  }
+  return [];
+};
+
 /** Options for the opencode agent provider. */
 export interface OpenCodeOptions {
   /** Environment variables injected by this agent provider. */
@@ -316,9 +388,15 @@ export const opencode = (
   env: options?.env ?? {},
   captureSessions: false,
 
-  buildPrintCommand({ prompt }: AgentCommandOptions): PrintCommand {
+  buildPrintCommand({
+    prompt,
+    dangerouslySkipPermissions,
+  }: AgentCommandOptions): PrintCommand {
+    const skipPerms = dangerouslySkipPermissions
+      ? " --dangerously-skip-permissions"
+      : "";
     return {
-      command: `opencode run --model ${shellEscape(model)} ${shellEscape(prompt)}`,
+      command: `opencode run --format json${skipPerms} --model ${shellEscape(model)} ${shellEscape(prompt)}`,
     };
   },
 
@@ -328,8 +406,8 @@ export const opencode = (
     return args;
   },
 
-  parseStreamLine(_line: string): ParsedStreamEvent[] {
-    return [];
+  parseStreamLine(line: string): ParsedStreamEvent[] {
+    return parseOpenCodeStreamLine(line);
   },
 });
 


### PR DESCRIPTION
## Summary

The opencode provider had a stub `parseStreamLine` that always returned `[]`, so when using `sandcastle.opencode(...)` none of the agent's output was visible — no text, no tool calls, no errors. The orchestrator's `onAgentStreamEvent` callback simply never fired.

This PR:

- Adds a proper JSONL parser for `opencode run --format json` output, handling `text`, `tool_use`, `error`, and `step_start` (session ID) events
- Adds `--format json` to `buildPrintCommand` so the structured output is actually produced
- Adds `--dangerously-skip-permissions` support so the agent doesn't hang waiting for interactive prompts inside containers
- For tool calls, maps known opencode tools (bash, read, write, edit, glob, grep, webfetch, task) to their primary display arg, with a `JSON.stringify` fallback for unknown tools so nothing is silently swallowed

Tested end-to-end with a Docker-based sandbox runner — text and tool call events now stream correctly through the full pipeline.