### PR TITLE
feat(init): support fully non-interactive setup via flags

### DIFF
--- a/.changeset/init-non-interactive-flags.md
+++ b/.changeset/init-non-interactive-flags.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add non-interactive flags to `sandcastle init`: `--sandbox-provider`, `--backlog-manager`, `--create-label`/`--skip-label`, `--build-image`/`--skip-build-image`. When all prompts have flag overrides, `init` runs without a TTY. Closes #510.

--- a/README.md
+++ b/README.md
@@ -610,12 +610,28 @@ Select a template during `sandcastle init` when prompted, or re-run init in a fr
 
 Scaffolds the `.sandcastle/` config directory and builds the container image. This is the first command you run in a new repo. You choose a sandbox provider (Docker or Podman) during init — selecting Podman writes a `Containerfile` instead of `Dockerfile` and uses `sandcastle podman build-image` for the build step.
 
-| Option         | Required | Default                      | Description                                                          |
-| -------------- | -------- | ---------------------------- | -------------------------------------------------------------------- |
-| `--image-name` | No       | `sandcastle:<repo-dir-name>` | Docker image name                                                    |
-| `--agent`      | No       | Interactive prompt           | Agent to use (`claude-code`, `pi`, `codex`, `opencode`)              |
-| `--model`      | No       | Agent's default model        | Model to use (e.g. `claude-sonnet-4-6`). Defaults to agent's default |
-| `--template`   | No       | Interactive prompt           | Template to scaffold (e.g. `blank`, `simple-loop`)                   |
+| Option               | Required | Default                      | Description                                                           |
+| -------------------- | -------- | ---------------------------- | --------------------------------------------------------------------- |
+| `--image-name`       | No       | `sandcastle:<repo-dir-name>` | Docker image name                                                     |
+| `--agent`            | No       | Interactive prompt           | Agent to use (`claude-code`, `pi`, `codex`, `opencode`)               |
+| `--model`            | No       | Agent's default model        | Model to use (e.g. `claude-sonnet-4-6`). Defaults to agent's default  |
+| `--template`         | No       | Interactive prompt           | Template to scaffold (e.g. `blank`, `simple-loop`)                    |
+| `--sandbox-provider` | No       | Interactive prompt           | Sandbox provider (`docker`, `podman`)                                 |
+| `--backlog-manager`  | No       | Interactive prompt           | Backlog manager (`github-issues`, `beads`)                            |
+| `--create-label`     | No       | Interactive prompt           | Whether to create the "Sandcastle" GitHub label (`true`/`false`)      |
+| `--build-image`      | No       | Interactive prompt           | Whether to build the sandbox image after scaffolding (`true`/`false`) |
+
+When all required flags are provided, `sandcastle init` runs end-to-end without any interactive prompts — this is required for non-TTY environments like CI. Example:
+
+```bash
+sandcastle init \
+  --template blank \
+  --agent claude-code \
+  --sandbox-provider docker \
+  --backlog-manager github-issues \
+  --create-label true \
+  --build-image true
+```
 
 Creates the following files:
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -166,4 +166,142 @@ describe("sandcastle CLI", () => {
       expect(output).toContain("claude-code");
     }
   });
+
+  it("init --help exposes new non-interactive flags", async () => {
+    const { stdout } = await runCli("init --help", process.cwd());
+    expect(stdout).toContain("--sandbox-provider");
+    expect(stdout).toContain("--backlog-manager");
+    expect(stdout).toContain("--create-label");
+    expect(stdout).toContain("--build-image");
+    expect(stdout).not.toContain("--skip-label");
+    expect(stdout).not.toContain("--skip-build-image");
+  });
+
+  it("init --sandbox-provider nonexistent produces error listing available providers", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "cli-host-"));
+    await initRepo(hostDir);
+
+    try {
+      await runCli(
+        "init --agent claude-code --sandbox-provider nonexistent",
+        hostDir,
+      );
+      expect.fail("Expected command to fail");
+    } catch (err: unknown) {
+      const { stdout, stderr } = err as { stdout: string; stderr: string };
+      const output = stdout + stderr;
+      expect(output).toContain("nonexistent");
+      expect(output).toContain("docker");
+      expect(output).toContain("podman");
+    }
+  });
+
+  it("init --backlog-manager nonexistent produces error listing available managers", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "cli-host-"));
+    await initRepo(hostDir);
+
+    try {
+      await runCli(
+        "init --agent claude-code --backlog-manager nonexistent",
+        hostDir,
+      );
+      expect.fail("Expected command to fail");
+    } catch (err: unknown) {
+      const { stdout, stderr } = err as { stdout: string; stderr: string };
+      const output = stdout + stderr;
+      expect(output).toContain("nonexistent");
+      expect(output).toContain("github-issues");
+      expect(output).toContain("beads");
+    }
+  });
+
+  it("init --create-label with invalid value produces error listing valid values", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "cli-host-"));
+    await initRepo(hostDir);
+
+    try {
+      await runCli(
+        "init --agent claude-code --sandbox-provider docker --backlog-manager github-issues --create-label maybe --build-image false --template blank",
+        hostDir,
+      );
+      expect.fail("Expected command to fail");
+    } catch (err: unknown) {
+      const { stdout, stderr } = err as { stdout: string; stderr: string };
+      const output = stdout + stderr;
+      expect(output).toContain("maybe");
+      expect(output).toContain("true");
+      expect(output).toContain("false");
+    }
+  });
+
+  it("init --build-image with invalid value produces error listing valid values", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "cli-host-"));
+    await initRepo(hostDir);
+
+    try {
+      await runCli(
+        "init --agent claude-code --sandbox-provider docker --backlog-manager github-issues --create-label false --build-image maybe --template blank",
+        hostDir,
+      );
+      expect.fail("Expected command to fail");
+    } catch (err: unknown) {
+      const { stdout, stderr } = err as { stdout: string; stderr: string };
+      const output = stdout + stderr;
+      expect(output).toContain("maybe");
+      expect(output).toContain("true");
+      expect(output).toContain("false");
+    }
+  });
+
+  it("init runs end-to-end with stdin closed when all flags are provided", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "cli-host-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    // Pipe an empty string to close stdin so any clack prompt would block forever.
+    // With all flags provided, init must skip every prompt and run to completion.
+    const { stdout, stderr } = await execAsync(
+      `echo "" | node ${cliPath} init --template blank --agent claude-code --sandbox-provider docker --backlog-manager github-issues --create-label false --build-image false`,
+      { cwd: hostDir },
+    );
+    const output = stdout + stderr;
+    expect(output).toContain("Init complete");
+
+    const fs = await import("node:fs/promises");
+    const configFiles = await fs.readdir(join(hostDir, ".sandcastle"));
+    expect(configFiles).toContain("Dockerfile");
+    expect(configFiles).toContain(".env.example");
+    expect(configFiles).toContain("prompt.md");
+  });
+
+  it("init --sandbox-provider podman writes a Containerfile (no prompt)", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "cli-host-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const { stdout, stderr } = await execAsync(
+      `echo "" | node ${cliPath} init --template blank --agent claude-code --sandbox-provider podman --backlog-manager github-issues --create-label false --build-image false`,
+      { cwd: hostDir },
+    );
+    expect(stdout + stderr).toContain("Init complete");
+
+    const fs = await import("node:fs/promises");
+    const configFiles = await fs.readdir(join(hostDir, ".sandcastle"));
+    expect(configFiles).toContain("Containerfile");
+    expect(configFiles).not.toContain("Dockerfile");
+  });
+
+  it("init --backlog-manager beads omits GitHub label step entirely", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "cli-host-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    // No --skip-label / --create-label needed: beads is not GitHub-based,
+    // so the label prompt is skipped regardless.
+    const { stdout, stderr } = await execAsync(
+      `echo "" | node ${cliPath} init --template blank --agent claude-code --sandbox-provider docker --backlog-manager beads --build-image false`,
+      { cwd: hostDir },
+    );
+    expect(stdout + stderr).toContain("Init complete");
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,6 +89,34 @@ const initModelOption = Options.text("model").pipe(
   Options.optional,
 );
 
+const sandboxProviderOption = Options.text("sandbox-provider").pipe(
+  Options.withDescription(
+    "Sandbox provider to use (docker, podman). Skips the interactive prompt.",
+  ),
+  Options.optional,
+);
+
+const backlogManagerOption = Options.text("backlog-manager").pipe(
+  Options.withDescription(
+    "Backlog manager to use (github-issues, beads). Skips the interactive prompt.",
+  ),
+  Options.optional,
+);
+
+const createLabelOption = Options.text("create-label").pipe(
+  Options.withDescription(
+    'Whether to create the "Sandcastle" GitHub label (true/false). Skips the interactive prompt.',
+  ),
+  Options.optional,
+);
+
+const buildImageOption = Options.text("build-image").pipe(
+  Options.withDescription(
+    "Whether to build the sandbox image after scaffolding (true/false). Skips the interactive prompt.",
+  ),
+  Options.optional,
+);
+
 const initCommand = Command.make(
   "init",
   {
@@ -96,12 +124,20 @@ const initCommand = Command.make(
     template: templateOption,
     agent: agentOption,
     model: initModelOption,
+    sandboxProvider: sandboxProviderOption,
+    backlogManager: backlogManagerOption,
+    createLabel: createLabelOption,
+    buildImage: buildImageOption,
   },
   ({
     imageName: imageNameFlag,
     template,
     agent: agentFlag,
     model: modelFlag,
+    sandboxProvider: sandboxProviderFlag,
+    backlogManager: backlogManagerFlag,
+    createLabel: createLabelFlag,
+    buildImage: buildImageFlag,
   }) =>
     Effect.gen(function* () {
       const d = yield* Display;
@@ -120,6 +156,58 @@ const initCommand = Command.make(
             }),
           );
         }
+      }
+
+      if (sandboxProviderFlag._tag === "Some") {
+        const valid = getSandboxProvider(sandboxProviderFlag.value);
+        if (!valid) {
+          const names = listSandboxProviders()
+            .map((p) => p.name)
+            .join(", ");
+          yield* Effect.fail(
+            new InitError({
+              message: `Unknown sandbox provider "${sandboxProviderFlag.value}". Available: ${names}`,
+            }),
+          );
+        }
+      }
+
+      if (backlogManagerFlag._tag === "Some") {
+        const valid = getBacklogManager(backlogManagerFlag.value);
+        if (!valid) {
+          const names = listBacklogManagers()
+            .map((b) => b.name)
+            .join(", ");
+          yield* Effect.fail(
+            new InitError({
+              message: `Unknown backlog manager "${backlogManagerFlag.value}". Available: ${names}`,
+            }),
+          );
+        }
+      }
+
+      if (
+        createLabelFlag._tag === "Some" &&
+        createLabelFlag.value !== "true" &&
+        createLabelFlag.value !== "false"
+      ) {
+        yield* Effect.fail(
+          new InitError({
+            message: `Unknown --create-label value "${createLabelFlag.value}". Available: true, false`,
+          }),
+        );
+      }
+
+      if (
+        buildImageFlag._tag === "Some" &&
+        buildImageFlag.value !== "true" &&
+        buildImageFlag.value !== "false"
+      ) {
+        yield* Effect.fail(
+          new InitError({
+            message: `Unknown --build-image value "${buildImageFlag.value}". Available: true, false`,
+          }),
+        );
       }
 
       // Resolve agent: CLI flag > interactive select
@@ -162,10 +250,14 @@ const initCommand = Command.make(
           ? modelFlag.value
           : selectedAgent.defaultModel;
 
-      // Resolve sandbox provider: interactive select (no default — user must choose)
+      // Resolve sandbox provider: CLI flag > interactive select (no default — user must choose)
       const sandboxProviders = listSandboxProviders();
       let selectedSandboxProvider: SandboxProviderEntry;
-      {
+      if (sandboxProviderFlag._tag === "Some") {
+        selectedSandboxProvider = getSandboxProvider(
+          sandboxProviderFlag.value,
+        )!;
+      } else {
         const selected = yield* Effect.promise(() =>
           clack.select({
             message: "Select a sandbox provider:",
@@ -185,10 +277,12 @@ const initCommand = Command.make(
         selectedSandboxProvider = getSandboxProvider(selected as string)!;
       }
 
-      // Resolve backlog manager: interactive select
+      // Resolve backlog manager: CLI flag > interactive select
       const backlogManagers = listBacklogManagers();
       let selectedBacklogManager: BacklogManagerEntry;
-      {
+      if (backlogManagerFlag._tag === "Some") {
+        selectedBacklogManager = getBacklogManager(backlogManagerFlag.value)!;
+      } else {
         const selected = yield* Effect.promise(() =>
           clack.select({
             message: "Select a backlog manager:",
@@ -233,16 +327,21 @@ const initCommand = Command.make(
         selectedTemplate = selected as string;
       }
 
-      // Offer to create the "Sandcastle" label on the repo (skip for non-GitHub backlog managers)
+      // Offer to create the "Sandcastle" label on the repo (skip for non-GitHub backlog managers).
+      // CLI flag --create-label true/false overrides the prompt.
       let shouldCreateLabel: boolean | symbol = false;
       if (selectedBacklogManager.name === "github-issues") {
-        shouldCreateLabel = yield* Effect.promise(() =>
-          clack.confirm({
-            message:
-              'Create a "Sandcastle" GitHub label? (Templates filter issues by this label)',
-            initialValue: true,
-          }),
-        );
+        if (createLabelFlag._tag === "Some") {
+          shouldCreateLabel = createLabelFlag.value === "true";
+        } else {
+          shouldCreateLabel = yield* Effect.promise(() =>
+            clack.confirm({
+              message:
+                'Create a "Sandcastle" GitHub label? (Templates filter issues by this label)',
+              initialValue: true,
+            }),
+          );
+        }
 
         if (shouldCreateLabel === true) {
           yield* Effect.try({
@@ -275,14 +374,19 @@ const initCommand = Command.make(
         ),
       );
 
-      // Prompt user before building image
+      // Prompt user before building image. CLI flag --build-image true/false overrides the prompt.
       const providerLabel = selectedSandboxProvider.label;
-      const shouldBuild = yield* Effect.promise(() =>
-        clack.confirm({
-          message: `Build the default ${providerLabel} image now?`,
-          initialValue: true,
-        }),
-      );
+      let shouldBuild: boolean | symbol;
+      if (buildImageFlag._tag === "Some") {
+        shouldBuild = buildImageFlag.value === "true";
+      } else {
+        shouldBuild = yield* Effect.promise(() =>
+          clack.confirm({
+            message: `Build the default ${providerLabel} image now?`,
+            initialValue: true,
+          }),
+        );
+      }
 
       if (shouldBuild === true) {
         const containerfileDir = join(cwd, CONFIG_DIR);


### PR DESCRIPTION
Closes #510.

`sandcastle init` previously had four prompts with no flag overrides, which made it impossible to run in a non-TTY environment (CI, scripts, container builds). This PR adds an override flag for every remaining prompt so init runs end-to-end with stdin closed.

## New flags

| Flag | Values | Default |
|---|---|---|
| `--sandbox-provider` | `docker`, `podman` | interactive prompt |
| `--backlog-manager` | `github-issues`, `beads` | interactive prompt |
| `--create-label` | `true`, `false` | interactive prompt (default: yes) |
| `--build-image` | `true`, `false` | interactive prompt (default: yes) |

All four flags follow the same `Options.text + optional` pattern as the existing `--template`, `--agent`, and `--model` flags: omit to be prompted, pass a value to skip the prompt.

When all flags are provided, `init` skips every clack prompt and runs to completion. Existing interactive behavior is unchanged when flags are omitted.

## Validation

- `--sandbox-provider` and `--backlog-manager` reject unknown values with an error listing valid choices.
- `--create-label` and `--build-image` reject values other than `true`/`false` with an error listing valid choices.

## Non-interactive example

```bash
sandcastle init \
  --template blank \
  --agent claude-code \
  --sandbox-provider docker \
  --backlog-manager github-issues \
  --create-label true \
  --build-image true
```

Exits 0, scaffolds `.sandcastle/`, no prompts.

## Tests

8 new cases in `src/cli.test.ts`:

- All new flags appear in `init --help`; removed flag names do not
- Invalid `--sandbox-provider` / `--backlog-manager` values error with the available list
- `--create-label` / `--build-image` with a non-boolean value error with `true, false`
- Fully non-interactive happy path with stdin closed → success
- `--sandbox-provider podman` writes a `Containerfile` (no `Dockerfile`)
- `--backlog-manager beads` skips the GitHub label step regardless of label flag

## Verification

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npx vitest run src/cli.test.ts` — 22/22 pass
- [x] Manual non-interactive run with stdin closed exits 0 and scaffolds correctly
- [x] Changeset added (`patch`, per `CLAUDE.md`'s pre-1.0 policy)
- [x] README's `sandcastle init` options table updated