### PR TITLE
Make simple-loop and sequential-reviewer templates backlog-agnostic

### DIFF
--- a/.changeset/backlog-agnostic-templates.md
+++ b/.changeset/backlog-agnostic-templates.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Replace hardcoded "GitHub issues" language in simple-loop and sequential-reviewer templates with backlog-agnostic wording so scaffolded projects read correctly regardless of the chosen backlog manager.

--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ console.log(result.output.score); // typed as number
 | Template                       | Description                                                               |
 | ------------------------------ | ------------------------------------------------------------------------- |
 | `blank`                        | Bare scaffold — write your own prompt and orchestration                   |
-| `simple-loop`                  | Picks GitHub issues one by one and closes them                            |
+| `simple-loop`                  | Picks issues one by one and closes them                                   |
 | `sequential-reviewer`          | Implements issues one by one, with a code review step after each          |
 | `parallel-planner`             | Plans parallelizable issues, executes on separate branches, then merges   |
 | `parallel-planner-with-review` | Plans parallelizable issues, executes with per-branch review, then merges |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ai-hero/sandcastle",
-  "version": "0.4.6",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ai-hero/sandcastle",
-      "version": "0.4.6",
+      "version": "0.5.8",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -1238,7 +1238,8 @@ describe("InitService scaffold", () => {
       );
       expect(prompt).toContain("bd ready --json");
       expect(prompt).toContain("bd close");
-      expect(prompt).not.toContain("gh issue");
+      expect(prompt).not.toContain("gh issue list");
+      expect(prompt).not.toContain("gh issue close");
       expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
       expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
     });
@@ -1301,6 +1302,17 @@ describe("InitService scaffold", () => {
       expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
     });
 
+    it("simple-loop prompt uses backlog-agnostic language", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, { templateName: "simple-loop" });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).not.toContain("GitHub issue");
+    });
+
     // --- sequential-reviewer ---
 
     it("sequential-reviewer with github-issues produces implement-prompt with gh issue commands", async () => {
@@ -1335,9 +1347,21 @@ describe("InitService scaffold", () => {
       );
       expect(prompt).toContain("bd ready --json");
       expect(prompt).toContain("bd close");
-      expect(prompt).not.toContain("gh issue");
+      expect(prompt).not.toContain("gh issue list");
+      expect(prompt).not.toContain("gh issue close");
       expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
       expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+    });
+
+    it("sequential-reviewer implement-prompt uses backlog-agnostic language", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, { templateName: "sequential-reviewer" });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "implement-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).not.toContain("GitHub issue");
     });
 
     // --- blank ---

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -21,7 +21,7 @@ const TEMPLATES: TemplateMetadata[] = [
   },
   {
     name: "simple-loop",
-    description: "Picks GitHub issues one by one and closes them",
+    description: "Picks issues one by one and closes them",
   },
   {
     name: "sequential-reviewer",

--- a/src/templates/sequential-reviewer/implement-prompt.md
+++ b/src/templates/sequential-reviewer/implement-prompt.md
@@ -10,7 +10,7 @@
 
 # Task
 
-You are RALPH — an autonomous coding agent working through GitHub issues one at a time.
+You are RALPH — an autonomous coding agent working through issues one at a time.
 
 ## Priority order
 

--- a/src/templates/sequential-reviewer/main.mts
+++ b/src/templates/sequential-reviewer/main.mts
@@ -1,7 +1,7 @@
 // Sequential Reviewer — implement-then-review loop
 //
 // This template drives a two-phase workflow per issue:
-//   Phase 1 (Implement): A sonnet agent picks an open GitHub issue, works on it
+//   Phase 1 (Implement): A sonnet agent picks an open issue, works on it
 //                        on a dedicated branch, commits the changes, and signals
 //                        completion.
 //   Phase 2 (Review):    A second sonnet agent reviews the branch diff and either
@@ -64,7 +64,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     // -----------------------------------------------------------------------
     // Phase 1: Implement
     //
-    // A sonnet agent picks the next open GitHub issue, writes the
+    // A sonnet agent picks the next open issue, writes the
     // implementation (using RGR: Red → Green → Repeat → Refactor), and
     // commits the result.
     //

--- a/src/templates/simple-loop/main.mts
+++ b/src/templates/simple-loop/main.mts
@@ -1,7 +1,7 @@
 import { run, claudeCode } from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 
-// Simple loop: an agent that picks open GitHub issues one by one and closes them.
+// Simple loop: an agent that picks open issues one by one and closes them.
 // Run this with: npx tsx .sandcastle/main.mts
 // Or add to package.json scripts: "sandcastle": "npx tsx .sandcastle/main.mts"
 

--- a/src/templates/simple-loop/prompt.md
+++ b/src/templates/simple-loop/prompt.md
@@ -10,7 +10,7 @@
 
 # Task
 
-You are RALPH — an autonomous coding agent working through GitHub issues one at a time.
+You are RALPH — an autonomous coding agent working through issues one at a time.
 
 ## Priority order
 

--- a/src/templates/simple-loop/template.json
+++ b/src/templates/simple-loop/template.json
@@ -1,4 +1,4 @@
 {
   "name": "simple-loop",
-  "description": "Picks GitHub issues one by one and closes them"
+  "description": "Picks issues one by one and closes them"
 }


### PR DESCRIPTION
The `simple-loop/prompt.md` and `sequential-reviewer/implement-prompt.md` templates hardcode "working through GitHub issues" in their prose, which is incorrect when users select a different backlog manager (e.g. Beads). Replaces the GitHub-specific language with generic task/issue terminology so the prompts work correctly regardless of backlog manager choice.

Closes #527.