### PR TITLE
Fix implementer in sequential-reviewer committing to main

### DIFF
--- a/.changeset/fix-sequential-reviewer-branch.md
+++ b/.changeset/fix-sequential-reviewer-branch.md
@@ -1,0 +1,9 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+fix: sequential-reviewer template uses createSandbox so implementer and reviewer share a branch
+
+The sequential-reviewer template previously used `merge-to-head` for the implementer, which merged the temp branch into HEAD and deleted it. The reviewer then tried to create a worktree for the host branch (e.g. `main`), which was already checked out — causing a git worktree conflict.
+
+Restructured to use `createSandbox()` with an explicit named branch, so both the implementer and reviewer run in the same sandbox on the same branch. This matches the pattern used by the parallel-planner-with-review template.

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -434,7 +434,7 @@ describe("InitService scaffold", () => {
       expect(mainTs).toContain('"@ai-hero/sandcastle"');
     });
 
-    it("main.mts calls sandcastle.run() twice per iteration (implement + review)", async () => {
+    it("main.mts uses createSandbox so implementer and reviewer share a sandbox", async () => {
       const dir = await makeDir();
       await runScaffold(dir, { templateName: "sequential-reviewer" });
 
@@ -442,14 +442,14 @@ describe("InitService scaffold", () => {
         join(dir, ".sandcastle", "main.mts"),
         "utf-8",
       );
-      expect(mainTs).toContain("sandcastle");
-      const runCallCount = (mainTs.match(/\.run\(/g) ?? []).length;
-      expect(runCallCount).toBeGreaterThanOrEqual(2);
+      expect(mainTs).toContain("createSandbox");
+      expect(mainTs).toContain("sandbox.run");
+      expect(mainTs).toContain("sandbox.close");
       expect(mainTs).toContain("implement-prompt.md");
       expect(mainTs).toContain("review-prompt.md");
     });
 
-    it("main.mts passes branch from implement result to review run", async () => {
+    it("main.mts does not use merge-to-head (incompatible with reviewer handoff)", async () => {
       const dir = await makeDir();
       await runScaffold(dir, { templateName: "sequential-reviewer" });
 
@@ -457,7 +457,18 @@ describe("InitService scaffold", () => {
         join(dir, ".sandcastle", "main.mts"),
         "utf-8",
       );
-      expect(mainTs).toContain("branch");
+      expect(mainTs).not.toContain("merge-to-head");
+    });
+
+    it("main.mts only reviews when implementer produces commits", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, { templateName: "sequential-reviewer" });
+
+      const mainTs = await readFile(
+        join(dir, ".sandcastle", "main.mts"),
+        "utf-8",
+      );
+      expect(mainTs).toContain("implement.commits.length");
     });
 
     it("implement-prompt.md contains issue selection and closure, not prompt argument placeholders", async () => {

--- a/src/templates/sequential-reviewer/main.mts
+++ b/src/templates/sequential-reviewer/main.mts
@@ -7,6 +7,9 @@
 //   Phase 2 (Review):    A second sonnet agent reviews the branch diff and either
 //                        approves it or makes corrections directly on the branch.
 //
+// Both phases share a single sandbox created via createSandbox(), so the
+// implementer and reviewer work on the same explicit branch.
+//
 // The outer loop repeats up to MAX_ITERATIONS times, processing one issue per
 // iteration. This is a middle-complexity option between the simple-loop (no review
 // gate) and the parallel-planner (concurrent execution with a planning phase).
@@ -45,62 +48,64 @@ const copyToWorktree = ["node_modules"];
 for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   console.log(`\n=== Iteration ${iteration}/${MAX_ITERATIONS} ===\n`);
 
-  // -------------------------------------------------------------------------
-  // Phase 1: Implement
-  //
-  // A sonnet agent picks the next open GitHub issue, creates a branch, writes
-  // the implementation (using RGR: Red → Green → Repeat → Refactor), and
-  // commits the result.
-  //
-  // The agent signals completion via <promise>COMPLETE</promise> when done.
-  // The result contains the branch name the agent worked on.
-  // -------------------------------------------------------------------------
-  const implement = await sandcastle.run({
+  // Generate a unique branch name for this iteration.
+  const branch = `sandcastle/sequential-reviewer/${Date.now()}`;
+
+  // Create a single sandbox that both the implementer and reviewer share.
+  // This gives both agents a real, named branch that persists across phases.
+  const sandbox = await sandcastle.createSandbox({
+    branch,
+    sandbox: docker(),
     hooks,
     copyToWorktree,
-    sandbox: docker(),
-    branchStrategy: { type: "merge-to-head" },
-    name: "implementer",
-    maxIterations: 100,
-    agent: sandcastle.claudeCode("claude-sonnet-4-6"),
-    promptFile: "./.sandcastle/implement-prompt.md",
   });
 
-  // Extract the branch the agent worked on so the reviewer can target it.
-  const branch = implement.branch;
+  try {
+    // -----------------------------------------------------------------------
+    // Phase 1: Implement
+    //
+    // A sonnet agent picks the next open GitHub issue, writes the
+    // implementation (using RGR: Red → Green → Repeat → Refactor), and
+    // commits the result.
+    //
+    // The agent signals completion via <promise>COMPLETE</promise> when done.
+    // -----------------------------------------------------------------------
+    const implement = await sandbox.run({
+      name: "implementer",
+      maxIterations: 100,
+      agent: sandcastle.claudeCode("claude-sonnet-4-6"),
+      promptFile: "./.sandcastle/implement-prompt.md",
+    });
 
-  if (!implement.commits.length) {
-    console.log("Implementation agent made no commits. Skipping review.");
-    continue;
+    if (!implement.commits.length) {
+      console.log("Implementation agent made no commits. Skipping review.");
+      continue;
+    }
+
+    console.log(`\nImplementation complete on branch: ${branch}`);
+    console.log(`Commits: ${implement.commits.length}`);
+
+    // -----------------------------------------------------------------------
+    // Phase 2: Review
+    //
+    // A second sonnet agent reviews the diff of the branch produced by
+    // Phase 1. It uses the {{BRANCH}} prompt argument to inspect the right
+    // branch, and either approves or makes corrections directly on the branch.
+    // -----------------------------------------------------------------------
+    await sandbox.run({
+      name: "reviewer",
+      maxIterations: 1,
+      agent: sandcastle.claudeCode("claude-sonnet-4-6"),
+      promptFile: "./.sandcastle/review-prompt.md",
+      promptArgs: {
+        BRANCH: branch,
+      },
+    });
+
+    console.log("\nReview complete.");
+  } finally {
+    await sandbox.close();
   }
-
-  console.log(`\nImplementation complete on branch: ${branch}`);
-  console.log(`Commits: ${implement.commits.length}`);
-
-  // -------------------------------------------------------------------------
-  // Phase 2: Review
-  //
-  // A second sonnet agent reviews the diff of the branch produced by Phase 1.
-  // It uses the {{BRANCH}} prompt argument to inspect the right branch, and
-  // either approves or makes corrections directly on the branch.
-  // -------------------------------------------------------------------------
-  await sandcastle.run({
-    hooks,
-    copyToWorktree,
-    sandbox: docker(),
-    branchStrategy: { type: "branch", branch },
-    name: "reviewer",
-    maxIterations: 1,
-    agent: sandcastle.claudeCode("claude-sonnet-4-6"),
-    promptFile: "./.sandcastle/review-prompt.md",
-    // Prompt arguments substitute {{BRANCH}} in review-prompt.md before the
-    // agent sees the prompt.
-    promptArgs: {
-      BRANCH: branch,
-    },
-  });
-
-  console.log("\nReview complete.");
 }
 
 console.log("\nAll done.");


### PR DESCRIPTION
The sequential-reviewer template's implementer phase uses `branchStrategy: { type: 'merge-to-head' }`, which should create a temporary branch and merge it back. However, users report that commits land directly on main and the subsequent reviewer phase fails because it tries to create a worktree for main (which is already checked out).

Investigates and fixes the branch creation/merge behavior so the implementer reliably works on a dedicated branch that the reviewer can then target.

Closes #514.