### PR TITLE
Fix Windows Docker mount errors with bind-mounted worktrees

### DIFF
--- a/.changeset/fix-windows-docker-mounts.md
+++ b/.changeset/fix-windows-docker-mounts.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix Docker mount failures on Windows hosts by switching from `-v host:sandbox` to `--mount type=bind,source=...,target=...` format (avoiding colon ambiguity with drive letters), and adding missing `patchGitMountsForWindows` calls in `createSandbox` and `createSandboxFromWorktree` code paths.

--- a/src/DockerLifecycle.test.ts
+++ b/src/DockerLifecycle.test.ts
@@ -72,4 +72,79 @@ describe("startContainer", () => {
     const runArgs = runCall![1] as string[];
     expect(runArgs).not.toContain("--network");
   });
+
+  it("uses --mount type=bind format instead of -v for volume mounts", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer("ctr", "img", {}, {
+        volumeMounts: [
+          { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
+        ],
+      }),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    expect(runArgs).not.toContain("-v");
+    expect(runArgs).toContain("--mount");
+    const mountIdx = runArgs.indexOf("--mount");
+    expect(runArgs[mountIdx + 1]).toBe(
+      "type=bind,source=/host/path,target=/sandbox/path",
+    );
+  });
+
+  it("handles Windows-style host paths with colons correctly", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer("ctr", "img", {}, {
+        volumeMounts: [
+          { hostPath: "C:/Users/x/repo", sandboxPath: "/home/agent/workspace" },
+        ],
+      }),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    expect(runArgs).not.toContain("-v");
+    const mountIdx = runArgs.indexOf("--mount");
+    expect(runArgs[mountIdx + 1]).toBe(
+      "type=bind,source=C:/Users/x/repo,target=/home/agent/workspace",
+    );
+  });
+
+  it("includes readonly flag for read-only mounts", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer("ctr", "img", {}, {
+        volumeMounts: [
+          { hostPath: "/host/path", sandboxPath: "/sandbox/path", readonly: true },
+        ],
+      }),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const mountIdx = runArgs.indexOf("--mount");
+    expect(runArgs[mountIdx + 1]).toBe(
+      "type=bind,source=/host/path,target=/sandbox/path,readonly",
+    );
+  });
 });

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -52,8 +52,14 @@ export const buildImage = (
     }
   });
 
+export interface VolumeMount {
+  readonly hostPath: string;
+  readonly sandboxPath: string;
+  readonly readonly?: boolean;
+}
+
 export interface StartContainerOptions {
-  readonly volumeMounts?: readonly string[];
+  readonly volumeMounts?: readonly VolumeMount[];
   readonly workdir?: string;
   /** Run the container as this uid:gid instead of the Dockerfile's USER. */
   readonly user?: string;
@@ -94,10 +100,11 @@ export const startContainer = (
       `${k}=${v}`,
     ]);
 
-    const volumeFlags = (options?.volumeMounts ?? []).flatMap((mount) => [
-      "-v",
-      mount,
-    ]);
+    const volumeFlags = (options?.volumeMounts ?? []).flatMap((mount) => {
+      let flag = `type=bind,source=${mount.hostPath},target=${mount.sandboxPath}`;
+      if (mount.readonly) flag += ",readonly";
+      return ["--mount", flag];
+    });
 
     const workdirFlags = options?.workdir ? ["-w", options.workdir] : [];
     const userFlags = options?.user ? ["--user", options.user] : [];

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -100,11 +100,10 @@ export const startContainer = (
       `${k}=${v}`,
     ]);
 
-    const volumeFlags = (options?.volumeMounts ?? []).flatMap((mount) => {
-      let flag = `type=bind,source=${mount.hostPath},target=${mount.sandboxPath}`;
-      if (mount.readonly) flag += ",readonly";
-      return ["--mount", flag];
-    });
+    const volumeFlags = (options?.volumeMounts ?? []).flatMap((mount) => [
+      "--mount",
+      `type=bind,source=${mount.hostPath},target=${mount.sandboxPath}${mount.readonly ? ",readonly" : ""}`,
+    ]);
 
     const workdirFlags = options?.workdir ? ["-w", options.workdir] : [];
     const userFlags = options?.user ? ["--user", options.user] : [];

--- a/src/createSandbox-windowsMounts.test.ts
+++ b/src/createSandbox-windowsMounts.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests that createSandbox and createSandboxFromWorktree call
+ * patchGitMountsForWindows between resolveGitMounts and startSandbox,
+ * mirroring the SandboxFactory pattern (ADR-0006).
+ */
+import { exec } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const execAsync = promisify(exec);
+
+// Mock patchGitMountsForWindows to track calls
+const mockPatchGitMountsForWindows = vi.fn(
+  async (
+    gitMounts: Array<{ hostPath: string; sandboxPath: string }>,
+    _worktreePath: string,
+    _sandboxRepoDir: string,
+  ) => gitMounts,
+);
+
+vi.mock("./mountUtils.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    patchGitMountsForWindows: (
+      gitMounts: Array<{ hostPath: string; sandboxPath: string }>,
+      worktreePath: string,
+      sandboxRepoDir: string,
+    ) => mockPatchGitMountsForWindows(gitMounts, worktreePath, sandboxRepoDir),
+  };
+});
+
+import { createSandbox, createSandboxFromWorktree } from "./createSandbox.js";
+import { createBindMountSandboxProvider } from "./SandboxProvider.js";
+import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
+
+/** A bind-mount provider that captures mounts without starting a real container */
+const captureMountsProvider = () => {
+  let capturedMounts: Array<{
+    hostPath: string;
+    sandboxPath: string;
+    readonly?: boolean;
+  }> = [];
+  const provider = createBindMountSandboxProvider({
+    name: "capture-mounts",
+    create: async (opts) => {
+      capturedMounts = [...opts.mounts];
+      return {
+        worktreePath: SANDBOX_REPO_DIR,
+        exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+        copyFileIn: async () => {},
+        copyFileOut: async () => {},
+        close: async () => {},
+      };
+    },
+  });
+  return { provider, getCapturedMounts: () => capturedMounts };
+};
+
+const initRepo = async (dir: string) => {
+  await execAsync("git init -b main", { cwd: dir });
+  await execAsync('git config user.email "test@test.com"', { cwd: dir });
+  await execAsync('git config user.name "Test"', { cwd: dir });
+};
+
+const commitFile = async (
+  dir: string,
+  name: string,
+  content: string,
+  message: string,
+) => {
+  await writeFile(join(dir, name), content);
+  await execAsync(`git add "${name}"`, { cwd: dir });
+  await execAsync(`git commit -m "${message}"`, { cwd: dir });
+};
+
+describe("createSandbox Windows mount patching", () => {
+  let hostDir: string;
+
+  afterEach(async () => {
+    mockPatchGitMountsForWindows.mockClear();
+    if (hostDir) {
+      await rm(hostDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it("createSandbox calls patchGitMountsForWindows with worktreePath and SANDBOX_REPO_DIR", async () => {
+    hostDir = await mkdtemp(join(tmpdir(), "wm-test-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "init.txt", "init", "initial commit");
+
+    const { provider } = captureMountsProvider();
+
+    const sandbox = await createSandbox({
+      branch: "test-windows-patch",
+      sandbox: provider,
+      cwd: hostDir,
+    });
+
+    try {
+      expect(mockPatchGitMountsForWindows).toHaveBeenCalledTimes(1);
+      const call = mockPatchGitMountsForWindows.mock.calls[0]!;
+      const gitMounts = call[0];
+      const calledWorktreePath = call[1];
+      const sandboxRepoDir = call[2];
+      // gitMounts should be an array (possibly empty if no parent .git)
+      expect(Array.isArray(gitMounts)).toBe(true);
+      // worktreePath should be the created worktree path
+      expect(calledWorktreePath).toContain(".sandcastle/worktrees");
+      // sandboxRepoDir should be the canonical sandbox dir
+      expect(sandboxRepoDir).toBe(SANDBOX_REPO_DIR);
+    } finally {
+      await sandbox.close();
+    }
+  });
+
+  it("createSandboxFromWorktree calls patchGitMountsForWindows", async () => {
+    hostDir = await mkdtemp(join(tmpdir(), "wm-test-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "init.txt", "init", "initial commit");
+
+    // Create a worktree to pass to createSandboxFromWorktree
+    const worktreePath = join(hostDir, ".sandcastle", "worktrees", "test-wt");
+    await execAsync(`git worktree add "${worktreePath}" -b test-wt-branch`, {
+      cwd: hostDir,
+    });
+
+    const { provider } = captureMountsProvider();
+
+    const sandbox = await createSandboxFromWorktree({
+      branch: "test-wt-branch",
+      worktreePath,
+      hostRepoDir: hostDir,
+      sandbox: provider,
+    });
+
+    try {
+      expect(mockPatchGitMountsForWindows).toHaveBeenCalledTimes(1);
+      const call = mockPatchGitMountsForWindows.mock.calls[0]!;
+      const gitMounts = call[0];
+      const patchWorktreePath = call[1];
+      const sandboxRepoDir = call[2];
+      expect(Array.isArray(gitMounts)).toBe(true);
+      expect(patchWorktreePath).toBe(worktreePath);
+      expect(sandboxRepoDir).toBe(SANDBOX_REPO_DIR);
+    } finally {
+      await sandbox.close();
+    }
+  });
+});

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -49,6 +49,7 @@ import { syncOut } from "./syncOut.js";
 import * as WorktreeManager from "./WorktreeManager.js";
 import { copyToWorktree } from "./CopyToWorktree.js";
 import { resolveCwd } from "./resolveCwd.js";
+import { patchGitMountsForWindows } from "./mountUtils.js";
 
 export interface CreateSandboxOptions {
   /** Explicit branch for the worktree (required). */
@@ -567,6 +568,17 @@ export const createSandboxFromWorktree = async (
       startEffect = resolveGitMounts(join(hostRepoDir, ".git")).pipe(
         Effect.provide(NodeFileSystem.layer),
         Effect.catchAll(() => Effect.succeed([])),
+        // Patch git mounts for Windows worktree compatibility (ADR-0006)
+        Effect.flatMap((gitMounts) =>
+          Effect.tryPromise({
+            try: () =>
+              patchGitMountsForWindows(gitMounts, worktreePath, SANDBOX_REPO_DIR),
+            catch: (e) =>
+              new Error(
+                `Failed to patch git mounts: ${e instanceof Error ? e.message : String(e)}`,
+              ),
+          }),
+        ),
         Effect.flatMap((gitMounts) =>
           startSandbox({
             provider,
@@ -729,6 +741,17 @@ export const createSandbox = async (
       startEffect = resolveGitMounts(join(hostRepoDir, ".git")).pipe(
         Effect.provide(NodeFileSystem.layer),
         Effect.catchAll(() => Effect.succeed([])),
+        // Patch git mounts for Windows worktree compatibility (ADR-0006)
+        Effect.flatMap((gitMounts) =>
+          Effect.tryPromise({
+            try: () =>
+              patchGitMountsForWindows(gitMounts, worktreePath, SANDBOX_REPO_DIR),
+            catch: (e) =>
+              new Error(
+                `Failed to patch git mounts: ${e instanceof Error ? e.message : String(e)}`,
+              ),
+          }),
+        ),
         Effect.flatMap((gitMounts) =>
           startSandbox({
             provider,

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -82,7 +82,7 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
       const volumeMounts = allMounts.map((m) => ({
         hostPath: m.hostPath,
         sandboxPath: m.sandboxPath,
-        ...(m.readonly ? { readonly: true as const } : {}),
+        readonly: m.readonly,
       }));
 
       // Resolve image name

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -77,12 +77,13 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
           (m) => m.hostPath === createOptions.worktreePath,
         )?.sandboxPath ?? "/home/agent/workspace";
 
-      // Build volume mount strings (internal mounts + user-provided mounts)
+      // Build volume mount list (internal mounts + user-provided mounts)
       const allMounts = [...createOptions.mounts, ...userMounts];
-      const volumeMounts = allMounts.map((m) => {
-        const base = `${m.hostPath}:${m.sandboxPath}`;
-        return m.readonly ? `${base}:ro` : base;
-      });
+      const volumeMounts = allMounts.map((m) => ({
+        hostPath: m.hostPath,
+        sandboxPath: m.sandboxPath,
+        ...(m.readonly ? { readonly: true as const } : {}),
+      }));
 
       // Resolve image name
       const imageName =


### PR DESCRIPTION
Fixes two bugs that break sandcastle on Windows hosts with Docker Desktop (WSL2 backend):

**Bug 1 — `-v` volume args misparsed due to drive-letter colon:** `DockerLifecycle.ts` builds volume strings as `-v host:sandbox` which breaks with Windows paths like `C:/Users/...` because Docker sees three colon-separated segments. Switches to `--mount type=bind,source=...,target=...` syntax which is comma-separated and unambiguous.

**Bug 2 — `createSandbox` skips `patchGitMountsForWindows`:** Both `createSandboxFromWorktree` and `createSandbox` in `createSandbox.ts` pipe `resolveGitMounts(...)` straight into `startSandbox` without the Windows path patch step that `SandboxFactory.ts` already applies. Adds the missing `patchGitMountsForWindows` call at both sites.

Closes #550.