### PR TITLE
Add structured output schema support to run()

### DIFF
--- a/.changeset/structured-output-support.md
+++ b/.changeset/structured-output-support.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add structured output support: `Output.object({ tag, schema })` and `Output.string({ tag })` extract typed, validated payloads from agent stdout. Adds `output` option to `RunOptions` with overloaded return type, `StructuredOutputError` for extraction failures, and entry-time validation for `maxIterations === 1` and tag-in-prompt checks.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ const result = await run({
 
   // Idle timeout in seconds — resets whenever the agent produces output. Default: 600 (10 minutes)
   idleTimeoutSeconds: 600,
+
+  // Structured output — extract a typed payload from the agent's stdout.
+  // Requires maxIterations === 1 and the tag must appear in the prompt.
+  // output: Output.object({ tag: "result", schema: z.object({ answer: z.number() }) }),
+  // output: Output.string({ tag: "summary" }),
 });
 
 console.log(result.iterations.length); // number of iterations executed
@@ -590,6 +595,31 @@ await run({
 
 Tell the agent to output your chosen string(s) in the prompt, and the orchestrator will stop when it detects any of them. The matched signal is returned as `result.completionSignal`.
 
+### Structured output
+
+Use `Output.object()` to extract a typed, schema-validated JSON payload from the agent's stdout. The agent emits its answer inside an XML tag you specify, and Sandcastle parses, validates, and returns it on `result.output`. See [ADR 0010](docs/adr/0010-structured-output.md) for design rationale.
+
+```ts
+import { run, Output, claudeCode } from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { z } from "zod";
+
+const result = await run({
+  agent: claudeCode("claude-opus-4-6"),
+  sandbox: docker(),
+  prompt: "Analyze the code and emit your findings inside <result> tags as JSON.",
+  output: Output.object({
+    tag: "result",
+    schema: z.object({ summary: z.string(), score: z.number() }),
+  }),
+});
+
+console.log(result.output.summary); // typed as string
+console.log(result.output.score); // typed as number
+```
+
+`Output.string({ tag })` extracts the tag contents as a plain string (trimmed, no JSON parsing). Both helpers require `maxIterations` to be `1` (the default). The resolved prompt must contain the configured opening tag literal.
+
 ### Templates
 
 `sandcastle init` prompts you to choose a sandbox provider (Docker or Podman), a backlog manager (GitHub Issues or Beads), and a template, which scaffolds a ready-to-use prompt and `main.mts` suited to a specific workflow. If your project's `package.json` has `"type": "module"`, the file will be named `main.ts` instead. Five templates are available:
@@ -684,6 +714,7 @@ Removes the Podman image.
 | `resumeSession`      | string             | —                             | Resume a prior Claude Code session by ID. Incompatible with `maxIterations > 1`. Session file must exist on host.                                               |
 | `signal`             | AbortSignal        | —                             | Cancel the run when aborted. Kills the in-flight agent subprocess and cancels lifecycle hooks; the worktree is preserved on disk. Rejects with `signal.reason`. |
 | `timeouts`           | Timeouts           | —                             | Override default timeouts for built-in lifecycle steps. Currently supports `{ copyToWorktreeMs?: number }` (default: 60 000).                                   |
+| `output`             | OutputDefinition   | —                             | Structured output definition (`Output.object(…)` or `Output.string(…)`). Requires `maxIterations === 1`. See [Structured output](#structured-output).          |
 
 ### `RunResult`
 
@@ -695,6 +726,7 @@ Removes the Podman image.
 | `commits`          | `{ sha }[]`         | Commits created during the run                                     |
 | `branch`           | string              | Target branch name                                                 |
 | `logFilePath`      | string?             | Path to the log file (only when logging to a file)                 |
+| `output`           | T?                  | Typed structured output (only present when `output` option is set) |
 
 ### `IterationResult`
 

--- a/src/Output.ts
+++ b/src/Output.ts
@@ -1,0 +1,114 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+
+// ---------------------------------------------------------------------------
+// Output definition types (branded values for run() overload discrimination)
+// ---------------------------------------------------------------------------
+
+/** Branded output definition for `Output.object({ tag, schema })`. */
+export interface OutputObjectDefinition<T> {
+  readonly _tag: "object";
+  readonly tag: string;
+  readonly schema: StandardSchemaV1<unknown, T>;
+}
+
+/** Branded output definition for `Output.string({ tag })`. */
+export interface OutputStringDefinition {
+  readonly _tag: "string";
+  readonly tag: string;
+}
+
+/** Union of all output definition shapes accepted by `run()`. */
+export type OutputDefinition =
+  | OutputObjectDefinition<any>
+  | OutputStringDefinition;
+
+// ---------------------------------------------------------------------------
+// Output namespace — public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Helpers for declaring structured output on `run()`.
+ *
+ * ```ts
+ * import { Output, run } from "@ai-hero/sandcastle";
+ * import { z } from "zod";
+ *
+ * const result = await run({
+ *   output: Output.object({ tag: "result", schema: z.object({ answer: z.number() }) }),
+ *   // ...
+ * });
+ * console.log(result.output.answer); // typed as number
+ * ```
+ */
+export const Output = {
+  /**
+   * Declare an object-typed structured output extracted from an XML tag in
+   * the agent's stdout. The tag contents are JSON-parsed (with fence-aware
+   * unwrapping) and validated against the provided Standard Schema validator.
+   */
+  object: <Schema extends StandardSchemaV1>(opts: {
+    tag: string;
+    schema: Schema;
+  }): OutputObjectDefinition<StandardSchemaV1.InferOutput<Schema>> => ({
+    _tag: "object",
+    tag: opts.tag,
+    schema: opts.schema as StandardSchemaV1<
+      unknown,
+      StandardSchemaV1.InferOutput<Schema>
+    >,
+  }),
+
+  /**
+   * Declare a string-typed structured output extracted from an XML tag in
+   * the agent's stdout. The tag contents are whitespace-trimmed and returned
+   * as a plain string — no JSON parsing, no schema validation.
+   */
+  string: (opts: { tag: string }): OutputStringDefinition => ({
+    _tag: "string",
+    tag: opts.tag,
+  }),
+} as const;
+
+// ---------------------------------------------------------------------------
+// StructuredOutputError
+// ---------------------------------------------------------------------------
+
+export interface StructuredOutputErrorOptions {
+  readonly tag: string;
+  readonly rawMatched: string | undefined;
+  readonly cause?: unknown;
+  readonly commits: { sha: string }[];
+  readonly branch: string;
+  readonly preservedWorktreePath?: string;
+}
+
+/**
+ * Thrown by `run()` when structured output extraction or validation fails.
+ *
+ * Possible failure modes:
+ * - The configured XML tag was not found in stdout (`rawMatched` is `undefined`).
+ * - The tag contents failed `JSON.parse` (`cause` carries the parse error).
+ * - The parsed JSON failed schema validation (`cause` carries the Standard Schema issues).
+ *
+ * The error carries `commits`, `branch`, and optionally `preservedWorktreePath`
+ * so callers can decide recovery without losing the run's side effects.
+ */
+export class StructuredOutputError extends Error {
+  readonly tag: string;
+  readonly rawMatched: string | undefined;
+  override readonly cause: unknown;
+  readonly commits: { sha: string }[];
+  readonly branch: string;
+  readonly preservedWorktreePath?: string;
+
+  constructor(message: string, options: StructuredOutputErrorOptions) {
+    super(message);
+    this.name = "StructuredOutputError";
+    this.tag = options.tag;
+    this.rawMatched = options.rawMatched;
+    this.cause = options.cause;
+    this.commits = options.commits;
+    this.branch = options.branch;
+    this.preservedWorktreePath = options.preservedWorktreePath;
+  }
+}

--- a/src/extractStructuredOutput.test.ts
+++ b/src/extractStructuredOutput.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from "vitest";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { extractStructuredOutput } from "./extractStructuredOutput.js";
+import { Output, StructuredOutputError } from "./Output.js";
+
+// ---------------------------------------------------------------------------
+// Mock Standard Schema validators
+// ---------------------------------------------------------------------------
+
+/** Create a mock Standard Schema that accepts any value and returns it as-is. */
+const passthrough = (): StandardSchemaV1<unknown, unknown> => ({
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    validate: (value: unknown) => ({ value }),
+  },
+});
+
+/** Create a mock Standard Schema that validates the value is an object with
+ *  the given keys, all of type string. Returns the value typed as T. */
+const mockObjectSchema = <T>(): StandardSchemaV1<unknown, T> => ({
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    validate: (value: unknown) => {
+      if (typeof value !== "object" || value === null) {
+        return {
+          issues: [{ message: "Expected an object" }],
+        };
+      }
+      return { value: value as T };
+    },
+  },
+});
+
+/** Create a mock Standard Schema that always fails validation. */
+const alwaysFail = (
+  msg = "validation failed",
+): StandardSchemaV1<unknown, never> => ({
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    validate: () => ({
+      issues: [{ message: msg }],
+    }),
+  },
+});
+
+const baseContext = {
+  commits: [{ sha: "abc123" }],
+  branch: "test-branch",
+};
+
+// ---------------------------------------------------------------------------
+// Output.object extraction
+// ---------------------------------------------------------------------------
+
+describe("extractStructuredOutput — Output.object", () => {
+  it("extracts and parses valid JSON from a single tag occurrence", async () => {
+    const stdout = 'Some output\n<result>{"answer": 42}</result>\nDone.';
+    const def = Output.object({ tag: "result", schema: passthrough() });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toEqual({ answer: 42 });
+  });
+
+  it("uses last occurrence when tag appears multiple times", async () => {
+    const stdout = [
+      '<result>{"answer": 1}</result>',
+      "Agent self-correcting...",
+      '<result>{"answer": 2}</result>',
+    ].join("\n");
+    const def = Output.object({ tag: "result", schema: passthrough() });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toEqual({ answer: 2 });
+  });
+
+  it("unwraps ```json fence inside tag", async () => {
+    const stdout = [
+      "<result>",
+      "```json",
+      '{"name": "test"}',
+      "```",
+      "</result>",
+    ].join("\n");
+    const def = Output.object({ tag: "result", schema: passthrough() });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toEqual({ name: "test" });
+  });
+
+  it("unwraps bare ``` fence (no language hint) inside tag", async () => {
+    const stdout = [
+      "<result>",
+      "```",
+      '{"name": "test"}',
+      "```",
+      "</result>",
+    ].join("\n");
+    const def = Output.object({ tag: "result", schema: passthrough() });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toEqual({ name: "test" });
+  });
+
+  it("handles JSON without any fence wrapping", async () => {
+    const stdout = '<data>{"x": 1}</data>';
+    const def = Output.object({ tag: "data", schema: passthrough() });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toEqual({ x: 1 });
+  });
+
+  it("throws StructuredOutputError with rawMatched=undefined when tag is missing", async () => {
+    const stdout = "No structured output here.";
+    const def = Output.object({ tag: "result", schema: passthrough() });
+    try {
+      await extractStructuredOutput(stdout, def, baseContext);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(StructuredOutputError);
+      const soe = err as StructuredOutputError;
+      expect(soe.tag).toBe("result");
+      expect(soe.rawMatched).toBeUndefined();
+      expect(soe.commits).toEqual(baseContext.commits);
+      expect(soe.branch).toBe(baseContext.branch);
+      expect(soe.message).toContain("<result>");
+    }
+  });
+
+  it("throws StructuredOutputError with rawMatched set on invalid JSON", async () => {
+    const stdout = "<result>not valid json</result>";
+    const def = Output.object({ tag: "result", schema: passthrough() });
+    try {
+      await extractStructuredOutput(stdout, def, baseContext);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(StructuredOutputError);
+      const soe = err as StructuredOutputError;
+      expect(soe.tag).toBe("result");
+      expect(soe.rawMatched).toBe("not valid json");
+      expect(soe.cause).toBeInstanceOf(SyntaxError);
+      expect(soe.message).toContain("invalid JSON");
+    }
+  });
+
+  it("throws StructuredOutputError with cause on schema validation failure", async () => {
+    const stdout = '<result>{"answer": 42}</result>';
+    const def = Output.object({ tag: "result", schema: alwaysFail("bad") });
+    try {
+      await extractStructuredOutput(stdout, def, baseContext);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(StructuredOutputError);
+      const soe = err as StructuredOutputError;
+      expect(soe.tag).toBe("result");
+      expect(soe.rawMatched).toBeDefined();
+      expect(soe.cause).toEqual([{ message: "bad" }]);
+      expect(soe.message).toContain("schema validation");
+    }
+  });
+
+  it("validates parsed JSON against the schema", async () => {
+    const stdout = '<result>"not an object"</result>';
+    const schema = mockObjectSchema<{ name: string }>();
+    const def = Output.object({ tag: "result", schema });
+    try {
+      await extractStructuredOutput(stdout, def, baseContext);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(StructuredOutputError);
+      const soe = err as StructuredOutputError;
+      expect(soe.cause).toEqual([{ message: "Expected an object" }]);
+    }
+  });
+
+  it("passes preservedWorktreePath through to the error", async () => {
+    const stdout = "no tag";
+    const def = Output.object({ tag: "result", schema: passthrough() });
+    try {
+      await extractStructuredOutput(stdout, def, {
+        ...baseContext,
+        preservedWorktreePath: "/tmp/worktree",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const soe = err as StructuredOutputError;
+      expect(soe.preservedWorktreePath).toBe("/tmp/worktree");
+    }
+  });
+
+  it("handles whitespace around JSON inside tags", async () => {
+    const stdout = "<result>  \n  {\"a\": 1}  \n  </result>";
+    const def = Output.object({ tag: "result", schema: passthrough() });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toEqual({ a: 1 });
+  });
+
+  it("handles nested objects in JSON", async () => {
+    const stdout =
+      '<result>{"nested": {"deep": true}, "list": [1, 2, 3]}</result>';
+    const def = Output.object({ tag: "result", schema: passthrough() });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toEqual({ nested: { deep: true }, list: [1, 2, 3] });
+  });
+
+  it("works with async schema validation", async () => {
+    const asyncSchema: StandardSchemaV1<unknown, { x: number }> = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: async (value: unknown) => ({
+          value: value as { x: number },
+        }),
+      },
+    };
+    const stdout = '<result>{"x": 99}</result>';
+    const def = Output.object({ tag: "result", schema: asyncSchema });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toEqual({ x: 99 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Output.string extraction
+// ---------------------------------------------------------------------------
+
+describe("extractStructuredOutput — Output.string", () => {
+  it("extracts and trims string content from tag", async () => {
+    const stdout = "output\n<summary>  Hello, world!  </summary>\nend";
+    const def = Output.string({ tag: "summary" });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toBe("Hello, world!");
+  });
+
+  it("uses last occurrence for string tags", async () => {
+    const stdout = "<note>first</note>\n<note>second</note>";
+    const def = Output.string({ tag: "note" });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toBe("second");
+  });
+
+  it("throws StructuredOutputError when string tag is missing", async () => {
+    const stdout = "no tags here";
+    const def = Output.string({ tag: "summary" });
+    try {
+      await extractStructuredOutput(stdout, def, baseContext);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(StructuredOutputError);
+      const soe = err as StructuredOutputError;
+      expect(soe.tag).toBe("summary");
+      expect(soe.rawMatched).toBeUndefined();
+    }
+  });
+
+  it("preserves multiline string content (after trim)", async () => {
+    const stdout = "<notes>\n  line 1\n  line 2\n</notes>";
+    const def = Output.string({ tag: "notes" });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toBe("line 1\n  line 2");
+  });
+
+  it("does not JSON-parse string content", async () => {
+    const stdout = '<data>{"this": "is not parsed"}</data>';
+    const def = Output.string({ tag: "data" });
+    const value = await extractStructuredOutput(stdout, def, baseContext);
+    expect(value).toBe('{"this": "is not parsed"}');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StructuredOutputError
+// ---------------------------------------------------------------------------
+
+describe("StructuredOutputError", () => {
+  it("is an instance of Error", () => {
+    const err = new StructuredOutputError("test", {
+      tag: "t",
+      rawMatched: undefined,
+      commits: [],
+      branch: "main",
+    });
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("has name StructuredOutputError", () => {
+    const err = new StructuredOutputError("test", {
+      tag: "t",
+      rawMatched: undefined,
+      commits: [],
+      branch: "main",
+    });
+    expect(err.name).toBe("StructuredOutputError");
+  });
+
+  it("carries all fields from options", () => {
+    const err = new StructuredOutputError("msg", {
+      tag: "result",
+      rawMatched: "raw text",
+      cause: new SyntaxError("bad json"),
+      commits: [{ sha: "abc" }],
+      branch: "my-branch",
+      preservedWorktreePath: "/tmp/wt",
+    });
+    expect(err.tag).toBe("result");
+    expect(err.rawMatched).toBe("raw text");
+    expect(err.cause).toBeInstanceOf(SyntaxError);
+    expect(err.commits).toEqual([{ sha: "abc" }]);
+    expect(err.branch).toBe("my-branch");
+    expect(err.preservedWorktreePath).toBe("/tmp/wt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Output helpers — type-level tests
+// ---------------------------------------------------------------------------
+
+describe("Output namespace", () => {
+  it("Output.object returns a definition with _tag 'object'", () => {
+    const def = Output.object({ tag: "result", schema: passthrough() });
+    expect(def._tag).toBe("object");
+    expect(def.tag).toBe("result");
+    expect(def.schema).toBeDefined();
+  });
+
+  it("Output.string returns a definition with _tag 'string'", () => {
+    const def = Output.string({ tag: "summary" });
+    expect(def._tag).toBe("string");
+    expect(def.tag).toBe("summary");
+  });
+});

--- a/src/extractStructuredOutput.ts
+++ b/src/extractStructuredOutput.ts
@@ -1,4 +1,3 @@
-import type { StandardSchemaV1 } from "@standard-schema/spec";
 import {
   StructuredOutputError,
   type OutputDefinition,

--- a/src/extractStructuredOutput.ts
+++ b/src/extractStructuredOutput.ts
@@ -1,0 +1,160 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import {
+  StructuredOutputError,
+  type OutputDefinition,
+  type OutputObjectDefinition,
+  type OutputStringDefinition,
+} from "./Output.js";
+
+interface ExtractionContext {
+  readonly commits: { sha: string }[];
+  readonly branch: string;
+  readonly preservedWorktreePath?: string;
+}
+
+/**
+ * Extract and validate structured output from the agent's stdout.
+ *
+ * - Finds the **last** occurrence of `<tag>...</tag>` in stdout.
+ * - For `Output.object`: unwraps optional Markdown fences, JSON-parses,
+ *   and validates against the Standard Schema.
+ * - For `Output.string`: trims whitespace only.
+ *
+ * Throws `StructuredOutputError` on missing tag, invalid JSON, or schema failure.
+ */
+export const extractStructuredOutput = async <T>(
+  stdout: string,
+  definition: OutputDefinition,
+  context: ExtractionContext,
+): Promise<T> => {
+  if (definition._tag === "object") {
+    return extractObject(
+      stdout,
+      definition as OutputObjectDefinition<T>,
+      context,
+    );
+  }
+  return extractString(stdout, definition, context) as T;
+};
+
+// ---------------------------------------------------------------------------
+// Object extraction
+// ---------------------------------------------------------------------------
+
+const extractObject = async <T>(
+  stdout: string,
+  definition: OutputObjectDefinition<T>,
+  context: ExtractionContext,
+): Promise<T> => {
+  const raw = findLastTagContent(stdout, definition.tag);
+
+  if (raw === undefined) {
+    throw new StructuredOutputError(
+      `Structured output tag <${definition.tag}> not found in agent output`,
+      { tag: definition.tag, rawMatched: undefined, ...context },
+    );
+  }
+
+  // Fence-aware unwrap + JSON parse
+  const unwrapped = unwrapFences(raw.trim());
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(unwrapped);
+  } catch (cause) {
+    throw new StructuredOutputError(
+      `Structured output tag <${definition.tag}> contains invalid JSON`,
+      { tag: definition.tag, rawMatched: raw, cause, ...context },
+    );
+  }
+
+  // Standard Schema validation
+  const result = await definition.schema["~standard"].validate(parsed);
+
+  if (result.issues) {
+    throw new StructuredOutputError(
+      `Structured output tag <${definition.tag}> failed schema validation`,
+      { tag: definition.tag, rawMatched: raw, cause: result.issues, ...context },
+    );
+  }
+
+  return result.value;
+};
+
+// ---------------------------------------------------------------------------
+// String extraction
+// ---------------------------------------------------------------------------
+
+const extractString = (
+  stdout: string,
+  definition: OutputStringDefinition,
+  context: ExtractionContext,
+): string => {
+  const raw = findLastTagContent(stdout, definition.tag);
+
+  if (raw === undefined) {
+    throw new StructuredOutputError(
+      `Structured output tag <${definition.tag}> not found in agent output`,
+      { tag: definition.tag, rawMatched: undefined, ...context },
+    );
+  }
+
+  return raw.trim();
+};
+
+// ---------------------------------------------------------------------------
+// Tag extraction — last match wins
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the content between the **last** `<tag>` and `</tag>` pair in text.
+ * Returns `undefined` if the tag is not found.
+ */
+const findLastTagContent = (
+  text: string,
+  tag: string,
+): string | undefined => {
+  const openTag = `<${tag}>`;
+  const closeTag = `</${tag}>`;
+
+  let lastContent: string | undefined;
+  let searchFrom = 0;
+
+  while (true) {
+    const openIdx = text.indexOf(openTag, searchFrom);
+    if (openIdx === -1) break;
+
+    const contentStart = openIdx + openTag.length;
+    const closeIdx = text.indexOf(closeTag, contentStart);
+    if (closeIdx === -1) break;
+
+    lastContent = text.slice(contentStart, closeIdx);
+    searchFrom = closeIdx + closeTag.length;
+  }
+
+  return lastContent;
+};
+
+// ---------------------------------------------------------------------------
+// Fence-aware unwrap (object mode only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip an optional Markdown code fence from text.
+ *
+ * Recognises:
+ * - ` ```json\n...\n``` `
+ * - ` ```\n...\n``` `
+ *
+ * If no fence is detected, returns the input unchanged (already trimmed by caller).
+ */
+const unwrapFences = (text: string): string => {
+  // Match ```json ... ``` or ``` ... ``` (with optional language hint)
+  const fenceMatch = text.match(
+    /^```(?:json)?\s*\n([\s\S]*?)\n\s*```\s*$/,
+  );
+  if (fenceMatch) {
+    return fenceMatch[1]!.trim();
+  }
+  return text;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,12 @@ export {
 } from "./SessionPaths.js";
 export type { SandboxHooks } from "./SandboxLifecycle.js";
 export type { MountConfig } from "./MountConfig.js";
+export { Output, StructuredOutputError } from "./Output.js";
+export type {
+  OutputDefinition,
+  OutputObjectDefinition,
+  OutputStringDefinition,
+} from "./Output.js";
 export { CwdError } from "./resolveCwd.js";
 export { claudeCode, codex, opencode, pi } from "./AgentProvider.js";
 export type {

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -16,6 +16,9 @@ import {
   type RunResult,
 } from "./run.js";
 import { claudeCode } from "./AgentProvider.js";
+import { Output, StructuredOutputError } from "./Output.js";
+import type { InteractiveOptions } from "./interactive.js";
+import type { WorktreeInteractiveOptions } from "./createWorktree.js";
 import { defaultImageName } from "./sandboxes/docker.js";
 import * as sandcastle from "./SandboxProvider.js";
 import { createBindMountSandboxProvider } from "./SandboxProvider.js";
@@ -909,5 +912,140 @@ describe("buildContextWindowLines", () => {
   it("returns empty array for empty iterations list", () => {
     const lines = buildContextWindowLines([]);
     expect(lines).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structured output validation
+// ---------------------------------------------------------------------------
+
+const mockSchema = () => ({
+  "~standard": {
+    version: 1 as const,
+    vendor: "test",
+    validate: (value: unknown) => ({ value }),
+  },
+});
+
+describe("structured output entry-time validation", () => {
+  it("throws when output is set with maxIterations !== 1", async () => {
+    await expect(
+      run({
+        agent: claudeCode("claude-opus-4-6"),
+        sandbox: testSandbox,
+        prompt: "emit <result>...</result>",
+        branchStrategy: { type: "head" },
+        output: Output.object({ tag: "result", schema: mockSchema() }),
+        maxIterations: 2,
+      }),
+    ).rejects.toThrow("output requires maxIterations to be 1");
+  });
+
+  it("allows output with maxIterations = 1 (default)", async () => {
+    // Should pass maxIterations check and fail later for a different reason
+    await expect(
+      run({
+        agent: claudeCode("claude-opus-4-6"),
+        sandbox: testSandbox,
+        prompt: "emit <result>...</result>",
+        branchStrategy: { type: "head" },
+        output: Output.object({ tag: "result", schema: mockSchema() }),
+      }),
+    ).rejects.not.toThrow("output requires maxIterations to be 1");
+  });
+
+  it("throws when output tag is not in the resolved prompt", async () => {
+    await expect(
+      run({
+        agent: claudeCode("claude-opus-4-6"),
+        sandbox: testSandbox,
+        prompt: "do some work",
+        branchStrategy: { type: "head" },
+        output: Output.object({ tag: "result", schema: mockSchema() }),
+      }),
+    ).rejects.toThrow("output tag <result> not found in the resolved prompt");
+  });
+
+  it("passes tag check when the tag appears in the prompt", async () => {
+    // Should pass the entry-time tag check and fail later for a different reason
+    // (the mock sandbox produces empty stdout, so extraction fails — but not the prompt check)
+    await expect(
+      run({
+        agent: claudeCode("claude-opus-4-6"),
+        sandbox: testSandbox,
+        prompt: "emit your answer inside <result> tags",
+        branchStrategy: { type: "head" },
+        output: Output.object({ tag: "result", schema: mockSchema() }),
+      }),
+    ).rejects.not.toThrow("not found in the resolved prompt");
+  });
+
+  it("validates tag presence for Output.string as well", async () => {
+    await expect(
+      run({
+        agent: claudeCode("claude-opus-4-6"),
+        sandbox: testSandbox,
+        prompt: "do some work",
+        branchStrategy: { type: "head" },
+        output: Output.string({ tag: "summary" }),
+      }),
+    ).rejects.toThrow("output tag <summary> not found in the resolved prompt");
+  });
+
+  it("validates tag presence with promptFile", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sandcastle-output-"));
+    const promptFile = join(dir, "prompt.md");
+    writeFileSync(promptFile, "do some work without the tag");
+
+    await expect(
+      run({
+        agent: claudeCode("claude-opus-4-6"),
+        sandbox: testSandbox,
+        promptFile,
+        branchStrategy: { type: "head" },
+        output: Output.object({ tag: "answer", schema: mockSchema() }),
+      }),
+    ).rejects.toThrow("output tag <answer> not found in the resolved prompt");
+  });
+});
+
+describe("RunOptions with output", () => {
+  it("allows output field on RunOptions", () => {
+    const opts: RunOptions = {
+      agent: claudeCode("claude-opus-4-6"),
+      sandbox: testSandbox,
+      prompt: "emit <result>...</result>",
+      output: Output.object({ tag: "result", schema: mockSchema() }),
+    };
+    expect(opts.output).toBeDefined();
+  });
+
+  it("allows output to be omitted", () => {
+    const opts: RunOptions = {
+      agent: claudeCode("claude-opus-4-6"),
+      sandbox: testSandbox,
+      prompt: "test",
+    };
+    expect(opts.output).toBeUndefined();
+  });
+});
+
+describe("output type-level exclusion", () => {
+  it("InteractiveOptions does not accept output", () => {
+    const opts: InteractiveOptions = {
+      agent: claudeCode("claude-opus-4-6"),
+      prompt: "test",
+    };
+    // @ts-expect-error output is not a field on InteractiveOptions
+    expect(opts.output).toBeUndefined();
+  });
+
+  it("WorktreeInteractiveOptions does not accept output", () => {
+    const opts: WorktreeInteractiveOptions = {
+      agent: claudeCode("claude-opus-4-6"),
+      prompt: "test",
+    };
+    // @ts-expect-error output is not a field on WorktreeInteractiveOptions
+    expect(opts.output).toBeUndefined();
   });
 });

--- a/src/run.ts
+++ b/src/run.ts
@@ -43,6 +43,12 @@ import {
   validateNoBuiltInArgOverride,
   BUILT_IN_PROMPT_ARG_KEYS,
 } from "./PromptArgumentSubstitution.js";
+import type {
+  OutputDefinition,
+  OutputObjectDefinition,
+  OutputStringDefinition,
+} from "./Output.js";
+import { extractStructuredOutput } from "./extractStructuredOutput.js";
 
 /** Default maximum number of iterations for a run. */
 export const DEFAULT_MAX_ITERATIONS = 1;
@@ -258,6 +264,21 @@ export interface RunOptions {
   readonly signal?: AbortSignal;
   /** Override default timeouts for built-in lifecycle steps. Unset keys keep their defaults. */
   readonly timeouts?: Timeouts;
+  /**
+   * Structured output definition. When provided, the agent's stdout is
+   * scanned for the configured XML tag after the iteration completes, and the
+   * result is parsed/validated and returned on `RunResult.output`.
+   *
+   * Use `Output.object({ tag, schema })` for JSON+schema or
+   * `Output.string({ tag })` for raw string extraction.
+   *
+   * Constraints:
+   * - `maxIterations` must be `1` (the default).
+   * - The resolved prompt must contain the configured opening tag literal.
+   *
+   * See ADR 0010 for design rationale.
+   */
+  readonly output?: OutputDefinition;
 }
 
 export type { IterationResult, IterationUsage } from "./Orchestrator.js";
@@ -279,7 +300,17 @@ export interface RunResult {
   readonly preservedWorktreePath?: string;
 }
 
-export const run = async (options: RunOptions): Promise<RunResult> => {
+/** Overload: with `Output.object`, returns `RunResult` with typed `output: T`. */
+export function run<T>(
+  options: RunOptions & { output: OutputObjectDefinition<T> },
+): Promise<RunResult & { output: T }>;
+/** Overload: with `Output.string`, returns `RunResult` with `output: string`. */
+export function run(
+  options: RunOptions & { output: OutputStringDefinition },
+): Promise<RunResult & { output: string }>;
+/** Overload: without `output`, returns the standard `RunResult`. */
+export function run(options: RunOptions): Promise<RunResult>;
+export async function run(options: RunOptions): Promise<RunResult & { output?: unknown }> {
   // If signal is already aborted, reject immediately without any setup
   options.signal?.throwIfAborted();
 
@@ -326,6 +357,14 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
     );
   }
 
+  // Validate: output requires maxIterations === 1
+  if (options.output && maxIterations !== 1) {
+    throw new Error(
+      "output requires maxIterations to be 1. " +
+        "Structured output is only supported for single-iteration runs.",
+    );
+  }
+
   // Extract explicit branch when in branch mode
   const branch: string | undefined =
     branchStrategy.type === "branch" ? branchStrategy.branch : undefined;
@@ -353,6 +392,17 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
   );
   const rawPrompt = resolved.text;
   const isInlinePrompt = resolved.source === "inline";
+
+  // Validate: output tag must appear in the resolved prompt
+  if (options.output) {
+    const openTag = `<${options.output.tag}>`;
+    if (!rawPrompt.includes(openTag)) {
+      throw new Error(
+        `output tag <${options.output.tag}> not found in the resolved prompt. ` +
+          "The caller must instruct the agent to emit the configured tag.",
+      );
+    }
+  }
 
   const agentName = provider.name;
 
@@ -538,9 +588,25 @@ export const run = async (options: RunOptions): Promise<RunResult> => {
     throw error;
   }
 
-  return {
+  const baseResult = {
     ...result,
     logFilePath:
       resolvedLogging.type === "file" ? resolvedLogging.path : undefined,
   };
-};
+
+  // Extract structured output after the iteration completes (separate pass from completion signal)
+  if (options.output) {
+    const output = await extractStructuredOutput(
+      baseResult.stdout,
+      options.output,
+      {
+        commits: baseResult.commits,
+        branch: baseResult.branch,
+        preservedWorktreePath: baseResult.preservedWorktreePath,
+      },
+    );
+    return { ...baseResult, output };
+  }
+
+  return baseResult;
+}


### PR DESCRIPTION
Adds first-class structured output support per ADR-0010. Introduces an `Output.object({ tag, schema })` helper and an optional `output` field on `RunOptions`. When provided, sandcastle scans the agent's stdout for the configured XML tag, extracts the JSON payload, validates it against the Standard Schema, and returns a typed `output: T` on `RunResult`.

Constraints: `maxIterations === 1` only (throws otherwise), caller owns the prompt instruction (throws if tag is absent from resolved prompt), last match wins, fence-aware extraction. Missing tag / invalid JSON / validation failure throws `StructuredOutputError` with diagnostic fields.

Closes #517.