### PR TITLE
Docker UID alignment via build-arg + pre-flight diagnostic

### DIFF
--- a/.changeset/docker-uid-alignment.md
+++ b/.changeset/docker-uid-alignment.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": patch
 ---
 
-Add Docker UID alignment via build-arg and pre-flight diagnostic. Dockerfile templates now accept `AGENT_UID`/`AGENT_GID` build-args (default 1000) and `sandcastle docker build-image` defaults them to the host UID/GID. The Docker provider gains `containerUid`/`containerGid` options and a pre-flight `docker image inspect` check that catches UID mismatches before container start. See ADR-0014.
+Add Docker UID alignment via build-arg and pre-flight diagnostic. Dockerfile templates now accept `AGENT_UID`/`AGENT_GID` build-args (default 1000) and `sandcastle docker build-image` defaults them to the host UID/GID. The Docker provider gains `containerUid`/`containerGid` options and a pre-flight `docker image inspect` check that catches UID mismatches before container start. Templates also pre-create the standard agent config dirs (`.codex`, `.claude`, `.gemini`, `.config`) so single-file bind mounts under those dirs avoid the root-owned-parent EACCES bug. See ADR-0014.

--- a/.changeset/docker-uid-alignment.md
+++ b/.changeset/docker-uid-alignment.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": patch
 ---
 
-Add Docker UID alignment via build-arg and pre-flight diagnostic. Dockerfile templates now accept `AGENT_UID`/`AGENT_GID` build-args (default 1000) and `sandcastle docker build-image` defaults them to the host UID/GID. The Docker provider gains `containerUid`/`containerGid` options and a pre-flight `docker image inspect` check that catches UID mismatches before container start. Templates also pre-create the standard agent config dirs (`.codex`, `.claude`, `.gemini`, `.config`) so single-file bind mounts under those dirs avoid the root-owned-parent EACCES bug. See ADR-0014.
+Add Docker UID alignment via build-arg and pre-flight diagnostic. Dockerfile templates now accept `AGENT_UID`/`AGENT_GID` build-args (default 1000) and `sandcastle docker build-image` defaults them to the host UID/GID. The Docker provider gains `containerUid`/`containerGid` options and a pre-flight `docker image inspect` check that catches UID mismatches before container start. See ADR-0014.

--- a/.changeset/docker-uid-alignment.md
+++ b/.changeset/docker-uid-alignment.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add Docker UID alignment via build-arg and pre-flight diagnostic. Dockerfile templates now accept `AGENT_UID`/`AGENT_GID` build-args (default 1000) and `sandcastle docker build-image` defaults them to the host UID/GID. The Docker provider gains `containerUid`/`containerGid` options and a pre-flight `docker image inspect` check that catches UID mismatches before container start. See ADR-0014.

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -15,11 +15,15 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
   && apt-get update && apt-get install -y gh \
   && rm -rf /var/lib/apt/lists/*
 
-# Rename the base image's "node" user (UID 1000) to "agent".
-# This keeps UID 1000 so that --userns=keep-id (Podman) and
-# --user 1000:1000 (Docker) map to the correct home directory owner.
-RUN usermod -d /home/agent -m -l agent node
-USER agent
+# Build-args for UID/GID alignment: sandcastle docker build-image
+# defaults these to the host user's UID/GID so image-built files
+# and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+# Rename the base image's "node" user to "agent" and align UID/GID.
+RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+USER ${AGENT_UID}:${AGENT_GID}
 
 # Install Claude Code CLI
 RUN curl -fsSL https://claude.ai/install.sh | bash

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -25,6 +25,11 @@ ARG AGENT_GID=1000
 RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 USER ${AGENT_UID}:${AGENT_GID}
 
+# Pre-create standard agent config directories so single-file bind mounts
+# (e.g. ~/.codex/auth.json) land in dirs owned by the agent user. Without
+# this, Docker auto-creates the parent dir as root and the agent gets EACCES.
+RUN mkdir -p /home/agent/.codex /home/agent/.claude /home/agent/.gemini /home/agent/.config
+
 # Install Claude Code CLI
 RUN curl -fsSL https://claude.ai/install.sh | bash
 

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -25,11 +25,6 @@ ARG AGENT_GID=1000
 RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 USER ${AGENT_UID}:${AGENT_GID}
 
-# Pre-create standard agent config directories so single-file bind mounts
-# (e.g. ~/.codex/auth.json) land in dirs owned by the agent user. Without
-# this, Docker auto-creates the parent dir as root and the agent gets EACCES.
-RUN mkdir -p /home/agent/.codex /home/agent/.claude /home/agent/.gemini /home/agent/.config
-
 # Install Claude Code CLI
 RUN curl -fsSL https://claude.ai/install.sh | bash
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ const result = await run({
   // Provider-specific config (like imageName, mounts) lives inside the provider factory call.
   sandbox: docker({
     imageName: "sandcastle:local",
+    // Optional: override the UID/GID used for --user flag (defaults to host UID/GID).
+    // Must match the UID baked into the image. Pre-flight check catches mismatches.
+    // containerUid: 1000,
+    // containerGid: 1000,
     // Optional: mount host directories into the sandbox (e.g. package manager caches)
     // hostPath supports absolute, tilde-expanded (~), and relative paths (resolved from cwd).
     // sandboxPath supports absolute and relative paths (resolved from the sandbox repo directory).
@@ -664,7 +668,7 @@ Errors if `.sandcastle/` already exists to prevent overwriting customizations.
 
 ### `sandcastle docker build-image`
 
-Rebuilds the Docker image from an existing `.sandcastle/` directory. Use this after modifying the Dockerfile.
+Rebuilds the Docker image from an existing `.sandcastle/` directory. Use this after modifying the Dockerfile. On Linux/macOS, the build automatically passes `--build-arg AGENT_UID=$(id -u)` and `AGENT_GID=$(id -g)` so the image's `agent` user matches the host UID — this prevents permission errors on image-built files without runtime chown.
 
 | Option         | Required | Default                      | Description                                                                       |
 | -------------- | -------- | ---------------------------- | --------------------------------------------------------------------------------- |

--- a/docs/adr/0014-docker-uid-alignment-via-build-arg.md
+++ b/docs/adr/0014-docker-uid-alignment-via-build-arg.md
@@ -1,0 +1,57 @@
+# Docker UID alignment via build-arg + pre-flight diagnostic
+
+Docker users on Linux with a non-1000 host UID hit `EACCES` on image-built files (`/home/agent`, Claude CLI binaries) because the Dockerfile hardcoded UID 1000. ADR-0005 reserved a build-time UID injection escape hatch — this ADR implements it.
+
+## Decision
+
+Align the image UID to the host UID at **build time** using Dockerfile `ARG` directives, matching ADR-0013's principle of build-time over runtime configuration.
+
+### Build-time: Dockerfile templates gain `AGENT_UID` / `AGENT_GID` ARGs
+
+All four agent Dockerfile templates (`CLAUDE_CODE_DOCKERFILE`, `PI_DOCKERFILE`, `CODEX_DOCKERFILE`, `OPENCODE_DOCKERFILE`) now declare:
+
+```dockerfile
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+```
+
+The existing `usermod -d /home/agent -m -l agent node` is replaced with:
+
+```dockerfile
+RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+USER ${AGENT_UID}:${AGENT_GID}
+```
+
+The `USER` directive is now numeric (`${AGENT_UID}:${AGENT_GID}`) instead of `USER agent`, so that `docker image inspect --format '{{.Config.User}}'` returns a parseable `UID:GID` for the pre-flight check.
+
+### Build-time: `sandcastle docker build-image` defaults build-args to host UID/GID
+
+`buildImage()` accepts a new `buildArgs: Record<string, string>` option. The CLI command defaults `AGENT_UID` to `process.getuid()` and `AGENT_GID` to `process.getgid()` on Linux/macOS. On Windows (where `getuid()` is unavailable), the ARGs keep their Dockerfile default of 1000.
+
+### Runtime: Docker provider gains `containerUid` / `containerGid`
+
+Mirrors the Podman provider's existing surface. Defaults to the host UID/GID (`process.getuid()` / `process.getgid()`, falling back to 1000). Used as the `--user` flag value and as the expected UID in the pre-flight check. Allows callers with hand-rolled images to declare the image's baked-in UID without rebuilding.
+
+### Runtime: pre-flight `docker image inspect` diagnostic
+
+Before `docker run`, the Docker provider calls `docker image inspect <img> --format '{{.Config.User}}'` and parses the numeric UID. If it doesn't match the effective UID (host UID or explicit `containerUid`), the provider throws a clear error naming both remedies:
+
+1. Rebuild with `sandcastle docker build-image`
+2. Pass `containerUid: <image-uid>` to `docker()` to match the image
+
+Non-numeric users (e.g. legacy images using `USER agent`) and images with no `USER` directive skip the check.
+
+## Considered options
+
+- **Runtime `chown -R`** — rejected in ADR-0005 for performance, log spam, and read-only mount failures.
+- **`--userns=remap`** (Docker daemon-level) — requires daemon config, not per-container. Not practical.
+- **`fixuid` / entrypoint script** — still chowns at startup. Solves identity but not performance.
+- **`--userns=keep-id`** (Podman-only) — not available in Docker. Already used by the Podman provider.
+- **Skip the pre-flight check** — silent `EACCES` is the bug this fixes; early detection is essential.
+
+## Consequences
+
+- Existing images built without `AGENT_UID`/`AGENT_GID` still work — the ARG defaults to 1000, matching the previous behavior.
+- Users with non-1000 UIDs must rebuild their image after upgrading. The pre-flight diagnostic catches this automatically and names the remedy.
+- The numeric `USER` directive means `docker image inspect` returns a parseable UID. Images using `USER agent` (pre-upgrade) skip the pre-flight check silently — they still work if the host UID happens to be 1000.
+- Supersedes ADR-0005's "reserved" note for the build-arg path. ADR-0005 remains accurate for the Podman side.

--- a/src/DockerLifecycle.test.ts
+++ b/src/DockerLifecycle.test.ts
@@ -7,12 +7,54 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { execFile } from "node:child_process";
-import { startContainer } from "./DockerLifecycle.js";
+import { startContainer, buildImage } from "./DockerLifecycle.js";
 
 const mockExecFile = vi.mocked(execFile);
 
 afterEach(() => {
   mockExecFile.mockReset();
+});
+
+describe("buildImage", () => {
+  it("passes --build-arg flags when buildArgs is provided", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      buildImage("my-image", "/tmp/dir", {
+        buildArgs: { AGENT_UID: "1001", AGENT_GID: "1001" },
+      }),
+    );
+
+    const buildCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "build",
+    );
+    expect(buildCall).toBeDefined();
+    const buildArgs = buildCall![1] as string[];
+    const uidIdx = buildArgs.indexOf("--build-arg");
+    expect(uidIdx).toBeGreaterThan(-1);
+    expect(buildArgs[uidIdx + 1]).toBe("AGENT_UID=1001");
+    const gidIdx = buildArgs.indexOf("--build-arg", uidIdx + 1);
+    expect(gidIdx).toBeGreaterThan(-1);
+    expect(buildArgs[gidIdx + 1]).toBe("AGENT_GID=1001");
+  });
+
+  it("does not pass --build-arg flags when buildArgs is omitted", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(buildImage("my-image", "/tmp/dir"));
+
+    const buildCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "build",
+    );
+    const buildArgs = buildCall![1] as string[];
+    expect(buildArgs).not.toContain("--build-arg");
+  });
 });
 
 describe("startContainer", () => {

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -35,20 +35,33 @@ const dockerExec = (args: string[]): Effect.Effect<string, DockerError> =>
 export const buildImage = (
   imageName: string,
   dockerfileDir: string,
-  options?: { readonly dockerfile?: string },
+  options?: {
+    readonly dockerfile?: string;
+    readonly buildArgs?: Record<string, string>;
+  },
 ): Effect.Effect<void, DockerError> =>
   Effect.gen(function* () {
+    const buildArgFlags = Object.entries(options?.buildArgs ?? {}).flatMap(
+      ([k, v]) => ["--build-arg", `${k}=${v}`],
+    );
     if (options?.dockerfile) {
       yield* dockerExec([
         "build",
         "-t",
         imageName,
+        ...buildArgFlags,
         "-f",
         resolve(options.dockerfile),
         process.cwd(),
       ]);
     } else {
-      yield* dockerExec(["build", "-t", imageName, resolve(dockerfileDir)]);
+      yield* dockerExec([
+        "build",
+        "-t",
+        imageName,
+        ...buildArgFlags,
+        resolve(dockerfileDir),
+      ]);
     }
   });
 

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -77,6 +77,11 @@ ARG AGENT_GID=1000
 RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 USER \${AGENT_UID}:\${AGENT_GID}
 
+# Pre-create standard agent config directories so single-file bind mounts
+# (e.g. ~/.codex/auth.json) land in dirs owned by the agent user. Without
+# this, Docker auto-creates the parent dir as root and the agent gets EACCES.
+RUN mkdir -p /home/agent/.codex /home/agent/.claude /home/agent/.gemini /home/agent/.config
+
 # Install Claude Code CLI
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
@@ -116,6 +121,11 @@ RUN npm install -g @mariozechner/pi-coding-agent
 
 USER \${AGENT_UID}:\${AGENT_GID}
 
+# Pre-create standard agent config directories so single-file bind mounts
+# (e.g. ~/.codex/auth.json) land in dirs owned by the agent user. Without
+# this, Docker auto-creates the parent dir as root and the agent gets EACCES.
+RUN mkdir -p /home/agent/.codex /home/agent/.claude /home/agent/.gemini /home/agent/.config
+
 WORKDIR /home/agent
 
 # In worktree sandbox mode, Sandcastle bind-mounts the git worktree at ${SANDBOX_REPO_DIR}
@@ -149,6 +159,11 @@ RUN npm install -g @openai/codex
 
 USER \${AGENT_UID}:\${AGENT_GID}
 
+# Pre-create standard agent config directories so single-file bind mounts
+# (e.g. ~/.codex/auth.json) land in dirs owned by the agent user. Without
+# this, Docker auto-creates the parent dir as root and the agent gets EACCES.
+RUN mkdir -p /home/agent/.codex /home/agent/.claude /home/agent/.gemini /home/agent/.config
+
 WORKDIR /home/agent
 
 # In worktree sandbox mode, Sandcastle bind-mounts the git worktree at ${SANDBOX_REPO_DIR}
@@ -181,6 +196,11 @@ RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/
 RUN npm install -g opencode-ai@latest
 
 USER \${AGENT_UID}:\${AGENT_GID}
+
+# Pre-create standard agent config directories so single-file bind mounts
+# (e.g. ~/.codex/auth.json) land in dirs owned by the agent user. Without
+# this, Docker auto-creates the parent dir as root and the agent gets EACCES.
+RUN mkdir -p /home/agent/.codex /home/agent/.claude /home/agent/.gemini /home/agent/.config
 
 WORKDIR /home/agent
 

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -67,11 +67,15 @@ RUN apt-get update && apt-get install -y \\
 
 {{BACKLOG_MANAGER_TOOLS}}
 
-# Rename the base image's "node" user (UID 1000) to "agent".
-# This keeps UID 1000 so that --userns=keep-id (Podman) and
-# --user 1000:1000 (Docker) map to the correct home directory owner.
-RUN usermod -d /home/agent -m -l agent node
-USER agent
+# Build-args for UID/GID alignment: sandcastle docker build-image
+# defaults these to the host user's UID/GID so image-built files
+# and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+# Rename the base image's "node" user to "agent" and align UID/GID.
+RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+USER \${AGENT_UID}:\${AGENT_GID}
 
 # Install Claude Code CLI
 RUN curl -fsSL https://claude.ai/install.sh | bash
@@ -98,15 +102,19 @@ RUN apt-get update && apt-get install -y \\
 
 {{BACKLOG_MANAGER_TOOLS}}
 
-# Rename the base image's "node" user (UID 1000) to "agent".
-# This keeps UID 1000 so that --userns=keep-id (Podman) and
-# --user 1000:1000 (Docker) map to the correct home directory owner.
-RUN usermod -d /home/agent -m -l agent node
+# Build-args for UID/GID alignment: sandcastle docker build-image
+# defaults these to the host user's UID/GID so image-built files
+# and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+# Rename the base image's "node" user to "agent" and align UID/GID.
+RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 
 # Install pi coding agent (run as root before USER agent)
 RUN npm install -g @mariozechner/pi-coding-agent
 
-USER agent
+USER \${AGENT_UID}:\${AGENT_GID}
 
 WORKDIR /home/agent
 
@@ -127,15 +135,19 @@ RUN apt-get update && apt-get install -y \\
 
 {{BACKLOG_MANAGER_TOOLS}}
 
-# Rename the base image's "node" user (UID 1000) to "agent".
-# This keeps UID 1000 so that --userns=keep-id (Podman) and
-# --user 1000:1000 (Docker) map to the correct home directory owner.
-RUN usermod -d /home/agent -m -l agent node
+# Build-args for UID/GID alignment: sandcastle docker build-image
+# defaults these to the host user's UID/GID so image-built files
+# and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+# Rename the base image's "node" user to "agent" and align UID/GID.
+RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 
 # Install Codex CLI (run as root before USER agent)
 RUN npm install -g @openai/codex
 
-USER agent
+USER \${AGENT_UID}:\${AGENT_GID}
 
 WORKDIR /home/agent
 
@@ -156,15 +168,19 @@ RUN apt-get update && apt-get install -y \\
 
 {{BACKLOG_MANAGER_TOOLS}}
 
-# Rename the base image's "node" user (UID 1000) to "agent".
-# This keeps UID 1000 so that --userns=keep-id (Podman) and
-# --user 1000:1000 (Docker) map to the correct home directory owner.
-RUN usermod -d /home/agent -m -l agent node
+# Build-args for UID/GID alignment: sandcastle docker build-image
+# defaults these to the host user's UID/GID so image-built files
+# and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+# Rename the base image's "node" user to "agent" and align UID/GID.
+RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 
 # Install OpenCode CLI (run as root before USER agent)
 RUN npm install -g opencode-ai@latest
 
-USER agent
+USER \${AGENT_UID}:\${AGENT_GID}
 
 WORKDIR /home/agent
 

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -77,11 +77,6 @@ ARG AGENT_GID=1000
 RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 USER \${AGENT_UID}:\${AGENT_GID}
 
-# Pre-create standard agent config directories so single-file bind mounts
-# (e.g. ~/.codex/auth.json) land in dirs owned by the agent user. Without
-# this, Docker auto-creates the parent dir as root and the agent gets EACCES.
-RUN mkdir -p /home/agent/.codex /home/agent/.claude /home/agent/.gemini /home/agent/.config
-
 # Install Claude Code CLI
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
@@ -121,11 +116,6 @@ RUN npm install -g @mariozechner/pi-coding-agent
 
 USER \${AGENT_UID}:\${AGENT_GID}
 
-# Pre-create standard agent config directories so single-file bind mounts
-# (e.g. ~/.codex/auth.json) land in dirs owned by the agent user. Without
-# this, Docker auto-creates the parent dir as root and the agent gets EACCES.
-RUN mkdir -p /home/agent/.codex /home/agent/.claude /home/agent/.gemini /home/agent/.config
-
 WORKDIR /home/agent
 
 # In worktree sandbox mode, Sandcastle bind-mounts the git worktree at ${SANDBOX_REPO_DIR}
@@ -159,11 +149,6 @@ RUN npm install -g @openai/codex
 
 USER \${AGENT_UID}:\${AGENT_GID}
 
-# Pre-create standard agent config directories so single-file bind mounts
-# (e.g. ~/.codex/auth.json) land in dirs owned by the agent user. Without
-# this, Docker auto-creates the parent dir as root and the agent gets EACCES.
-RUN mkdir -p /home/agent/.codex /home/agent/.claude /home/agent/.gemini /home/agent/.config
-
 WORKDIR /home/agent
 
 # In worktree sandbox mode, Sandcastle bind-mounts the git worktree at ${SANDBOX_REPO_DIR}
@@ -196,11 +181,6 @@ RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/
 RUN npm install -g opencode-ai@latest
 
 USER \${AGENT_UID}:\${AGENT_GID}
-
-# Pre-create standard agent config directories so single-file bind mounts
-# (e.g. ~/.codex/auth.json) land in dirs owned by the agent user. Without
-# this, Docker auto-creates the parent dir as root and the agent gets EACCES.
-RUN mkdir -p /home/agent/.codex /home/agent/.claude /home/agent/.gemini /home/agent/.config
 
 WORKDIR /home/agent
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,18 @@ const resolveImageName = (
   cwd: string,
 ): string => (cliFlag._tag === "Some" ? cliFlag.value : defaultImageName(cwd));
 
+// --- UID build-args ---
+
+/** Build-args that align the image UID/GID to the host (Linux/macOS). No-op on Windows. */
+const defaultUidBuildArgs = (): Record<string, string> => {
+  const args: Record<string, string> = {};
+  const uid = process.getuid?.();
+  const gid = process.getgid?.();
+  if (uid !== undefined) args.AGENT_UID = String(uid);
+  if (gid !== undefined) args.AGENT_GID = String(gid);
+  return args;
+};
+
 // --- Config directory check ---
 
 const CONFIG_DIR = ".sandcastle";
@@ -292,19 +304,10 @@ const initCommand = Command.make(
             podmanBuildImage(imageName, containerfileDir),
           );
         } else {
-          // Default build-args for UID alignment (Linux/macOS)
-          const initBuildArgs: Record<string, string> = {};
-          const initHostUid = process.getuid?.();
-          const initHostGid = process.getgid?.();
-          if (initHostUid !== undefined)
-            initBuildArgs.AGENT_UID = String(initHostUid);
-          if (initHostGid !== undefined)
-            initBuildArgs.AGENT_GID = String(initHostGid);
-
           yield* d.spinner(
             `Building ${providerLabel} image '${imageName}'...`,
             buildImage(imageName, containerfileDir, {
-              buildArgs: initBuildArgs,
+              buildArgs: defaultUidBuildArgs(),
             }),
           );
         }
@@ -354,18 +357,11 @@ const buildImageCommand = Command.make(
       const dockerfilePath =
         dockerfile._tag === "Some" ? dockerfile.value : undefined;
 
-      // Default build-args for UID alignment (Linux/macOS)
-      const buildArgs: Record<string, string> = {};
-      const hostUid = process.getuid?.();
-      const hostGid = process.getgid?.();
-      if (hostUid !== undefined) buildArgs.AGENT_UID = String(hostUid);
-      if (hostGid !== undefined) buildArgs.AGENT_GID = String(hostGid);
-
       yield* d.spinner(
         `Building Docker image '${imageName}'...`,
         buildImage(imageName, dockerfileDir, {
           dockerfile: dockerfilePath,
-          buildArgs,
+          buildArgs: defaultUidBuildArgs(),
         }),
       );
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -292,9 +292,20 @@ const initCommand = Command.make(
             podmanBuildImage(imageName, containerfileDir),
           );
         } else {
+          // Default build-args for UID alignment (Linux/macOS)
+          const initBuildArgs: Record<string, string> = {};
+          const initHostUid = process.getuid?.();
+          const initHostGid = process.getgid?.();
+          if (initHostUid !== undefined)
+            initBuildArgs.AGENT_UID = String(initHostUid);
+          if (initHostGid !== undefined)
+            initBuildArgs.AGENT_GID = String(initHostGid);
+
           yield* d.spinner(
             `Building ${providerLabel} image '${imageName}'...`,
-            buildImage(imageName, containerfileDir),
+            buildImage(imageName, containerfileDir, {
+              buildArgs: initBuildArgs,
+            }),
           );
         }
         yield* d.status("Init complete! Image built successfully.", "success");
@@ -342,10 +353,19 @@ const buildImageCommand = Command.make(
       const dockerfileDir = join(cwd, CONFIG_DIR);
       const dockerfilePath =
         dockerfile._tag === "Some" ? dockerfile.value : undefined;
+
+      // Default build-args for UID alignment (Linux/macOS)
+      const buildArgs: Record<string, string> = {};
+      const hostUid = process.getuid?.();
+      const hostGid = process.getgid?.();
+      if (hostUid !== undefined) buildArgs.AGENT_UID = String(hostUid);
+      if (hostGid !== undefined) buildArgs.AGENT_GID = String(hostGid);
+
       yield* d.spinner(
         `Building Docker image '${imageName}'...`,
         buildImage(imageName, dockerfileDir, {
           dockerfile: dockerfilePath,
+          buildArgs,
         }),
       );
 

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -126,6 +126,176 @@ describe("docker()", () => {
     expect(provider.tag).toBe("bind-mount");
   });
 
+  it("runs pre-flight docker image inspect before docker run", async () => {
+    const callOrder: string[] = [];
+    mockExecFile.mockImplementation((_command, args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      if (Array.isArray(args) && args[0] === "image" && args[1] === "inspect") {
+        callOrder.push("inspect");
+        const hostUid = process.getuid?.() ?? 1000;
+        const hostGid = process.getgid?.() ?? 1000;
+        callback(null, `${hostUid}:${hostGid}\n`, "");
+      } else if (Array.isArray(args) && args[0] === "run") {
+        callOrder.push("run");
+        callback(null, "", "");
+      } else {
+        callback(null, "", "");
+      }
+      return undefined as any;
+    });
+
+    const provider = docker();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    expect(callOrder).toEqual(["inspect", "run"]);
+
+    await handle.close();
+  });
+
+  it("throws on UID mismatch between image and host", async () => {
+    mockExecFile.mockImplementation((_command, args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      if (Array.isArray(args) && args[0] === "image" && args[1] === "inspect") {
+        callback(null, "9999:9999\n", "");
+      } else {
+        callback(null, "", "");
+      }
+      return undefined as any;
+    });
+
+    const provider = docker();
+
+    await expect(
+      provider.create({
+        worktreePath: "/tmp/worktree",
+        hostRepoPath: "/tmp/repo",
+        mounts: [
+          { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+        ],
+        env: {},
+      }),
+    ).rejects.toThrow("UID mismatch");
+  });
+
+  it("containerUid override bypasses UID mismatch with host", async () => {
+    mockExecFile.mockImplementation((_command, args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      if (Array.isArray(args) && args[0] === "image" && args[1] === "inspect") {
+        // Image has UID 500, which differs from host but matches containerUid
+        callback(null, "500:500\n", "");
+      } else {
+        callback(null, "", "");
+      }
+      return undefined as any;
+    });
+
+    const provider = docker({ containerUid: 500, containerGid: 500 });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    // Should succeed — containerUid matches image UID
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    expect(runCall).toBeDefined();
+
+    await handle.close();
+  });
+
+  it("throws a clear error when image is not found locally", async () => {
+    mockExecFile.mockImplementationOnce((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(new Error("no such image"), "", "");
+      return undefined as any;
+    });
+
+    const provider = docker({ imageName: "my-app:latest" });
+
+    await expect(
+      provider.create({
+        worktreePath: "/tmp/worktree",
+        hostRepoPath: "/tmp/repo",
+        mounts: [
+          { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+        ],
+        env: {},
+      }),
+    ).rejects.toThrow(
+      "Image 'my-app:latest' not found locally. Build it first with 'sandcastle docker build-image'.",
+    );
+  });
+
+  it("uses host UID/GID by default for --user flag", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = docker();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const userIdx = runArgs.indexOf("--user");
+    expect(userIdx).toBeGreaterThan(-1);
+    const hostUid = process.getuid?.() ?? 1000;
+    const hostGid = process.getgid?.() ?? 1000;
+    expect(runArgs[userIdx + 1]).toBe(`${hostUid}:${hostGid}`);
+
+    await handle.close();
+  });
+
+  it("uses containerUid/containerGid for --user flag when provided", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = docker({ containerUid: 500, containerGid: 500 });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const userIdx = runArgs.indexOf("--user");
+    expect(userIdx).toBeGreaterThan(-1);
+    expect(runArgs[userIdx + 1]).toBe("500:500");
+
+    await handle.close();
+  });
+
   it("copyFileIn calls docker cp with correct arguments", async () => {
     mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
       const callback = rest[rest.length - 1];

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -102,13 +102,13 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
       const imageName =
         configuredImageName ?? defaultImageName(createOptions.hostRepoPath);
 
-      const hostUid =
+      const containerUid =
         options?.containerUid ?? process.getuid?.() ?? 1000;
-      const hostGid =
+      const containerGid =
         options?.containerGid ?? process.getgid?.() ?? 1000;
 
       // Pre-flight: verify image exists and UID matches
-      await checkImageUid(imageName, hostUid);
+      await checkImageUid(imageName, containerUid);
 
       // Start container
       await Effect.runPromise(
@@ -122,7 +122,7 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
           {
             volumeMounts,
             workdir: worktreePath,
-            user: `${hostUid}:${hostGid}`,
+            user: `${containerUid}:${containerGid}`,
             network: options?.network,
           },
         ),

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -31,6 +31,19 @@ export interface DockerOptions {
   /** Docker image name (default: derived from repo directory name). */
   readonly imageName?: string;
   /**
+   * The UID of the `agent` user inside the container image (default: host UID via `process.getuid()`, or 1000).
+   *
+   * Must match the UID baked into the image at build time. Used as the `--user` flag value
+   * and checked against the image's configured UID in the pre-flight diagnostic.
+   */
+  readonly containerUid?: number;
+  /**
+   * The GID of the `agent` user inside the container image (default: host GID via `process.getgid()`, or 1000).
+   *
+   * Must match the GID baked into the image at build time. Used as the `--user` flag value.
+   */
+  readonly containerGid?: number;
+  /**
    * Additional host directories to bind-mount into the sandbox.
    *
    * Each entry specifies a `hostPath` (tilde-expanded) and `sandboxPath`.
@@ -89,8 +102,13 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
       const imageName =
         configuredImageName ?? defaultImageName(createOptions.hostRepoPath);
 
-      const hostUid = process.getuid?.() ?? 1000;
-      const hostGid = process.getgid?.() ?? 1000;
+      const hostUid =
+        options?.containerUid ?? process.getuid?.() ?? 1000;
+      const hostGid =
+        options?.containerGid ?? process.getgid?.() ?? 1000;
+
+      // Pre-flight: verify image exists and UID matches
+      await checkImageUid(imageName, hostUid);
 
       // Start container
       await Effect.runPromise(
@@ -271,3 +289,46 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
 
 // Re-export for backwards compatibility
 export { defaultImageName };
+
+const checkImageUid = (imageName: string, expectedUid: number): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    execFile(
+      "docker",
+      ["image", "inspect", imageName, "--format", "{{.Config.User}}"],
+      (error, stdout) => {
+        if (error) {
+          reject(
+            new Error(
+              `Image '${imageName}' not found locally. Build it first with 'sandcastle docker build-image'.`,
+            ),
+          );
+          return;
+        }
+        const imageUser = (stdout ?? "").toString().trim();
+        if (!imageUser) {
+          // No USER directive in image — skip check
+          resolve();
+          return;
+        }
+        const uidPart = imageUser.split(":")[0]!;
+        const imageUid = parseInt(uidPart, 10);
+        if (isNaN(imageUid)) {
+          // Non-numeric user (e.g. "agent") — can't compare, skip check
+          resolve();
+          return;
+        }
+        if (imageUid !== expectedUid) {
+          reject(
+            new Error(
+              `UID mismatch: image '${imageName}' was built with UID ${imageUid}, ` +
+                `but the expected UID is ${expectedUid}. ` +
+                `Rebuild the image with 'sandcastle docker build-image', ` +
+                `or pass containerUid: ${imageUid} to docker() to match the image.`,
+            ),
+          );
+        } else {
+          resolve();
+        }
+      },
+    );
+  });


### PR DESCRIPTION
## Summary

- Parameterize all 4 Dockerfile templates with `ARG AGENT_UID=1000` / `ARG AGENT_GID=1000` and apply via `groupmod -g` / `usermod -u -g`
- `DockerLifecycle.buildImage` accepts `buildArgs: Record<string, string>` option
- `sandcastle docker build-image` (and `sandcastle init` Docker build) defaults `AGENT_UID`/`AGENT_GID` to `process.getuid()` / `process.getgid()` on Linux/macOS
- Docker provider gains `containerUid` / `containerGid` options mirroring the Podman provider surface
- Pre-flight `docker image inspect` runs before `docker run`; on UID mismatch, errors with a message naming both remedies (rebuild and `containerUid` override)
- ADR-0014 documents the decision (build-time over runtime chown / userns / entrypoint script)

closes #573, closes #502, closes #504, closes #537, closes #539

## Test plan

- [x] `buildImage` passes `--build-arg` flags when `buildArgs` is provided
- [x] `buildImage` omits `--build-arg` flags when `buildArgs` is omitted
- [x] Docker provider uses host UID/GID by default for `--user` flag
- [x] Docker provider uses `containerUid`/`containerGid` for `--user` flag when provided
- [x] Pre-flight `docker image inspect` runs before `docker run`
- [x] UID mismatch between image and host throws clear error
- [x] `containerUid` override bypasses UID mismatch with host
- [x] Image not found locally throws clear error
- [x] Typecheck passes
- [x] All tests pass (12 pre-existing CLI test failures due to missing `dist/` build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)