### PR TITLE
Harden Docker/Podman bind mounts: SELinux labels + parent dirs

### DIFF
--- a/.changeset/docker-selinux-label.md
+++ b/.changeset/docker-selinux-label.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Apply `:z` SELinux label by default on Docker bind mounts, matching the existing Podman behavior. Adds `selinuxLabel` option to `DockerOptions` (`"z"` | `"Z"` | `false`, default `"z"`). Extracts shared `formatVolumeMount` from Podman provider into `src/mountUtils.ts` so both providers use the same volume-mount formatter.

--- a/.changeset/file-mount-parent-dirs.md
+++ b/.changeset/file-mount-parent-dirs.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Auto-create parent directories for file-target bind mounts under `/home/agent`. When a user mount targets a single file whose sandbox-side parent directory may not exist in the image (e.g. `/home/agent/.codex/auth.json`), both Docker and Podman providers now run `mkdir -p` + `chown` on the parent at container start. File mounts whose parent is outside `/home/agent` fail at config time with a clear error and remediation guidance.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ const result = await run({
       { hostPath: "~/.npm", sandboxPath: "/home/agent/.npm", readonly: true },
       { hostPath: "data", sandboxPath: "data" }, // mounts <cwd>/data → <sandbox-repo>/data
     ],
+    // Optional: SELinux volume label — "z" (default, shared), "Z" (private), or false (none).
+    // No-op on non-SELinux systems (Docker Desktop on macOS/Windows, Linux without SELinux).
+    selinuxLabel: "z",
     // Optional: provider-level env vars merged at launch time
     env: { DOCKER_SPECIFIC: "value" },
     // Optional: attach container to Docker network(s) — string or string[]
@@ -1131,7 +1134,7 @@ const result = await run({
 
 For real-world examples, see:
 
-- [`src/sandboxes/docker.ts`](src/sandboxes/docker.ts) — bind-mount provider using Docker containers
+- [`src/sandboxes/docker.ts`](src/sandboxes/docker.ts) — bind-mount provider using Docker containers (with SELinux label support)
 - [`src/sandboxes/vercel.ts`](src/sandboxes/vercel.ts) — isolated provider using Vercel Firecracker microVMs via `@vercel/sandbox`
 - [`src/sandboxes/podman.ts`](src/sandboxes/podman.ts) — bind-mount provider using Podman containers (with SELinux label support)
 - [`src/sandboxes/test-isolated.ts`](src/sandboxes/test-isolated.ts) — isolated provider using temp directories (used in tests)

--- a/src/DockerLifecycle.test.ts
+++ b/src/DockerLifecycle.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Effect } from "effect";
 
-vi.mock("node:child_process", () => ({
-  execFile: vi.fn(),
-  execFileSync: vi.fn(),
-}));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    execFile: vi.fn(),
+    execFileSync: vi.fn(),
+  };
+});
 
 import { execFile } from "node:child_process";
 import { startContainer, buildImage } from "./DockerLifecycle.js";
@@ -115,7 +119,7 @@ describe("startContainer", () => {
     expect(runArgs).not.toContain("--network");
   });
 
-  it("uses --mount type=bind format instead of -v for volume mounts", async () => {
+  it("uses -v format with formatVolumeMount for volume mounts", async () => {
     mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
       cb(null, "", "");
       return undefined as any;
@@ -133,37 +137,9 @@ describe("startContainer", () => {
       ([, args]) => Array.isArray(args) && args[0] === "run",
     );
     const runArgs = runCall![1] as string[];
-    expect(runArgs).not.toContain("-v");
-    expect(runArgs).toContain("--mount");
-    const mountIdx = runArgs.indexOf("--mount");
-    expect(runArgs[mountIdx + 1]).toBe(
-      "type=bind,source=/host/path,target=/sandbox/path",
-    );
-  });
-
-  it("handles Windows-style host paths with colons correctly", async () => {
-    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
-      cb(null, "", "");
-      return undefined as any;
-    });
-
-    await Effect.runPromise(
-      startContainer("ctr", "img", {}, {
-        volumeMounts: [
-          { hostPath: "C:/Users/x/repo", sandboxPath: "/home/agent/workspace" },
-        ],
-      }),
-    );
-
-    const runCall = mockExecFile.mock.calls.find(
-      ([, args]) => Array.isArray(args) && args[0] === "run",
-    );
-    const runArgs = runCall![1] as string[];
-    expect(runArgs).not.toContain("-v");
-    const mountIdx = runArgs.indexOf("--mount");
-    expect(runArgs[mountIdx + 1]).toBe(
-      "type=bind,source=C:/Users/x/repo,target=/home/agent/workspace",
-    );
+    expect(runArgs).toContain("-v");
+    const vIdx = runArgs.indexOf("-v");
+    expect(runArgs[vIdx + 1]).toBe("/host/path:/sandbox/path:z");
   });
 
   it("includes readonly flag for read-only mounts", async () => {
@@ -184,9 +160,98 @@ describe("startContainer", () => {
       ([, args]) => Array.isArray(args) && args[0] === "run",
     );
     const runArgs = runCall![1] as string[];
-    const mountIdx = runArgs.indexOf("--mount");
-    expect(runArgs[mountIdx + 1]).toBe(
-      "type=bind,source=/host/path,target=/sandbox/path,readonly",
+    const vIdx = runArgs.indexOf("-v");
+    expect(runArgs[vIdx + 1]).toBe("/host/path:/sandbox/path:ro,z");
+  });
+
+  it("default mount string ends with :z (SELinux shared label)", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer("ctr", "img", {}, {
+        volumeMounts: [
+          { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
+        ],
+      }),
     );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const vIdx = runArgs.indexOf("-v");
+    expect(runArgs[vIdx + 1]).toBe("/host/path:/sandbox/path:z");
+  });
+
+  it("selinuxLabel 'Z' produces :Z suffix", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer("ctr", "img", {}, {
+        volumeMounts: [
+          { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
+        ],
+        selinuxLabel: "Z",
+      }),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const vIdx = runArgs.indexOf("-v");
+    expect(runArgs[vIdx + 1]).toBe("/host/path:/sandbox/path:Z");
+  });
+
+  it("selinuxLabel false produces no SELinux suffix", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer("ctr", "img", {}, {
+        volumeMounts: [
+          { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
+        ],
+        selinuxLabel: false,
+      }),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const vIdx = runArgs.indexOf("-v");
+    expect(runArgs[vIdx + 1]).toBe("/host/path:/sandbox/path");
+  });
+
+  it("readonly with selinuxLabel false produces :ro only", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer("ctr", "img", {}, {
+        volumeMounts: [
+          { hostPath: "/host/path", sandboxPath: "/sandbox/path", readonly: true },
+        ],
+        selinuxLabel: false,
+      }),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const vIdx = runArgs.indexOf("-v");
+    expect(runArgs[vIdx + 1]).toBe("/host/path:/sandbox/path:ro");
   });
 });

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 import { execFile } from "node:child_process";
 import { resolve } from "node:path";
 import { DockerError } from "./errors.js";
+import { formatVolumeMount, type SelinuxLabel } from "./mountUtils.js";
 
 const dockerExec = (args: string[]): Effect.Effect<string, DockerError> =>
   Effect.async((resume) => {
@@ -78,6 +79,14 @@ export interface StartContainerOptions {
   readonly user?: string;
   /** Docker network(s) to attach the container to. Passed as `--network` flags. */
   readonly network?: string | readonly string[];
+  /**
+   * SELinux volume label suffix applied to bind mounts (default `"z"`).
+   *
+   * - `"z"` — shared label. No-op on non-SELinux systems.
+   * - `"Z"` — private label; only this container can access the mount.
+   * - `false` — disable labeling entirely.
+   */
+  readonly selinuxLabel?: SelinuxLabel;
 }
 
 /**
@@ -113,9 +122,10 @@ export const startContainer = (
       `${k}=${v}`,
     ]);
 
+    const selinuxLabel = options?.selinuxLabel ?? "z";
     const volumeFlags = (options?.volumeMounts ?? []).flatMap((mount) => [
-      "--mount",
-      `type=bind,source=${mount.hostPath},target=${mount.sandboxPath}${mount.readonly ? ",readonly" : ""}`,
+      "-v",
+      formatVolumeMount(mount, selinuxLabel),
     ]);
 
     const workdirFlags = options?.workdir ? ["-w", options.workdir] : [];

--- a/src/mountUtils.test.ts
+++ b/src/mountUtils.test.ts
@@ -556,28 +556,19 @@ describe("patchGitMountsForWindows", () => {
 describe("formatVolumeMount", () => {
   it("formats basic mount without options", () => {
     expect(
-      formatVolumeMount(
-        { hostPath: "/host", sandboxPath: "/sandbox" },
-        false,
-      ),
+      formatVolumeMount({ hostPath: "/host", sandboxPath: "/sandbox" }, false),
     ).toBe("/host:/sandbox");
   });
 
   it("appends :z when selinuxLabel is 'z'", () => {
     expect(
-      formatVolumeMount(
-        { hostPath: "/host", sandboxPath: "/sandbox" },
-        "z",
-      ),
+      formatVolumeMount({ hostPath: "/host", sandboxPath: "/sandbox" }, "z"),
     ).toBe("/host:/sandbox:z");
   });
 
   it("appends :Z when selinuxLabel is 'Z'", () => {
     expect(
-      formatVolumeMount(
-        { hostPath: "/host", sandboxPath: "/sandbox" },
-        "Z",
-      ),
+      formatVolumeMount({ hostPath: "/host", sandboxPath: "/sandbox" }, "Z"),
     ).toBe("/host:/sandbox:Z");
   });
 
@@ -652,7 +643,7 @@ describe("processFileMountParents", () => {
     ];
     expect(() =>
       processFileMountParents(mounts, sandboxHomedir, fileStatFn),
-    ).toThrow(/parent directory.*\/opt\/foo.*outside the agent home/i);
+    ).toThrow(/parent directory.*\/opt\/foo.*outside the sandbox home/i);
   });
 
   it("error message includes remediation guidance", () => {
@@ -729,11 +720,7 @@ describe("processFileMountParents", () => {
         sandboxPath: "/home/agent/.codex/missing",
       },
     ];
-    const result = processFileMountParents(
-      mounts,
-      sandboxHomedir,
-      throwStatFn,
-    );
+    const result = processFileMountParents(mounts, sandboxHomedir, throwStatFn);
     expect(result).toEqual([]);
   });
 

--- a/src/mountUtils.test.ts
+++ b/src/mountUtils.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeMounts,
   parseGitdirPath,
   patchGitMountsForWindows,
+  formatVolumeMount,
   PARENT_GIT_SANDBOX_DIR,
 } from "./mountUtils.js";
 import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
@@ -548,5 +549,79 @@ describe("patchGitMountsForWindows", () => {
         `gitdir: ${PARENT_GIT_SANDBOX_DIR}/worktrees/backslash-wt\n`,
       );
     });
+  });
+});
+
+describe("formatVolumeMount", () => {
+  it("formats basic mount without options", () => {
+    expect(
+      formatVolumeMount(
+        { hostPath: "/host", sandboxPath: "/sandbox" },
+        false,
+      ),
+    ).toBe("/host:/sandbox");
+  });
+
+  it("appends :z when selinuxLabel is 'z'", () => {
+    expect(
+      formatVolumeMount(
+        { hostPath: "/host", sandboxPath: "/sandbox" },
+        "z",
+      ),
+    ).toBe("/host:/sandbox:z");
+  });
+
+  it("appends :Z when selinuxLabel is 'Z'", () => {
+    expect(
+      formatVolumeMount(
+        { hostPath: "/host", sandboxPath: "/sandbox" },
+        "Z",
+      ),
+    ).toBe("/host:/sandbox:Z");
+  });
+
+  it("appends :ro when readonly is true and no SELinux", () => {
+    expect(
+      formatVolumeMount(
+        { hostPath: "/host", sandboxPath: "/sandbox", readonly: true },
+        false,
+      ),
+    ).toBe("/host:/sandbox:ro");
+  });
+
+  it("combines ro and z options", () => {
+    expect(
+      formatVolumeMount(
+        { hostPath: "/host", sandboxPath: "/sandbox", readonly: true },
+        "z",
+      ),
+    ).toBe("/host:/sandbox:ro,z");
+  });
+
+  it("combines ro and Z options", () => {
+    expect(
+      formatVolumeMount(
+        { hostPath: "/host", sandboxPath: "/sandbox", readonly: true },
+        "Z",
+      ),
+    ).toBe("/host:/sandbox:ro,Z");
+  });
+
+  it("omits options for writable mount with selinuxLabel false", () => {
+    const result = formatVolumeMount(
+      { hostPath: "/host", sandboxPath: "/sandbox" },
+      false,
+    );
+    expect(result).toBe("/host:/sandbox");
+    expect(result).not.toContain("::");
+  });
+
+  it("accepts undefined selinuxLabel (treated as false)", () => {
+    expect(
+      formatVolumeMount(
+        { hostPath: "/host", sandboxPath: "/sandbox" },
+        undefined,
+      ),
+    ).toBe("/host:/sandbox");
   });
 });

--- a/src/mountUtils.test.ts
+++ b/src/mountUtils.test.ts
@@ -9,6 +9,7 @@ import {
   parseGitdirPath,
   patchGitMountsForWindows,
   formatVolumeMount,
+  processFileMountParents,
   PARENT_GIT_SANDBOX_DIR,
 } from "./mountUtils.js";
 import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
@@ -623,5 +624,127 @@ describe("formatVolumeMount", () => {
         undefined,
       ),
     ).toBe("/host:/sandbox");
+  });
+});
+
+describe("processFileMountParents", () => {
+  const sandboxHomedir = "/home/agent";
+  const fileStatFn = () => ({ isFile: () => true });
+  const dirStatFn = () => ({ isFile: () => false });
+
+  it("returns parent dir for a file mount under /home/agent", () => {
+    const mounts = [
+      {
+        hostPath: "/host/.codex/auth.json",
+        sandboxPath: "/home/agent/.codex/auth.json",
+      },
+    ];
+    const result = processFileMountParents(mounts, sandboxHomedir, fileStatFn);
+    expect(result).toEqual(["/home/agent/.codex"]);
+  });
+
+  it("throws for a file mount whose parent is outside /home/agent", () => {
+    const mounts = [
+      {
+        hostPath: "/host/config.json",
+        sandboxPath: "/opt/foo/config.json",
+      },
+    ];
+    expect(() =>
+      processFileMountParents(mounts, sandboxHomedir, fileStatFn),
+    ).toThrow(/parent directory.*\/opt\/foo.*outside the agent home/i);
+  });
+
+  it("error message includes remediation guidance", () => {
+    const mounts = [
+      {
+        hostPath: "/host/config.json",
+        sandboxPath: "/opt/foo/config.json",
+      },
+    ];
+    expect(() =>
+      processFileMountParents(mounts, sandboxHomedir, fileStatFn),
+    ).toThrow(/mount the parent directory instead.*or rebuild/i);
+  });
+
+  it("returns empty array for directory mounts", () => {
+    const mounts = [
+      {
+        hostPath: "/host/data",
+        sandboxPath: "/home/agent/data",
+      },
+    ];
+    const result = processFileMountParents(mounts, sandboxHomedir, dirStatFn);
+    expect(result).toEqual([]);
+  });
+
+  it("skips mounts whose parent IS /home/agent itself", () => {
+    const mounts = [
+      {
+        hostPath: "/host/.gitconfig",
+        sandboxPath: "/home/agent/.gitconfig",
+      },
+    ];
+    const result = processFileMountParents(mounts, sandboxHomedir, fileStatFn);
+    expect(result).toEqual([]);
+  });
+
+  it("deduplicates parent dirs across multiple file mounts", () => {
+    const mounts = [
+      {
+        hostPath: "/host/.codex/auth.json",
+        sandboxPath: "/home/agent/.codex/auth.json",
+      },
+      {
+        hostPath: "/host/.codex/config.json",
+        sandboxPath: "/home/agent/.codex/config.json",
+      },
+    ];
+    const result = processFileMountParents(mounts, sandboxHomedir, fileStatFn);
+    expect(result).toEqual(["/home/agent/.codex"]);
+  });
+
+  it("returns multiple distinct parent dirs", () => {
+    const mounts = [
+      {
+        hostPath: "/host/.codex/auth.json",
+        sandboxPath: "/home/agent/.codex/auth.json",
+      },
+      {
+        hostPath: "/host/.claude/settings.json",
+        sandboxPath: "/home/agent/.claude/settings.json",
+      },
+    ];
+    const result = processFileMountParents(mounts, sandboxHomedir, fileStatFn);
+    expect(result).toEqual(["/home/agent/.codex", "/home/agent/.claude"]);
+  });
+
+  it("skips mounts that cannot be stat'd", () => {
+    const throwStatFn = () => {
+      throw new Error("ENOENT");
+    };
+    const mounts = [
+      {
+        hostPath: "/host/missing",
+        sandboxPath: "/home/agent/.codex/missing",
+      },
+    ];
+    const result = processFileMountParents(
+      mounts,
+      sandboxHomedir,
+      throwStatFn,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("handles deeply nested file mounts under /home/agent", () => {
+    const mounts = [
+      {
+        hostPath: "/host/deep.json",
+        sandboxPath: "/home/agent/.config/deep/nested/file.json",
+      },
+    ];
+    const result = processFileMountParents(mounts, sandboxHomedir, fileStatFn);
+    expect(result).toEqual(["/home/agent/.config/deep/nested"]);
   });
 });

--- a/src/mountUtils.ts
+++ b/src/mountUtils.ts
@@ -362,7 +362,7 @@ export const processFileMountParents = (
     if (!parentDir.startsWith(sandboxHomedir + "/")) {
       throw new Error(
         `Cannot mount file to '${mount.sandboxPath}': ` +
-          `parent directory '${parentDir}' is outside the agent home directory ('${sandboxHomedir}'). ` +
+          `parent directory '${parentDir}' is outside the sandbox home directory ('${sandboxHomedir}'). ` +
           `Mount the parent directory instead, or rebuild the image with '${parentDir}' pre-created.`,
       );
     }

--- a/src/mountUtils.ts
+++ b/src/mountUtils.ts
@@ -13,6 +13,15 @@ import type { MountConfig } from "./MountConfig.js";
 import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
 
 /**
+ * SELinux volume label suffix applied to bind mounts.
+ *
+ * - `"z"` — shared label. No-op on non-SELinux systems.
+ * - `"Z"` — private label; only this container can access the mount.
+ * - `false` — disable labeling entirely.
+ */
+export type SelinuxLabel = "z" | "Z" | false;
+
+/**
  * Deterministic mount point inside the sandbox for the parent repo's .git
  * directory when the workspace is a git worktree. See ADR-0006.
  */
@@ -290,4 +299,23 @@ export const patchGitMountsForWindows = async (
   }
 
   return correctedMounts;
+};
+
+/**
+ * Format a bind mount into a `-v` style string for container runtimes.
+ *
+ * Produces: `hostPath:sandboxPath[:ro][,z|Z]`
+ *
+ * Used by both Podman and Docker providers.
+ */
+export const formatVolumeMount = (
+  mount: { hostPath: string; sandboxPath: string; readonly?: boolean },
+  selinuxLabel: SelinuxLabel | undefined,
+): string => {
+  const base = `${mount.hostPath}:${mount.sandboxPath}`;
+  const options = [mount.readonly ? "ro" : undefined, selinuxLabel || undefined]
+    .filter((option): option is string => option !== undefined)
+    .join(",");
+
+  return options ? `${base}:${options}` : base;
 };

--- a/src/mountUtils.ts
+++ b/src/mountUtils.ts
@@ -5,9 +5,9 @@
  * validation, image naming, and Windows path normalization.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { tmpdir, homedir } from "node:os";
-import { isAbsolute, resolve, join } from "node:path";
+import { isAbsolute, resolve, join, dirname } from "node:path";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import type { MountConfig } from "./MountConfig.js";
 import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
@@ -318,4 +318,57 @@ export const formatVolumeMount = (
     .join(",");
 
   return options ? `${base}:${options}` : base;
+};
+
+/**
+ * Detect file-target mounts whose sandbox-side parent directory may not
+ * exist in the container image, and return the parent dirs that need to
+ * be created at container start.
+ *
+ * Validates at config time: if a file mount's sandbox parent is outside
+ * `sandboxHomedir`, throws with a clear error and remediation guidance.
+ *
+ * For file mounts whose parent is under `sandboxHomedir` (but not equal
+ * to it — `/home/agent` always exists), returns the unique set of parent
+ * directories that must be `mkdir -p` + `chown`'d before the agent runs.
+ *
+ * @param mounts - Resolved mounts (hostPath already validated to exist).
+ * @param sandboxHomedir - The agent's home directory in the sandbox (e.g. `/home/agent`).
+ * @param statFn - Injectable stat function for testing (defaults to `statSync`).
+ */
+export const processFileMountParents = (
+  mounts: ReadonlyArray<{ hostPath: string; sandboxPath: string }>,
+  sandboxHomedir: string,
+  statFn: (path: string) => { isFile(): boolean } = statSync,
+): string[] => {
+  const parentDirs = new Set<string>();
+
+  for (const mount of mounts) {
+    let isFile: boolean;
+    try {
+      isFile = statFn(mount.hostPath).isFile();
+    } catch {
+      continue;
+    }
+
+    if (!isFile) continue;
+
+    const parentDir = dirname(mount.sandboxPath);
+
+    // Parent IS sandboxHomedir — it always exists in the image
+    if (parentDir === sandboxHomedir) continue;
+
+    // Parent is outside sandboxHomedir — fail at config time
+    if (!parentDir.startsWith(sandboxHomedir + "/")) {
+      throw new Error(
+        `Cannot mount file to '${mount.sandboxPath}': ` +
+          `parent directory '${parentDir}' is outside the agent home directory ('${sandboxHomedir}'). ` +
+          `Mount the parent directory instead, or rebuild the image with '${parentDir}' pre-created.`,
+      );
+    }
+
+    parentDirs.add(parentDir);
+  }
+
+  return [...parentDirs];
 };

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -503,11 +503,12 @@ describe("docker()", () => {
     // Should run as root
     expect(mkdirArgs).toContain("--user");
     expect(mkdirArgs[mkdirArgs.indexOf("--user") + 1]).toBe("0:0");
-    // Should target /home/agent/.codex
-    const shCmd = mkdirArgs[mkdirArgs.length - 1]!;
+    // Script body is fixed; the dir and uid:gid are passed as argv after `sh`
+    const shCmdIdx = mkdirArgs.indexOf("-c");
+    const shCmd = mkdirArgs[shCmdIdx + 1]!;
     expect(shCmd).toContain("mkdir -p");
-    expect(shCmd).toContain("/home/agent/.codex");
     expect(shCmd).toContain("chown");
+    expect(mkdirArgs).toContain("/home/agent/.codex");
 
     unlinkSync(tmpFile);
     rmdirSync(tmpDir);
@@ -537,9 +538,7 @@ describe("docker()", () => {
         cmd === "docker" &&
         Array.isArray(args) &&
         args[0] === "exec" &&
-        args.some(
-          (a: string) => typeof a === "string" && a.includes("mkdir"),
-        ),
+        args.some((a: string) => typeof a === "string" && a.includes("mkdir")),
     );
     expect(mkdirCall).toBeUndefined();
 
@@ -553,11 +552,9 @@ describe("docker()", () => {
 
     expect(() =>
       docker({
-        mounts: [
-          { hostPath: tmpFile, sandboxPath: "/opt/foo/config.json" },
-        ],
+        mounts: [{ hostPath: tmpFile, sandboxPath: "/opt/foo/config.json" }],
       }),
-    ).toThrow(/outside the agent home directory/);
+    ).toThrow(/outside the sandbox home directory/);
 
     unlinkSync(tmpFile);
     rmdirSync(tmpDir);

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -15,6 +15,9 @@ vi.mock("node:child_process", async () => {
 });
 
 import { execFile } from "node:child_process";
+import { writeFileSync, mkdtempSync, unlinkSync, rmdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { docker } from "./docker.js";
 import type { BindMountSandboxHandle } from "../SandboxProvider.js";
 
@@ -457,6 +460,107 @@ describe("docker()", () => {
     expect(runArgs[vIdx + 1]).toBe("/tmp/worktree:/home/agent/workspace");
 
     await handle.close();
+  });
+
+  it("runs mkdir+chown for file mount parent dirs after container start", async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "docker-test-"));
+    const tmpFile = join(tmpDir, "auth.json");
+    writeFileSync(tmpFile, "{}");
+
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = docker({
+      mounts: [
+        { hostPath: tmpFile, sandboxPath: "/home/agent/.codex/auth.json" },
+      ],
+    });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    // Find the docker exec call for mkdir+chown
+    const mkdirCall = mockExecFile.mock.calls.find(
+      ([cmd, args]) =>
+        cmd === "docker" &&
+        Array.isArray(args) &&
+        args[0] === "exec" &&
+        args.some(
+          (a: string) =>
+            typeof a === "string" && a.includes("mkdir") && a.includes("chown"),
+        ),
+    );
+    expect(mkdirCall).toBeDefined();
+    const mkdirArgs = mkdirCall![1] as string[];
+    // Should run as root
+    expect(mkdirArgs).toContain("--user");
+    expect(mkdirArgs[mkdirArgs.indexOf("--user") + 1]).toBe("0:0");
+    // Should target /home/agent/.codex
+    const shCmd = mkdirArgs[mkdirArgs.length - 1]!;
+    expect(shCmd).toContain("mkdir -p");
+    expect(shCmd).toContain("/home/agent/.codex");
+    expect(shCmd).toContain("chown");
+
+    unlinkSync(tmpFile);
+    rmdirSync(tmpDir);
+    await handle.close();
+  });
+
+  it("does not run mkdir+chown when there are no file mounts", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = docker();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    // Should NOT have any docker exec for mkdir
+    const mkdirCall = mockExecFile.mock.calls.find(
+      ([cmd, args]) =>
+        cmd === "docker" &&
+        Array.isArray(args) &&
+        args[0] === "exec" &&
+        args.some(
+          (a: string) => typeof a === "string" && a.includes("mkdir"),
+        ),
+    );
+    expect(mkdirCall).toBeUndefined();
+
+    await handle.close();
+  });
+
+  it("throws at construction time for file mount with parent outside /home/agent", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "docker-test-"));
+    const tmpFile = join(tmpDir, "config.json");
+    writeFileSync(tmpFile, "{}");
+
+    expect(() =>
+      docker({
+        mounts: [
+          { hostPath: tmpFile, sandboxPath: "/opt/foo/config.json" },
+        ],
+      }),
+    ).toThrow(/outside the agent home directory/);
+
+    unlinkSync(tmpFile);
+    rmdirSync(tmpDir);
   });
 
   it("copyFileIn rejects when docker cp fails", async () => {

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -47,6 +47,15 @@ describe("docker()", () => {
     expect("branchStrategy" in provider).toBe(false);
   });
 
+  it("accepts selinuxLabel option", () => {
+    const withZ = docker({ selinuxLabel: "z" });
+    const withBigZ = docker({ selinuxLabel: "Z" });
+    const withFalse = docker({ selinuxLabel: false });
+    expect(withZ.tag).toBe("bind-mount");
+    expect(withBigZ.tag).toBe("bind-mount");
+    expect(withFalse.tag).toBe("bind-mount");
+  });
+
   it("accepts a mounts option with valid paths", () => {
     const provider = docker({
       mounts: [{ hostPath: "~", sandboxPath: "/mnt/home" }],
@@ -364,6 +373,88 @@ describe("docker()", () => {
     expect(cpArgs[0]).toBe("cp");
     expect(cpArgs[1]).toMatch(/^sandcastle-.*:\/sandbox\/output\.txt$/);
     expect(cpArgs[2]).toBe("/host/output.txt");
+
+    await handle.close();
+  });
+
+  it("default mounts include :z SELinux label", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = docker();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const vIdx = runArgs.indexOf("-v");
+    expect(vIdx).toBeGreaterThan(-1);
+    expect(runArgs[vIdx + 1]).toMatch(/:z$/);
+
+    await handle.close();
+  });
+
+  it("selinuxLabel 'Z' produces :Z suffix on mounts", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = docker({ selinuxLabel: "Z" });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const vIdx = runArgs.indexOf("-v");
+    expect(runArgs[vIdx + 1]).toMatch(/:Z$/);
+
+    await handle.close();
+  });
+
+  it("selinuxLabel false produces no SELinux suffix on mounts", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = docker({ selinuxLabel: false });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const vIdx = runArgs.indexOf("-v");
+    expect(runArgs[vIdx + 1]).toBe("/tmp/worktree:/home/agent/workspace");
 
     await handle.close();
   });

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -35,6 +35,7 @@ import {
 export interface DockerOptions {
   /** Docker image name (default: derived from repo directory name). */
   readonly imageName?: string;
+  /**
    * The UID of the `agent` user inside the container image (default: host UID via `process.getuid()`, or 1000).
    *
    * Must match the UID baked into the image at build time. Used as the `--user` flag value
@@ -121,10 +122,8 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
       const imageName =
         configuredImageName ?? defaultImageName(createOptions.hostRepoPath);
 
-      const containerUid =
-        options?.containerUid ?? process.getuid?.() ?? 1000;
-      const containerGid =
-        options?.containerGid ?? process.getgid?.() ?? 1000;
+      const containerUid = options?.containerUid ?? process.getuid?.() ?? 1000;
+      const containerGid = options?.containerGid ?? process.getgid?.() ?? 1000;
 
       // Pre-flight: verify image exists and UID matches
       await checkImageUid(imageName, containerUid);
@@ -160,7 +159,10 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
               containerName,
               "sh",
               "-c",
-              `mkdir -p "${dir}" && chown ${hostUid}:${hostGid} "${dir}"`,
+              `mkdir -p "$1" && chown "$2" "$1"`,
+              "sh",
+              dir,
+              `${containerUid}:${containerGid}`,
             ],
             (error) => {
               if (error) {

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -25,12 +25,12 @@ import {
   type InteractiveExecOptions,
 } from "../SandboxProvider.js";
 import type { MountConfig } from "../MountConfig.js";
+import type { SelinuxLabel } from "../mountUtils.js";
 import { defaultImageName, resolveUserMounts } from "../mountUtils.js";
 
 export interface DockerOptions {
   /** Docker image name (default: derived from repo directory name). */
   readonly imageName?: string;
-  /**
    * The UID of the `agent` user inside the container image (default: host UID via `process.getuid()`, or 1000).
    *
    * Must match the UID baked into the image at build time. Used as the `--user` flag value
@@ -43,6 +43,14 @@ export interface DockerOptions {
    * Must match the GID baked into the image at build time. Used as the `--user` flag value.
    */
   readonly containerGid?: number;
+  /**
+   * SELinux volume label suffix applied to bind mounts.
+   *
+   * - `"z"` — shared label (default). No-op on non-SELinux systems.
+   * - `"Z"` — private label; only this container can access the mount.
+   * - `false` — disable labeling entirely.
+   */
+  readonly selinuxLabel?: SelinuxLabel;
   /**
    * Additional host directories to bind-mount into the sandbox.
    *
@@ -71,6 +79,7 @@ export interface DockerOptions {
  */
 export const docker = (options?: DockerOptions): SandboxProvider => {
   const configuredImageName = options?.imageName;
+  const selinuxLabel = options?.selinuxLabel ?? "z";
   const sandboxHomedir = "/home/agent";
   const userMounts = options?.mounts
     ? resolveUserMounts(options.mounts, sandboxHomedir)
@@ -124,6 +133,7 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
             workdir: worktreePath,
             user: `${containerUid}:${containerGid}`,
             network: options?.network,
+            selinuxLabel,
           },
         ),
       );

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -26,7 +26,11 @@ import {
 } from "../SandboxProvider.js";
 import type { MountConfig } from "../MountConfig.js";
 import type { SelinuxLabel } from "../mountUtils.js";
-import { defaultImageName, resolveUserMounts } from "../mountUtils.js";
+import {
+  defaultImageName,
+  resolveUserMounts,
+  processFileMountParents,
+} from "../mountUtils.js";
 
 export interface DockerOptions {
   /** Docker image name (default: derived from repo directory name). */
@@ -84,6 +88,12 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
   const userMounts = options?.mounts
     ? resolveUserMounts(options.mounts, sandboxHomedir)
     : [];
+  // Validate file mounts and collect parent dirs to create at container start.
+  // Throws at construction time if any file mount parent is outside sandboxHomedir.
+  const parentDirsToCreate = processFileMountParents(
+    userMounts,
+    sandboxHomedir,
+  );
 
   return createBindMountSandboxProvider({
     name: "docker",
@@ -137,6 +147,35 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
           },
         ),
       );
+
+      // Create parent directories for file mounts and chown to the container user
+      for (const dir of parentDirsToCreate) {
+        await new Promise<void>((resolve, reject) => {
+          execFile(
+            "docker",
+            [
+              "exec",
+              "--user",
+              "0:0",
+              containerName,
+              "sh",
+              "-c",
+              `mkdir -p "${dir}" && chown ${hostUid}:${hostGid} "${dir}"`,
+            ],
+            (error) => {
+              if (error) {
+                reject(
+                  new Error(
+                    `Failed to create parent directory '${dir}' in container: ${error.message}`,
+                  ),
+                );
+              } else {
+                resolve();
+              }
+            },
+          );
+        });
+      }
 
       // Set up signal handlers for cleanup
       const onExit = () => {

--- a/src/sandboxes/podman.test.ts
+++ b/src/sandboxes/podman.test.ts
@@ -511,9 +511,7 @@ describe("podman()", () => {
     // Verify no chown exec call was made
     const chownCall = mockExecFile.mock.calls.find(
       ([cmd, args]) =>
-        cmd === "podman" &&
-        Array.isArray(args) &&
-        args.includes("chown"),
+        cmd === "podman" && Array.isArray(args) && args.includes("chown"),
     );
     expect(chownCall).toBeUndefined();
 
@@ -662,11 +660,13 @@ describe("podman()", () => {
     // Should run as root
     expect(mkdirArgs).toContain("--user");
     expect(mkdirArgs[mkdirArgs.indexOf("--user") + 1]).toBe("0:0");
-    // Should target /home/agent/.codex with container UID
-    const shCmd = mkdirArgs[mkdirArgs.length - 1]!;
+    // Script body is fixed; the dir and uid:gid are passed as argv after `sh`
+    const shCmdIdx = mkdirArgs.indexOf("-c");
+    const shCmd = mkdirArgs[shCmdIdx + 1]!;
     expect(shCmd).toContain("mkdir -p");
-    expect(shCmd).toContain("/home/agent/.codex");
-    expect(shCmd).toContain("chown 1000:1000");
+    expect(shCmd).toContain("chown");
+    expect(mkdirArgs).toContain("/home/agent/.codex");
+    expect(mkdirArgs).toContain("1000:1000");
 
     unlinkSync(tmpFile);
     rmdirSync(tmpDir);
@@ -696,9 +696,7 @@ describe("podman()", () => {
         cmd === "podman" &&
         Array.isArray(args) &&
         args[0] === "exec" &&
-        args.some(
-          (a: string) => typeof a === "string" && a.includes("mkdir"),
-        ),
+        args.some((a: string) => typeof a === "string" && a.includes("mkdir")),
     );
     expect(mkdirCall).toBeUndefined();
 
@@ -712,11 +710,9 @@ describe("podman()", () => {
 
     expect(() =>
       podman({
-        mounts: [
-          { hostPath: tmpFile, sandboxPath: "/opt/foo/config.json" },
-        ],
+        mounts: [{ hostPath: tmpFile, sandboxPath: "/opt/foo/config.json" }],
       }),
-    ).toThrow(/outside the agent home directory/);
+    ).toThrow(/outside the sandbox home directory/);
 
     unlinkSync(tmpFile);
     rmdirSync(tmpDir);

--- a/src/sandboxes/podman.test.ts
+++ b/src/sandboxes/podman.test.ts
@@ -15,7 +15,9 @@ vi.mock("node:child_process", async () => {
 });
 
 import { execFile, execFileSync } from "node:child_process";
-import { homedir } from "node:os";
+import { writeFileSync, mkdtempSync, unlinkSync, rmdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
 import { podman, defaultImageName } from "./podman.js";
 import type { BindMountSandboxHandle } from "../SandboxProvider.js";
 
@@ -617,6 +619,107 @@ describe("podman()", () => {
     ).rejects.toThrow("podman cp (in) failed");
 
     await handle.close();
+  });
+
+  it("runs mkdir+chown for file mount parent dirs after container start", async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "podman-test-"));
+    const tmpFile = join(tmpDir, "auth.json");
+    writeFileSync(tmpFile, "{}");
+
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({
+      mounts: [
+        { hostPath: tmpFile, sandboxPath: "/home/agent/.codex/auth.json" },
+      ],
+    });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    // Find the podman exec call for mkdir+chown
+    const mkdirCall = mockExecFile.mock.calls.find(
+      ([cmd, args]) =>
+        cmd === "podman" &&
+        Array.isArray(args) &&
+        args[0] === "exec" &&
+        args.some(
+          (a: string) =>
+            typeof a === "string" && a.includes("mkdir") && a.includes("chown"),
+        ),
+    );
+    expect(mkdirCall).toBeDefined();
+    const mkdirArgs = mkdirCall![1] as string[];
+    // Should run as root
+    expect(mkdirArgs).toContain("--user");
+    expect(mkdirArgs[mkdirArgs.indexOf("--user") + 1]).toBe("0:0");
+    // Should target /home/agent/.codex with container UID
+    const shCmd = mkdirArgs[mkdirArgs.length - 1]!;
+    expect(shCmd).toContain("mkdir -p");
+    expect(shCmd).toContain("/home/agent/.codex");
+    expect(shCmd).toContain("chown 1000:1000");
+
+    unlinkSync(tmpFile);
+    rmdirSync(tmpDir);
+    await handle.close();
+  });
+
+  it("does not run mkdir+chown when there are no file mounts", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    // Should NOT have any podman exec for mkdir
+    const mkdirCall = mockExecFile.mock.calls.find(
+      ([cmd, args]) =>
+        cmd === "podman" &&
+        Array.isArray(args) &&
+        args[0] === "exec" &&
+        args.some(
+          (a: string) => typeof a === "string" && a.includes("mkdir"),
+        ),
+    );
+    expect(mkdirCall).toBeUndefined();
+
+    await handle.close();
+  });
+
+  it("throws at construction time for file mount with parent outside /home/agent", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "podman-test-"));
+    const tmpFile = join(tmpDir, "config.json");
+    writeFileSync(tmpFile, "{}");
+
+    expect(() =>
+      podman({
+        mounts: [
+          { hostPath: tmpFile, sandboxPath: "/opt/foo/config.json" },
+        ],
+      }),
+    ).toThrow(/outside the agent home directory/);
+
+    unlinkSync(tmpFile);
+    rmdirSync(tmpDir);
   });
 
   it("includes timeout on signal handler cleanup", async () => {

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -202,7 +202,10 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
               containerName,
               "sh",
               "-c",
-              `mkdir -p "${dir}" && chown ${containerUid}:${containerGid} "${dir}"`,
+              `mkdir -p "$1" && chown "$2" "$1"`,
+              "sh",
+              dir,
+              `${containerUid}:${containerGid}`,
             ],
             (error) => {
               if (error) {
@@ -435,4 +438,3 @@ const checkPodmanMachine = (): Promise<void> =>
       },
     );
   });
-

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -28,6 +28,7 @@ import {
   defaultImageName,
   resolveUserMounts,
   formatVolumeMount,
+  processFileMountParents,
 } from "../mountUtils.js";
 
 export interface PodmanOptions {
@@ -102,6 +103,12 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
   const userMounts = options?.mounts
     ? resolveUserMounts(options.mounts, sandboxHomedir)
     : [];
+  // Validate file mounts and collect parent dirs to create at container start.
+  // Throws at construction time if any file mount parent is outside sandboxHomedir.
+  const parentDirsToCreate = processFileMountParents(
+    userMounts,
+    sandboxHomedir,
+  );
 
   return createBindMountSandboxProvider({
     name: "podman",
@@ -182,6 +189,35 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
           },
         );
       });
+
+      // Create parent directories for file mounts and chown to the container user
+      for (const dir of parentDirsToCreate) {
+        await new Promise<void>((resolve, reject) => {
+          execFile(
+            "podman",
+            [
+              "exec",
+              "--user",
+              "0:0",
+              containerName,
+              "sh",
+              "-c",
+              `mkdir -p "${dir}" && chown ${containerUid}:${containerGid} "${dir}"`,
+            ],
+            (error) => {
+              if (error) {
+                reject(
+                  new Error(
+                    `Failed to create parent directory '${dir}' in container: ${error.message}`,
+                  ),
+                );
+              } else {
+                resolve();
+              }
+            },
+          );
+        });
+      }
 
       // Set up signal handlers for cleanup
       const onExit = () => {

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -23,7 +23,12 @@ import {
   type InteractiveExecOptions,
 } from "../SandboxProvider.js";
 import type { MountConfig } from "../MountConfig.js";
-import { defaultImageName, resolveUserMounts } from "../mountUtils.js";
+import type { SelinuxLabel } from "../mountUtils.js";
+import {
+  defaultImageName,
+  resolveUserMounts,
+  formatVolumeMount,
+} from "../mountUtils.js";
 
 export interface PodmanOptions {
   /** Podman image name (default: derived from repo directory name). */
@@ -35,7 +40,7 @@ export interface PodmanOptions {
    * - `"Z"` — private label; only this container can access the mount.
    * - `false` — disable labeling entirely.
    */
-  readonly selinuxLabel?: "z" | "Z" | false;
+  readonly selinuxLabel?: SelinuxLabel;
   /**
    * User namespace mode for rootless Podman.
    *
@@ -395,14 +400,3 @@ const checkPodmanMachine = (): Promise<void> =>
     );
   });
 
-const formatVolumeMount = (
-  mount: { hostPath: string; sandboxPath: string; readonly?: boolean },
-  selinuxLabel: PodmanOptions["selinuxLabel"],
-): string => {
-  const base = `${mount.hostPath}:${mount.sandboxPath}`;
-  const options = [mount.readonly ? "ro" : undefined, selinuxLabel || undefined]
-    .filter((option): option is string => option !== undefined)
-    .join(",");
-
-  return options ? `${base}:${options}` : base;
-};


### PR DESCRIPTION
Two mount-hardening improvements for the Docker and Podman sandbox providers:

1. **SELinux label support for Docker** (#575): Promotes `formatVolumeMount` from `src/sandboxes/podman.ts` into the shared `src/mountUtils.ts` so both providers use the same volume-mount formatter. Adds `selinuxLabel?: "z" | "Z" | false` to `DockerOptions` (default `"z"`), matching Podman's existing surface. The `:z` suffix is silently ignored on non-SELinux Docker, so this is a no-op on those platforms and a fix on Fedora/RHEL/CentOS.

2. **Auto-create parent dirs for file mounts** (#574): Detects single-file bind mounts whose parent directory doesn't exist in the image. For mounts under `/home/agent`, runs `mkdir -p` + non-recursive `chown agent:agent` at container start. For mounts outside `/home/agent`, fails at config time with a clear error and remediation steps. Applies to both Docker and Podman providers.

Both changes coordinate on `mountUtils.ts` to avoid merge conflicts.

Closes #574, #575. PR description references `docs/research/permissions-systemic-fix.md` §1.B and §1.C.

Closes #575