### PR TITLE
feat: dockerCompose() sandbox provider (#471)

### DIFF
--- a/.changeset/docker-compose-provider.md
+++ b/.changeset/docker-compose-provider.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add a `dockerCompose()` sandbox provider that delegates container configuration to a user-managed `docker-compose.yml`. Sandcastle invokes `docker compose run -d` against a service (default name `agent`) and injects only the per-run worktree bind mount, workdir, and env vars; image, networks, GPU reservations, resource limits, and dependent services live in the compose file. Options: `composeFile`, `serviceName`, `projectDirectory`, `projectName`, `mounts`, `env`. Closes the long-running ask in #471.

--- a/README.md
+++ b/README.md
@@ -67,12 +67,28 @@ await run({
 
 Sandcastle uses a `SandboxProvider` to create isolated environments. The `sandbox` option on `run()` and `createSandbox()` accepts any provider. A no-sandbox option is also available for `interactive()` and `wt.interactive()`. Built-in providers:
 
-| Provider   | Import path                                | Type       | Accepted by                                   |
-| ---------- | ------------------------------------------ | ---------- | --------------------------------------------- |
-| Docker     | `@ai-hero/sandcastle/sandboxes/docker`     | Bind-mount | `run()`, `createSandbox()`, `interactive()`   |
-| Podman     | `@ai-hero/sandcastle/sandboxes/podman`     | Bind-mount | `run()`, `createSandbox()`, `interactive()`   |
-| Vercel     | `@ai-hero/sandcastle/sandboxes/vercel`     | Isolated   | `run()`, `createSandbox()`, `interactive()`   |
-| No-sandbox | `@ai-hero/sandcastle/sandboxes/no-sandbox` | None       | `interactive()`, `wt.interactive()` (default) |
+| Provider       | Import path                                    | Type       | Accepted by                                   |
+| -------------- | ---------------------------------------------- | ---------- | --------------------------------------------- |
+| Docker         | `@ai-hero/sandcastle/sandboxes/docker`         | Bind-mount | `run()`, `createSandbox()`, `interactive()`   |
+| Docker Compose | `@ai-hero/sandcastle/sandboxes/docker-compose` | Bind-mount | `run()`, `createSandbox()`, `interactive()`   |
+| Podman         | `@ai-hero/sandcastle/sandboxes/podman`         | Bind-mount | `run()`, `createSandbox()`, `interactive()`   |
+| Vercel         | `@ai-hero/sandcastle/sandboxes/vercel`         | Isolated   | `run()`, `createSandbox()`, `interactive()`   |
+| No-sandbox     | `@ai-hero/sandcastle/sandboxes/no-sandbox`     | None       | `interactive()`, `wt.interactive()` (default) |
+
+Use `dockerCompose()` when the per-run container needs config that doesn't fit on `DockerOptions` — GPUs, custom resource limits, or dependent services. The compose file owns image, networks, GPU reservations, and dependencies; sandcastle injects only the worktree mount and workdir.
+
+```typescript
+import { dockerCompose } from "@ai-hero/sandcastle/sandboxes/docker-compose";
+
+await run({
+  agent: claudeCode("claude-opus-4-6"),
+  sandbox: dockerCompose({
+    composeFile: ".sandcastle/docker-compose.yml",
+    // serviceName defaults to "agent"
+  }),
+  prompt: "...",
+});
+```
 
 Worktree methods (`wt.run()`, `wt.interactive()`, `wt.createSandbox()`) accept the same providers as their top-level counterparts. `wt.interactive()` defaults to `noSandbox()` when no sandbox is specified.
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
       "import": "./dist/sandboxes/docker.js",
       "types": "./dist/sandboxes/docker.d.ts"
     },
+    "./sandboxes/docker-compose": {
+      "import": "./dist/sandboxes/docker-compose.js",
+      "types": "./dist/sandboxes/docker-compose.d.ts"
+    },
     "./sandboxes/vercel": {
       "import": "./dist/sandboxes/vercel.js",
       "types": "./dist/sandboxes/vercel.d.ts"

--- a/src/DockerComposeLifecycle.test.ts
+++ b/src/DockerComposeLifecycle.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+import { execFile } from "node:child_process";
+import { startContainer, removeContainer } from "./DockerComposeLifecycle.js";
+
+const mockExecFile = vi.mocked(execFile);
+
+afterEach(() => {
+  mockExecFile.mockReset();
+});
+
+const okExecFile = () => {
+  mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+    cb(null, "", "");
+    return undefined as any;
+  });
+};
+
+const findCall = (predicate: (args: string[]) => boolean) =>
+  mockExecFile.mock.calls.find(
+    ([, args]) => Array.isArray(args) && predicate(args as string[]),
+  );
+
+const findRunCall = () =>
+  findCall((args) => args[0] === "compose" && args.includes("run"));
+
+describe("DockerComposeLifecycle.startContainer", () => {
+  it("invokes 'docker compose run -d --name <name> <service>'", async () => {
+    okExecFile();
+
+    await Effect.runPromise(
+      startContainer("ctr", "agent", {}, { projectDirectory: "/repo" }),
+    );
+
+    const runCall = findRunCall();
+    expect(runCall).toBeDefined();
+    const args = runCall![1] as string[];
+    expect(args[0]).toBe("compose");
+    expect(args).toContain("run");
+    expect(args).toContain("-d");
+    const nameIdx = args.indexOf("--name");
+    expect(nameIdx).toBeGreaterThan(-1);
+    expect(args[nameIdx + 1]).toBe("ctr");
+    // service name is the final positional
+    expect(args[args.length - 1]).toBe("agent");
+  });
+
+  it("passes --project-directory when projectDirectory is provided", async () => {
+    okExecFile();
+
+    await Effect.runPromise(
+      startContainer("ctr", "agent", {}, { projectDirectory: "/repo" }),
+    );
+
+    const runCall = findRunCall();
+    const args = runCall![1] as string[];
+    const idx = args.indexOf("--project-directory");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("/repo");
+  });
+
+  it("passes -f when composeFile is provided", async () => {
+    okExecFile();
+
+    await Effect.runPromise(
+      startContainer(
+        "ctr",
+        "agent",
+        {},
+        {
+          composeFile: "/repo/.sandcastle/docker-compose.yml",
+        },
+      ),
+    );
+
+    const runCall = findRunCall();
+    const args = runCall![1] as string[];
+    const idx = args.indexOf("-f");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("/repo/.sandcastle/docker-compose.yml");
+  });
+
+  it("passes -p when projectName is provided", async () => {
+    okExecFile();
+
+    await Effect.runPromise(
+      startContainer("ctr", "agent", {}, { projectName: "sandcastle-abc" }),
+    );
+
+    const runCall = findRunCall();
+    const args = runCall![1] as string[];
+    const idx = args.indexOf("-p");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("sandcastle-abc");
+  });
+
+  it("passes --workdir when workdir is provided", async () => {
+    okExecFile();
+
+    await Effect.runPromise(
+      startContainer("ctr", "agent", {}, { workdir: "/home/agent/workspace" }),
+    );
+
+    const runCall = findRunCall();
+    const args = runCall![1] as string[];
+    const idx = args.indexOf("--workdir");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("/home/agent/workspace");
+  });
+
+  it("passes -e flags for env vars", async () => {
+    okExecFile();
+
+    await Effect.runPromise(
+      startContainer("ctr", "agent", { FOO: "bar", BAZ: "qux" }),
+    );
+
+    const runCall = findRunCall();
+    const args = runCall![1] as string[];
+    const fooIdx = args.findIndex((a) => a === "FOO=bar");
+    expect(fooIdx).toBeGreaterThan(-1);
+    expect(args[fooIdx - 1]).toBe("-e");
+    const bazIdx = args.findIndex((a) => a === "BAZ=qux");
+    expect(bazIdx).toBeGreaterThan(-1);
+    expect(args[bazIdx - 1]).toBe("-e");
+  });
+
+  it("uses -v host:container for volume mounts (compose run rejects --mount)", async () => {
+    okExecFile();
+
+    await Effect.runPromise(
+      startContainer(
+        "ctr",
+        "agent",
+        {},
+        {
+          volumeMounts: [
+            { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
+          ],
+        },
+      ),
+    );
+
+    const runCall = findRunCall();
+    const args = runCall![1] as string[];
+    expect(args).not.toContain("--mount");
+    expect(args).toContain("-v");
+    const idx = args.indexOf("-v");
+    expect(args[idx + 1]).toBe("/host/path:/sandbox/path");
+  });
+
+  it("handles Windows-style host paths with drive-letter colons in -v", async () => {
+    okExecFile();
+
+    await Effect.runPromise(
+      startContainer(
+        "ctr",
+        "agent",
+        {},
+        {
+          volumeMounts: [
+            {
+              hostPath: "C:/Users/x/repo",
+              sandboxPath: "/home/agent/workspace",
+            },
+          ],
+        },
+      ),
+    );
+
+    const runCall = findRunCall();
+    const args = runCall![1] as string[];
+    const idx = args.indexOf("-v");
+    expect(args[idx + 1]).toBe("C:/Users/x/repo:/home/agent/workspace");
+  });
+
+  it("appends :ro suffix for read-only mounts", async () => {
+    okExecFile();
+
+    await Effect.runPromise(
+      startContainer(
+        "ctr",
+        "agent",
+        {},
+        {
+          volumeMounts: [
+            {
+              hostPath: "/host/path",
+              sandboxPath: "/sandbox/path",
+              readonly: true,
+            },
+          ],
+        },
+      ),
+    );
+
+    const runCall = findRunCall();
+    const args = runCall![1] as string[];
+    const idx = args.indexOf("-v");
+    expect(args[idx + 1]).toBe("/host/path:/sandbox/path:ro");
+  });
+
+  it("does not pass UID-related flags (compose owns it via build args)", async () => {
+    okExecFile();
+
+    await Effect.runPromise(startContainer("ctr", "agent", {}));
+
+    const runCall = findRunCall();
+    const args = runCall![1] as string[];
+    expect(args).not.toContain("--user");
+  });
+
+  it("checks for existing container before run and rejects if present", async () => {
+    mockExecFile.mockImplementation((_cmd, args, _opts, cb: any) => {
+      if (Array.isArray(args) && args[0] === "ps") {
+        cb(null, "ctr\n", "");
+      } else {
+        cb(null, "", "");
+      }
+      return undefined as any;
+    });
+
+    await expect(
+      Effect.runPromise(startContainer("ctr", "agent", {})),
+    ).rejects.toThrow(/already exists/);
+  });
+});
+
+describe("DockerComposeLifecycle.removeContainer", () => {
+  it("calls docker stop then docker rm with the container name", async () => {
+    okExecFile();
+
+    await Effect.runPromise(removeContainer("ctr"));
+
+    const stopCall = findCall((args) => args[0] === "stop");
+    expect(stopCall).toBeDefined();
+    expect((stopCall![1] as string[])[1]).toBe("ctr");
+
+    const rmCall = findCall((args) => args[0] === "rm" && args[1] === "ctr");
+    expect(rmCall).toBeDefined();
+  });
+
+  it("ignores errors from stop and rm (best-effort cleanup)", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(new Error("not found"), "", "");
+      return undefined as any;
+    });
+
+    await expect(
+      Effect.runPromise(removeContainer("ctr")),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/DockerComposeLifecycle.ts
+++ b/src/DockerComposeLifecycle.ts
@@ -1,0 +1,126 @@
+import { Effect } from "effect";
+import { execFile } from "node:child_process";
+import { DockerError } from "./errors.js";
+
+const dockerExec = (args: string[]): Effect.Effect<string, DockerError> =>
+  Effect.async((resume) => {
+    execFile(
+      "docker",
+      args,
+      { maxBuffer: 10 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          resume(
+            Effect.fail(
+              new DockerError({
+                message:
+                  `docker ${args[0]} ${args[1] ?? ""} failed: ${stderr?.toString() || error.message}`.trim(),
+              }),
+            ),
+          );
+        } else {
+          resume(Effect.succeed(stdout.toString()));
+        }
+      },
+    );
+  });
+
+export interface VolumeMount {
+  readonly hostPath: string;
+  readonly sandboxPath: string;
+  readonly readonly?: boolean;
+}
+
+export interface ComposeStartContainerOptions {
+  readonly volumeMounts?: readonly VolumeMount[];
+  readonly workdir?: string;
+  /** Path to the compose file. When omitted, docker compose auto-discovers from projectDirectory. */
+  readonly composeFile?: string;
+  /** Project directory passed to `docker compose --project-directory`. */
+  readonly projectDirectory?: string;
+  /** Compose project name. When omitted, docker compose derives it from the project directory. */
+  readonly projectName?: string;
+}
+
+const composeBaseArgs = (options?: ComposeStartContainerOptions): string[] => {
+  const args = ["compose"];
+  if (options?.composeFile) args.push("-f", options.composeFile);
+  if (options?.projectDirectory)
+    args.push("--project-directory", options.projectDirectory);
+  if (options?.projectName) args.push("-p", options.projectName);
+  return args;
+};
+
+/**
+ * Start a one-off container for a compose service in detached mode.
+ *
+ * Equivalent to `docker compose run -d --name <containerName> ...flags <serviceName>`.
+ * Image, networks, GPU reservations, and dependent services come from the compose file —
+ * sandcastle only injects the per-run worktree mount, workdir, and env.
+ */
+export const startContainer = (
+  containerName: string,
+  serviceName: string,
+  env: Record<string, string>,
+  options?: ComposeStartContainerOptions,
+): Effect.Effect<void, DockerError> =>
+  Effect.gen(function* () {
+    const existing = yield* dockerExec([
+      "ps",
+      "-a",
+      "--filter",
+      `name=^${containerName}$`,
+      "--format",
+      "{{.Names}}",
+    ]);
+
+    if (existing.trim() === containerName) {
+      yield* Effect.fail(
+        new DockerError({
+          message: `Container '${containerName}' already exists. Run cleanup first.`,
+        }),
+      );
+    }
+
+    const envFlags = Object.entries(env).flatMap(([k, v]) => [
+      "-e",
+      `${k}=${v}`,
+    ]);
+
+    // docker compose run does not accept --mount (unlike docker run); use -v.
+    // On Windows, drive letters are recognised so `C:\path:/sandbox/path` parses
+    // correctly — the second colon is the separator.
+    const volumeFlags = (options?.volumeMounts ?? []).flatMap((mount) => [
+      "-v",
+      `${mount.hostPath}:${mount.sandboxPath}${mount.readonly ? ":ro" : ""}`,
+    ]);
+
+    const workdirFlags = options?.workdir ? ["--workdir", options.workdir] : [];
+
+    yield* dockerExec([
+      ...composeBaseArgs(options),
+      "run",
+      "-d",
+      "--name",
+      containerName,
+      ...envFlags,
+      ...volumeFlags,
+      ...workdirFlags,
+      serviceName,
+    ]);
+  });
+
+/**
+ * Stop and remove a container previously started by `docker compose run`.
+ *
+ * Uses plain `docker stop`/`docker rm` rather than `docker compose rm` because
+ * the container is named explicitly via `--name` and we don't need the compose
+ * project context for teardown.
+ */
+export const removeContainer = (
+  containerName: string,
+): Effect.Effect<void, DockerError> =>
+  Effect.gen(function* () {
+    yield* Effect.ignore(dockerExec(["stop", containerName]));
+    yield* Effect.ignore(dockerExec(["rm", containerName]));
+  });

--- a/src/sandboxes/docker-compose.test.ts
+++ b/src/sandboxes/docker-compose.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:child_process")>(
+      "node:child_process",
+    );
+
+  return {
+    ...actual,
+    execFile: vi.fn(),
+    execFileSync: vi.fn(),
+    spawn: vi.fn(),
+  };
+});
+
+import { execFile } from "node:child_process";
+import { dockerCompose } from "./docker-compose.js";
+import type { BindMountSandboxHandle } from "../SandboxProvider.js";
+
+const mockExecFile = vi.mocked(execFile);
+
+afterEach(() => {
+  mockExecFile.mockReset();
+});
+
+const okExecFile = () => {
+  mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+    const callback = rest[rest.length - 1];
+    callback(null, "", "");
+    return undefined as any;
+  });
+};
+
+const findRunArgs = (): string[] | undefined => {
+  const call = mockExecFile.mock.calls.find(
+    ([, args]) =>
+      Array.isArray(args) && args[0] === "compose" && args.includes("run"),
+  );
+  return call ? (call[1] as string[]) : undefined;
+};
+
+describe("dockerCompose()", () => {
+  it("returns a SandboxProvider with tag 'bind-mount' and name 'docker-compose'", () => {
+    const provider = dockerCompose();
+    expect(provider.tag).toBe("bind-mount");
+    expect(provider.name).toBe("docker-compose");
+  });
+
+  it("has a create function", () => {
+    const provider = dockerCompose();
+    expect(typeof provider.create).toBe("function");
+  });
+
+  it("does not have a branchStrategy property", () => {
+    const provider = dockerCompose();
+    expect("branchStrategy" in provider).toBe(false);
+  });
+
+  it("accepts a mounts option with valid paths", () => {
+    const provider = dockerCompose({
+      mounts: [{ hostPath: "~", sandboxPath: "/mnt/home" }],
+    });
+    expect(provider.tag).toBe("bind-mount");
+  });
+
+  it("throws at construction time if a mount hostPath does not exist", () => {
+    expect(() =>
+      dockerCompose({
+        mounts: [
+          {
+            hostPath: "/nonexistent/path/does/not/exist",
+            sandboxPath: "/mnt/cache",
+          },
+        ],
+      }),
+    ).toThrow("Mount hostPath does not exist");
+  });
+
+  it("throws at construction time if composeFile does not exist", () => {
+    expect(() =>
+      dockerCompose({
+        composeFile: "/nonexistent/docker-compose.yml",
+      }),
+    ).toThrow("Compose file does not exist");
+  });
+
+  it("accepts an env option", () => {
+    const provider = dockerCompose({ env: { MY_VAR: "hello" } });
+    expect(provider.env).toEqual({ MY_VAR: "hello" });
+  });
+
+  it("defaults env to empty object when not provided", () => {
+    const provider = dockerCompose();
+    expect(provider.env).toEqual({});
+  });
+
+  it("does not run UID pre-flight (no docker image inspect call)", async () => {
+    okExecFile();
+
+    const provider = dockerCompose();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const inspectCall = mockExecFile.mock.calls.find(
+      ([, args]) =>
+        Array.isArray(args) && args[0] === "image" && args[1] === "inspect",
+    );
+    expect(inspectCall).toBeUndefined();
+
+    await handle.close();
+  });
+
+  it("invokes 'docker compose run -d --name <name> agent' by default", async () => {
+    okExecFile();
+
+    const provider = dockerCompose();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const args = findRunArgs();
+    expect(args).toBeDefined();
+    expect(args![0]).toBe("compose");
+    expect(args).toContain("run");
+    expect(args).toContain("-d");
+    const nameIdx = args!.indexOf("--name");
+    expect(nameIdx).toBeGreaterThan(-1);
+    expect(args![nameIdx + 1]).toMatch(/^sandcastle-/);
+    expect(args![args!.length - 1]).toBe("agent");
+
+    await handle.close();
+  });
+
+  it("uses serviceName option when provided", async () => {
+    okExecFile();
+
+    const provider = dockerCompose({ serviceName: "worker" });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const args = findRunArgs();
+    expect(args![args!.length - 1]).toBe("worker");
+
+    await handle.close();
+  });
+
+  it("passes the worktree as a -v host:container volume", async () => {
+    okExecFile();
+
+    const provider = dockerCompose();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const args = findRunArgs()!;
+    const idx = args.indexOf("-v");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("/tmp/worktree:/home/agent/workspace");
+
+    await handle.close();
+  });
+
+  it("passes --workdir set to the worktree sandbox path", async () => {
+    okExecFile();
+
+    const provider = dockerCompose();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const args = findRunArgs()!;
+    const idx = args.indexOf("--workdir");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("/home/agent/workspace");
+
+    await handle.close();
+  });
+
+  it("does not pass --user (compose users own UID via build args)", async () => {
+    okExecFile();
+
+    const provider = dockerCompose();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const args = findRunArgs()!;
+    expect(args).not.toContain("--user");
+
+    await handle.close();
+  });
+
+  it("forwards composeFile, projectName, projectDirectory to docker compose", async () => {
+    okExecFile();
+
+    const provider = dockerCompose({
+      composeFile: "package.json",
+      projectName: "sandcastle-test",
+      projectDirectory: "/tmp/repo",
+    });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const args = findRunArgs()!;
+    const fIdx = args.indexOf("-f");
+    expect(fIdx).toBeGreaterThan(-1);
+    expect(args[fIdx + 1]).toMatch(/package\.json$/);
+    const pdIdx = args.indexOf("--project-directory");
+    expect(pdIdx).toBeGreaterThan(-1);
+    expect(args[pdIdx + 1]).toBe("/tmp/repo");
+    const pIdx = args.indexOf("-p");
+    expect(pIdx).toBeGreaterThan(-1);
+    expect(args[pIdx + 1]).toBe("sandcastle-test");
+
+    await handle.close();
+  });
+
+  it("copyFileIn calls docker cp with correct arguments", async () => {
+    okExecFile();
+
+    const provider = dockerCompose();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const bmHandle = handle as BindMountSandboxHandle;
+    await bmHandle.copyFileIn("/host/file.txt", "/sandbox/file.txt");
+
+    const cpCall = mockExecFile.mock.calls.find(
+      ([cmd, args]) =>
+        cmd === "docker" &&
+        Array.isArray(args) &&
+        args[0] === "cp" &&
+        args[1] === "/host/file.txt",
+    );
+    expect(cpCall).toBeDefined();
+    const cpArgs = cpCall![1] as string[];
+    expect(cpArgs[2]).toMatch(/^sandcastle-.*:\/sandbox\/file\.txt$/);
+
+    await handle.close();
+  });
+
+  it("copyFileOut calls docker cp with correct arguments", async () => {
+    okExecFile();
+
+    const provider = dockerCompose();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const bmHandle = handle as BindMountSandboxHandle;
+    await bmHandle.copyFileOut("/sandbox/output.txt", "/host/output.txt");
+
+    const cpCall = mockExecFile.mock.calls.find(
+      ([cmd, args]) =>
+        cmd === "docker" &&
+        Array.isArray(args) &&
+        args[0] === "cp" &&
+        args[2] === "/host/output.txt",
+    );
+    expect(cpCall).toBeDefined();
+    const cpArgs = cpCall![1] as string[];
+    expect(cpArgs[1]).toMatch(/^sandcastle-.*:\/sandbox\/output\.txt$/);
+
+    await handle.close();
+  });
+
+  it("copyFileIn rejects when docker cp fails", async () => {
+    mockExecFile.mockImplementation((_command, args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      if (Array.isArray(args) && args[0] === "cp") {
+        callback(new Error("no such file"));
+      } else {
+        callback(null, "", "");
+      }
+      return undefined as any;
+    });
+
+    const provider = dockerCompose();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const bmHandle = handle as BindMountSandboxHandle;
+    await expect(
+      bmHandle.copyFileIn("/nonexistent", "/sandbox/file.txt"),
+    ).rejects.toThrow("docker cp (in) failed");
+
+    await handle.close();
+  });
+});

--- a/src/sandboxes/docker-compose.ts
+++ b/src/sandboxes/docker-compose.ts
@@ -1,0 +1,312 @@
+/**
+ * Docker-compose sandbox provider — wraps a user-managed `docker-compose.yml`
+ * into a SandboxProvider.
+ *
+ * Sandcastle delegates container configuration (image, networks, GPUs,
+ * resource limits, dependent services) to the compose file. It only injects
+ * the per-run worktree bind mount, workdir, and env vars, then invokes
+ * `docker compose run -d`.
+ *
+ * Usage:
+ *   import { dockerCompose } from "sandcastle/sandboxes/docker-compose";
+ *   await run({
+ *     agent: claudeCode("claude-opus-4-6"),
+ *     sandbox: dockerCompose({ composeFile: ".sandcastle/docker-compose.yml" }),
+ *   });
+ */
+
+import {
+  execFile,
+  execFileSync,
+  spawn,
+  type StdioOptions,
+} from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { isAbsolute, resolve as resolvePath } from "node:path";
+import { createInterface } from "node:readline";
+import { Effect } from "effect";
+import { startContainer, removeContainer } from "../DockerComposeLifecycle.js";
+import {
+  createBindMountSandboxProvider,
+  type SandboxProvider,
+  type BindMountCreateOptions,
+  type BindMountSandboxHandle,
+  type ExecResult,
+  type InteractiveExecOptions,
+} from "../SandboxProvider.js";
+import type { MountConfig } from "../MountConfig.js";
+import { resolveUserMounts } from "../mountUtils.js";
+
+export interface DockerComposeOptions {
+  /**
+   * Path to the compose file. Resolved against `process.cwd()` if relative.
+   * When omitted, docker compose auto-discovers from the project directory.
+   *
+   * Common values: `".sandcastle/docker-compose.yml"`, `"docker-compose.yml"`.
+   */
+  readonly composeFile?: string;
+  /**
+   * Service name from the compose file to run. Defaults to `"agent"`.
+   */
+  readonly serviceName?: string;
+  /**
+   * Project directory passed to `docker compose --project-directory`.
+   * When omitted, defaults to `process.cwd()`. Relative paths inside the
+   * compose file resolve against this directory.
+   */
+  readonly projectDirectory?: string;
+  /**
+   * Compose project name (`-p` flag). When omitted, docker compose derives it
+   * from the project directory. Pass a unique value (e.g. per-session) to
+   * avoid collisions when multiple sandcastle runs share a project directory.
+   */
+  readonly projectName?: string;
+  /**
+   * Additional host directories to bind-mount into the sandbox.
+   *
+   * Each entry specifies a `hostPath` (tilde-expanded) and `sandboxPath`.
+   * If `hostPath` does not exist, sandbox creation fails with a clear error.
+   *
+   * These are merged with the worktree bind mount sandcastle injects.
+   * For mounts that should be visible to dependent services, declare them
+   * in the compose file instead.
+   */
+  readonly mounts?: readonly MountConfig[];
+  /** Environment variables injected by this provider. Merged at launch time with env resolver and agent provider env. */
+  readonly env?: Record<string, string>;
+}
+
+/**
+ * Create a docker-compose sandbox provider.
+ *
+ * The returned provider invokes `docker compose run -d` against the configured
+ * service. The compose file owns image, networks, GPU reservations, resource
+ * limits, and dependent services; sandcastle only injects the worktree mount
+ * and workdir.
+ */
+export const dockerCompose = (
+  options?: DockerComposeOptions,
+): SandboxProvider => {
+  const serviceName = options?.serviceName ?? "agent";
+  const sandboxHomedir = "/home/agent";
+  const userMounts = options?.mounts
+    ? resolveUserMounts(options.mounts, sandboxHomedir)
+    : [];
+
+  const composeFile = options?.composeFile
+    ? isAbsolute(options.composeFile)
+      ? options.composeFile
+      : resolvePath(process.cwd(), options.composeFile)
+    : undefined;
+
+  if (composeFile && !existsSync(composeFile)) {
+    throw new Error(
+      `Compose file does not exist: ${options?.composeFile} (resolved to ${composeFile})`,
+    );
+  }
+
+  return createBindMountSandboxProvider({
+    name: "docker-compose",
+    env: options?.env,
+    sandboxHomedir,
+    create: async (
+      createOptions: BindMountCreateOptions,
+    ): Promise<BindMountSandboxHandle> => {
+      const containerName = `sandcastle-${randomUUID()}`;
+
+      const worktreePath =
+        createOptions.mounts.find(
+          (m) => m.hostPath === createOptions.worktreePath,
+        )?.sandboxPath ?? "/home/agent/workspace";
+
+      const allMounts = [...createOptions.mounts, ...userMounts];
+      const volumeMounts = allMounts.map((m) => ({
+        hostPath: m.hostPath,
+        sandboxPath: m.sandboxPath,
+        readonly: m.readonly,
+      }));
+
+      const projectDirectory = options?.projectDirectory ?? process.cwd();
+
+      try {
+        await Effect.runPromise(
+          startContainer(
+            containerName,
+            serviceName,
+            {
+              ...createOptions.env,
+              HOME: "/home/agent",
+            },
+            {
+              volumeMounts,
+              workdir: worktreePath,
+              composeFile,
+              projectDirectory,
+              projectName: options?.projectName,
+            },
+          ),
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `docker compose run failed for service '${serviceName}': ${message}`,
+        );
+      }
+
+      const onExit = () => {
+        try {
+          execFileSync("docker", ["rm", "-f", containerName], {
+            stdio: "ignore",
+          });
+        } catch {
+          /* best-effort */
+        }
+      };
+      const onSignal = () => {
+        onExit();
+        process.exit(1);
+      };
+      process.on("exit", onExit);
+      process.on("SIGINT", onSignal);
+      process.on("SIGTERM", onSignal);
+
+      const handle: BindMountSandboxHandle = {
+        worktreePath,
+
+        exec: (
+          command: string,
+          opts?: {
+            onLine?: (line: string) => void;
+            cwd?: string;
+            sudo?: boolean;
+            stdin?: string;
+          },
+        ): Promise<ExecResult> => {
+          const effectiveCommand = opts?.sudo ? `sudo ${command}` : command;
+          const args = ["exec"];
+          if (opts?.stdin !== undefined) args.push("-i");
+          if (opts?.cwd) args.push("-w", opts.cwd);
+          args.push(containerName, "sh", "-c", effectiveCommand);
+
+          return new Promise((resolve, reject) => {
+            const proc = spawn("docker", args, {
+              stdio: [
+                opts?.stdin !== undefined ? "pipe" : "ignore",
+                "pipe",
+                "pipe",
+              ],
+            });
+
+            if (opts?.stdin !== undefined) {
+              proc.stdin!.write(opts.stdin);
+              proc.stdin!.end();
+            }
+
+            const stdoutChunks: string[] = [];
+            const stderrChunks: string[] = [];
+
+            if (opts?.onLine) {
+              const onLine = opts.onLine;
+              const rl = createInterface({ input: proc.stdout! });
+              rl.on("line", (line) => {
+                stdoutChunks.push(line);
+                onLine(line);
+              });
+            } else {
+              proc.stdout!.on("data", (chunk: Buffer) => {
+                stdoutChunks.push(chunk.toString());
+              });
+            }
+
+            proc.stderr!.on("data", (chunk: Buffer) => {
+              stderrChunks.push(chunk.toString());
+            });
+
+            proc.on("error", (error) => {
+              reject(new Error(`docker exec failed: ${error.message}`));
+            });
+
+            proc.on("close", (code) => {
+              resolve({
+                stdout: stdoutChunks.join(opts?.onLine ? "\n" : ""),
+                stderr: stderrChunks.join(""),
+                exitCode: code ?? 0,
+              });
+            });
+          });
+        },
+
+        interactiveExec: (
+          args: string[],
+          opts: InteractiveExecOptions,
+        ): Promise<{ exitCode: number }> => {
+          return new Promise((resolve, reject) => {
+            const dockerArgs = ["exec"];
+            if (
+              "isTTY" in opts.stdin &&
+              (opts.stdin as { isTTY?: boolean }).isTTY
+            ) {
+              dockerArgs.push("-it");
+            } else {
+              dockerArgs.push("-i");
+            }
+            if (opts.cwd) dockerArgs.push("-w", opts.cwd);
+            dockerArgs.push(containerName, ...args);
+
+            const proc = spawn("docker", dockerArgs, {
+              stdio: [opts.stdin, opts.stdout, opts.stderr] as StdioOptions,
+            });
+
+            proc.on("error", (error: Error) => {
+              reject(new Error(`docker exec failed: ${error.message}`));
+            });
+
+            proc.on("close", (code: number | null) => {
+              resolve({ exitCode: code ?? 0 });
+            });
+          });
+        },
+
+        copyFileIn: (hostPath: string, sandboxPath: string): Promise<void> =>
+          new Promise((resolve, reject) => {
+            execFile(
+              "docker",
+              ["cp", hostPath, `${containerName}:${sandboxPath}`],
+              (error) => {
+                if (error) {
+                  reject(new Error(`docker cp (in) failed: ${error.message}`));
+                } else {
+                  resolve();
+                }
+              },
+            );
+          }),
+
+        copyFileOut: (sandboxPath: string, hostPath: string): Promise<void> =>
+          new Promise((resolve, reject) => {
+            execFile(
+              "docker",
+              ["cp", `${containerName}:${sandboxPath}`, hostPath],
+              (error) => {
+                if (error) {
+                  reject(new Error(`docker cp (out) failed: ${error.message}`));
+                } else {
+                  resolve();
+                }
+              },
+            );
+          }),
+
+        close: async (): Promise<void> => {
+          process.removeListener("exit", onExit);
+          process.removeListener("SIGINT", onSignal);
+          process.removeListener("SIGTERM", onSignal);
+          await Effect.runPromise(removeContainer(containerName));
+        },
+      };
+
+      return handle;
+    },
+  });
+};


### PR DESCRIPTION
Closes #471.

Adds a `dockerCompose()` sandbox provider that delegates container
configuration to a user-managed `docker-compose.yml`. Sandcastle invokes
`docker compose run -d` against a service (default `agent`) and injects
only the per-run worktree bind mount, workdir, and env vars. Image,
networks, GPU reservations, resource limits, and dependent services live
in the compose file — meaning every Docker option is reachable today
without sandcastle adding a flag for each.

```ts
import { dockerCompose } from "@ai-hero/sandcastle/sandboxes/docker-compose";

await run({
  agent: claudeCode("claude-opus-4-6"),
  sandbox: dockerCompose({ composeFile: ".sandcastle/docker-compose.yml" }),
  prompt: "...",
});
```

## Notes for review

- **`--deps` not passed.** The issue body suggested `docker compose run --deps …`; in compose v2 dependent services run by default and only `--no-deps` opts out, so the flag is omitted.
- **`serviceName` shipped.** The issue listed an explicit service-name option as a "natural follow-up". Including it now keeps the API symmetric with `docker()` and avoids a follow-up release; happy to drop if you'd rather defer.
- **`projectName` shipped as the lower-level primitive.** The issue's `isolateDeps: true` follow-up can be built on top of this. Per-session isolation itself is left for that follow-up.
- **No UID pre-flight.** Compose users own UID via build args, so the docker provider's pre-flight check is intentionally skipped.
- **Compose file path verified at construction.** Misconfiguration fails fast, before a worktree is created.

## Tests

- `src/DockerComposeLifecycle.test.ts` (13 tests) covers the docker-compose CLI shape: argv layout, `-v` mounts (incl. Windows drive-letter colons), `:ro` suffix, `-f`/`-p`/`--project-directory`/`--workdir`/`-e` flags, no `--user`, pre-existing-container guard, best-effort cleanup.
- `src/sandboxes/docker-compose.test.ts` (18 tests) covers `dockerCompose()`: provider tag/name, mount validation, compose-file existence check, worktree volume, default workdir, `serviceName` override, `projectName`/`projectDirectory`/`composeFile` propagation, `copyFileIn`/`copyFileOut`.
- `npm run typecheck` and `npm run build` both green.
- End-to-end smoke run against a real compose file with NVIDIA GPU reservation: `docker compose run -d` started a real container, `nvidia-smi -L` from `handle.exec()` listed the host GPU inside the container, workdir and `close()` cleanup behaved as expected.

## Out of scope (per issue)

- `sandcastle init` scaffolding for a starter compose file
- `dockerCompose({ isolateDeps: true })` per-session project isolation

Changeset attached.