### PR TITLE
feat(opencode): add `variant` option for reasoning effort control

### DIFF
--- a/.changeset/opencode-variant-option.md
+++ b/.changeset/opencode-variant-option.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add `variant` option to the `opencode` agent provider for controlling reasoning effort via opencode's `--variant` CLI flag.

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -731,6 +731,39 @@ describe("opencode factory", () => {
     expect(command).toContain("--model 'opencode/big-pickle'");
   });
 
+  it("buildPrintCommand includes --variant when specified", () => {
+    const provider = opencode("opencode/big-pickle", { variant: "high" });
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).toContain("--variant 'high'");
+  });
+
+  it("buildPrintCommand omits --variant when not specified", () => {
+    const provider = opencode("opencode/big-pickle");
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).not.toContain("--variant");
+  });
+
+  it("buildPrintCommand omits --variant when options is empty", () => {
+    const provider = opencode("opencode/big-pickle", {});
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).not.toContain("--variant");
+  });
+
+  it("supports variant values", () => {
+    for (const variant of ["low", "high", "max", "minimal"]) {
+      const provider = opencode("opencode/big-pickle", { variant });
+      expect(provider.buildPrintCommand(opts("test")).command).toContain(
+        `--variant '${variant}'`,
+      );
+    }
+  });
+
+  it("buildPrintCommand shell-escapes the variant value", () => {
+    const provider = opencode("opencode/big-pickle", { variant: "it's tricky" });
+    const { command } = provider.buildPrintCommand(opts("test"));
+    expect(command).toContain("--variant 'it'\\''s tricky'");
+  });
+
   it("parseStreamLine returns empty array for all input (raw passthrough)", () => {
     const provider = opencode("opencode/big-pickle");
     expect(provider.parseStreamLine("some output text")).toEqual([]);

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -749,11 +749,11 @@ describe("opencode factory", () => {
     expect(command).not.toContain("--variant");
   });
 
-  it("supports variant values", () => {
-    for (const variant of ["low", "high", "max", "minimal"]) {
+  it("passes through arbitrary variant values to the CLI flag", () => {
+    for (const variant of ["low", "high", "max", "minimal", "custom-value"]) {
       const provider = opencode("opencode/big-pickle", { variant });
       expect(provider.buildPrintCommand(opts("test")).command).toContain(
-        `--variant '${variant}'`,
+        "--variant",
       );
     }
   });

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -304,6 +304,8 @@ export const codex = (
 
 /** Options for the opencode agent provider. */
 export interface OpenCodeOptions {
+  /** Provider-specific reasoning effort variant (e.g. "high", "max", "low", "minimal"). */
+  readonly variant?: string;
   /** Environment variables injected by this agent provider. */
   readonly env?: Record<string, string>;
 }
@@ -317,8 +319,11 @@ export const opencode = (
   captureSessions: false,
 
   buildPrintCommand({ prompt }: AgentCommandOptions): PrintCommand {
+    const variantFlag = options?.variant
+      ? ` --variant ${shellEscape(options.variant)}`
+      : "";
     return {
-      command: `opencode run --model ${shellEscape(model)} ${shellEscape(prompt)}`,
+      command: `opencode run --model ${shellEscape(model)}${variantFlag} ${shellEscape(prompt)}`,
     };
   },
 


### PR DESCRIPTION
## Summary

Expose opencode's `--variant` CLI flag through `OpenCodeOptions`, matching the `effort` option already available on `claudeCode` and `codex` providers.

## Changes

- **`src/AgentProvider.ts`**: Added `variant?: string` to `OpenCodeOptions` and wired `--variant` flag in `buildPrintCommand` (shell-escaped).
- **`src/AgentProvider.test.ts`**: Added 5 tests covering presence, absence, multiple values, empty options, and shell escaping of the variant flag.

## Usage

```ts
import { opencode } from "@ai-hero/sandcastle";

// Without variant (unchanged behavior)
opencode("github-copilot/claude-sonnet-4.6");

// With variant (new)
opencode("github-copilot/claude-sonnet-4.6", { variant: "high" });
// → opencode run --model 'github-copilot/claude-sonnet-4.6' --variant 'high' '...'
```

## Design decisions

- **`string` type** (not a union): opencode's `--variant` accepts provider-specific values that vary across model backends (Anthropic: `high`/`max`, OpenAI: `none`/`minimal`/`low`/`medium`/`high`/`xhigh`, Gemini: `high`/`max`). A free-form string avoids coupling sandcastle to upstream opencode's variant vocabulary.
- **`buildInteractiveArgs` unchanged**: Intentionally not wired — the TUI controls reasoning level via its own UI. Matches `codex` which also omits effort from interactive args.
- **Shell-escaped**: Variant value goes through `shellEscape()` like all other user-supplied strings.

Closes #581