### PR TITLE
feat(pi): add `thinking` option for reasoning level control

### DIFF
--- a/.changeset/pi-thinking-option.md
+++ b/.changeset/pi-thinking-option.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add `thinking` option to the `pi` agent provider for controlling reasoning level via pi's `--thinking` CLI flag.

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -268,6 +268,33 @@ describe("pi factory", () => {
     expect(command).toContain("--model 'claude-sonnet-4-6'");
   });
 
+  it("buildPrintCommand includes --thinking when specified", () => {
+    const provider = pi("claude-sonnet-4-6", { thinking: "high" });
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).toContain("--thinking high");
+  });
+
+  it("buildPrintCommand omits --thinking when not specified", () => {
+    const provider = pi("claude-sonnet-4-6");
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).not.toContain("--thinking");
+  });
+
+  it("buildPrintCommand omits --thinking when options is empty", () => {
+    const provider = pi("claude-sonnet-4-6", {});
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).not.toContain("--thinking");
+  });
+
+  it("supports all thinking levels", () => {
+    for (const thinking of ["off", "minimal", "low", "medium", "high", "xhigh"] as const) {
+      const provider = pi("claude-sonnet-4-6", { thinking });
+      expect(provider.buildPrintCommand(opts("test")).command).toContain(
+        `--thinking ${thinking}`,
+      );
+    }
+  });
+
   it("parseStreamLine extracts text from message_update event", () => {
     const provider = pi("claude-sonnet-4-6");
     const line = JSON.stringify({

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -189,6 +189,8 @@ const parsePiStreamLine = (line: string): ParsedStreamEvent[] => {
 
 /** Options for the pi agent provider. */
 export interface PiOptions {
+  /** Reasoning/thinking level for the agent. */
+  readonly thinking?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   /** Environment variables injected by this agent provider. */
   readonly env?: Record<string, string>;
 }
@@ -199,8 +201,11 @@ export const pi = (model: string, options?: PiOptions): AgentProvider => ({
   captureSessions: false,
 
   buildPrintCommand({ prompt }: AgentCommandOptions): PrintCommand {
+    const thinkingFlag = options?.thinking
+      ? ` --thinking ${options.thinking}`
+      : "";
     return {
-      command: `pi -p --mode json --no-session --model ${shellEscape(model)}`,
+      command: `pi -p --mode json --no-session${thinkingFlag} --model ${shellEscape(model)}`,
       stdin: prompt,
     };
   },


### PR DESCRIPTION
## Summary

Expose pi's `--thinking` CLI flag through `PiOptions`, matching the `effort` option on `claudeCode`/`codex` and `variant` on `opencode`.

## Changes

- **`src/AgentProvider.ts`**: Added `thinking?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh"` to `PiOptions` and wired `--thinking` flag in `buildPrintCommand`.
- **`src/AgentProvider.test.ts`**: Added 4 tests covering presence, absence, empty options, and all 6 thinking levels.

## Usage

```ts
import { pi } from "@ai-hero/sandcastle";

// Without thinking (unchanged behavior)
pi("claude-sonnet-4-6");

// With thinking (new)
pi("claude-sonnet-4-6", { thinking: "high" });
// → pi -p --mode json --no-session --thinking high --model 'claude-sonnet-4-6'
```

## Design decisions

- **Typed union** (not `string`): Pi has a fixed, documented set of 6 levels (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`). Using a union provides compile-time safety — same pattern as `claudeCode` and `codex`.
- **No shell-escaping needed**: Values come from a typed union of known-safe alphanumeric strings — same approach as `claudeCode`'s `effort`.
- **`buildInteractiveArgs` unchanged**: Pi's TUI manages thinking level via Shift+Tab — no need to pass it on the interactive command line.

Closes #583