### PR TITLE
fix: harden Dockerfile templates — eliminate silent failures, use APT best practices

### DIFF
--- a/.changeset/harden-dockerfile-templates.md
+++ b/.changeset/harden-dockerfile-templates.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Harden Dockerfile templates: eliminate pipe patterns that silently swallow download failures, use `--no-install-recommends`, and store APT keyrings in `/etc/apt/keyrings/`.

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -1,18 +1,20 @@
 FROM node:22-bookworm
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   git \
   curl \
   jq \
   && rm -rf /var/lib/apt/lists/*
 
-# Install GitHub CLI
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-  && apt-get update && apt-get install -y gh \
+# GitHub CLI
+RUN install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+     -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && chmod a+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+     > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update && apt-get install -y --no-install-recommends gh \
   && rm -rf /var/lib/apt/lists/*
 
 # Build-args for UID/GID alignment: sandcastle docker build-image

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -59,7 +59,7 @@ export interface AgentEntry {
 const CLAUDE_CODE_DOCKERFILE = `FROM node:22-bookworm
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \\
+RUN apt-get update && apt-get install -y --no-install-recommends \\
   git \\
   curl \\
   jq \\
@@ -94,7 +94,7 @@ ENTRYPOINT ["sleep", "infinity"]
 const PI_DOCKERFILE = `FROM node:22-bookworm
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \\
+RUN apt-get update && apt-get install -y --no-install-recommends \\
   git \\
   curl \\
   jq \\
@@ -127,7 +127,7 @@ ENTRYPOINT ["sleep", "infinity"]
 const CODEX_DOCKERFILE = `FROM node:22-bookworm
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \\
+RUN apt-get update && apt-get install -y --no-install-recommends \\
   git \\
   curl \\
   jq \\
@@ -160,7 +160,7 @@ ENTRYPOINT ["sleep", "infinity"]
 const OPENCODE_DOCKERFILE = `FROM node:22-bookworm
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \\
+RUN apt-get update && apt-get install -y --no-install-recommends \\
   git \\
   curl \\
   jq \\
@@ -249,16 +249,18 @@ export interface BacklogManagerEntry {
   readonly envExample: string;
 }
 
-const GITHUB_CLI_TOOLS = `# Install GitHub CLI
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \\
-  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \\
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \\
-  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \\
-  && apt-get update && apt-get install -y gh \\
+const GITHUB_CLI_TOOLS = `# GitHub CLI
+RUN install -m 0755 -d /etc/apt/keyrings \\
+  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \\
+     -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \\
+  && chmod a+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \\
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \\
+     > /etc/apt/sources.list.d/github-cli.list \\
+  && apt-get update && apt-get install -y --no-install-recommends gh \\
   && rm -rf /var/lib/apt/lists/*`;
 
 const BEADS_TOOLS = `# Install system dependencies for Beads
-RUN apt-get update && apt-get install -y \\
+RUN apt-get update && apt-get install -y --no-install-recommends \\
   dpkg-dev \\
   libicu72 \\
   && rm -rf /var/lib/apt/lists/* \\


### PR DESCRIPTION
## Summary

Harden all Dockerfile templates to eliminate silent download failures and follow APT best practices.

## Problem

The current `GITHUB_CLI_TOOLS` constant and all agent Dockerfile templates use pipe patterns that silently swallow failures:

```dockerfile
# Current — if curl fails, dd exits 0 with empty file → cryptic GPG error later
RUN curl -fsSL https://...keyring.gpg \
  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
```

## Solution

```dockerfile
# Fixed — curl failure stops the build immediately
RUN install -m 0755 -d /etc/apt/keyrings \
  && curl -fsSL https://...keyring.gpg \
     -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
  && chmod a+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
```

## Changes

- **`src/InitService.ts`**: Hardened `GITHUB_CLI_TOOLS` constant (no pipes, `/etc/apt/keyrings/`, `--no-install-recommends`). Added `--no-install-recommends` to base packages in all 4 agent Dockerfile templates + `BEADS_TOOLS`.
- **`.sandcastle/Dockerfile`**: Same hardening applied to the repo's dogfood Dockerfile.
- **`.changeset/harden-dockerfile-templates.md`**: Patch changeset.

## What this fixes for users

- `sandcastle init` now generates Dockerfiles that fail fast on network errors instead of building silently broken images
- Smaller images via `--no-install-recommends`
- Keyrings in the modern `/etc/apt/keyrings/` location per Debian policy

Closes #593