### PR TITLE
feat(init): add Gitea and Forgejo backlog manager support

### DIFF
--- a/.changeset/gitea-forgejo-backlog.md
+++ b/.changeset/gitea-forgejo-backlog.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": minor
+---
+
+Add Gitea Issues and Forgejo Issues as backlog manager choices in `sandcastle init`. The two share a single curl + jq based adapter because Forgejo is a soft-fork of Gitea and exposes the same `/api/v1` surface; only the env var names (`GITEA_*` vs `FORGEJO_*`) differ. Issue listing emits the same `{number, title, body, labels: [{name}], comments: [{body}]}` shape as the GitHub Issues path so existing templates work unchanged.

--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ console.log(result.output.score); // typed as number
 
 ### Templates
 
-`sandcastle init` prompts you to choose a sandbox provider (Docker or Podman), a backlog manager (GitHub Issues or Beads), and a template, which scaffolds a ready-to-use prompt and `main.mts` suited to a specific workflow. If your project's `package.json` has `"type": "module"`, the file will be named `main.ts` instead. Five templates are available:
+`sandcastle init` prompts you to choose a sandbox provider (Docker or Podman), a backlog manager (GitHub Issues, Gitea Issues, Forgejo Issues, or Beads), and a template, which scaffolds a ready-to-use prompt and `main.mts` suited to a specific workflow. If your project's `package.json` has `"type": "module"`, the file will be named `main.ts` instead. Five templates are available:
 
 | Template                       | Description                                                               |
 | ------------------------------ | ------------------------------------------------------------------------- |

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -201,6 +201,38 @@ describe("InitService scaffold", () => {
     expect(envExample).not.toContain("GH_TOKEN=");
   });
 
+  it("generates .env.example with GITEA_* vars when backlog manager is gitea-issues", async () => {
+    const dir = await makeDir();
+    await runScaffold(dir, {
+      backlogManager: getBacklogManager("gitea-issues"),
+    });
+
+    const envExample = await readFile(
+      join(dir, ".sandcastle", ".env.example"),
+      "utf-8",
+    );
+    expect(envExample).toContain("GITEA_URL=");
+    expect(envExample).toContain("GITEA_TOKEN=");
+    expect(envExample).toContain("GITEA_REPO=");
+    expect(envExample).not.toContain("GH_TOKEN=");
+  });
+
+  it("generates .env.example with FORGEJO_* vars when backlog manager is forgejo-issues", async () => {
+    const dir = await makeDir();
+    await runScaffold(dir, {
+      backlogManager: getBacklogManager("forgejo-issues"),
+    });
+
+    const envExample = await readFile(
+      join(dir, ".sandcastle", ".env.example"),
+      "utf-8",
+    );
+    expect(envExample).toContain("FORGEJO_URL=");
+    expect(envExample).toContain("FORGEJO_TOKEN=");
+    expect(envExample).toContain("FORGEJO_REPO=");
+    expect(envExample).not.toContain("GH_TOKEN=");
+  });
+
   it("does not scaffold config.json for blank template", async () => {
     const dir = await makeDir();
     await runScaffold(dir);
@@ -1152,10 +1184,12 @@ describe("InitService scaffold", () => {
   // --- Backlog manager ---
 
   describe("Backlog manager registry", () => {
-    it("listBacklogManagers returns github-issues and beads", () => {
+    it("listBacklogManagers returns github-issues, beads, gitea-issues, and forgejo-issues", () => {
       const managers = listBacklogManagers();
       expect(managers.some((m) => m.name === "github-issues")).toBe(true);
       expect(managers.some((m) => m.name === "beads")).toBe(true);
+      expect(managers.some((m) => m.name === "gitea-issues")).toBe(true);
+      expect(managers.some((m) => m.name === "forgejo-issues")).toBe(true);
     });
 
     it("getBacklogManager returns github-issues entry with expected templateArgs", () => {
@@ -1200,6 +1234,54 @@ describe("InitService scaffold", () => {
       );
     });
 
+    it("getBacklogManager returns gitea-issues entry with expected templateArgs", () => {
+      const manager = getBacklogManager("gitea-issues");
+      expect(manager).toBeDefined();
+      expect(manager!.label).toBe("Gitea Issues");
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain("curl");
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "$GITEA_URL/api/v1/repos/$GITEA_REPO/issues",
+      );
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "labels=Sandcastle",
+      );
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain("comments");
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "$GITEA_TOKEN",
+      );
+      expect(manager!.templateArgs.VIEW_TASK_COMMAND).toContain(
+        "$GITEA_URL/api/v1/repos/$GITEA_REPO/issues/<ID>",
+      );
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain(
+        "Completed by Sandcastle",
+      );
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain('"closed"');
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).not.toContain("gh");
+      expect(manager!.envExample).toContain("GITEA_URL=");
+      expect(manager!.envExample).toContain("GITEA_TOKEN=");
+      expect(manager!.envExample).toContain("GITEA_REPO=");
+    });
+
+    it("getBacklogManager returns forgejo-issues entry with expected templateArgs", () => {
+      const manager = getBacklogManager("forgejo-issues");
+      expect(manager).toBeDefined();
+      expect(manager!.label).toBe("Forgejo Issues");
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain("curl");
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "$FORGEJO_URL/api/v1/repos/$FORGEJO_REPO/issues",
+      );
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "$FORGEJO_TOKEN",
+      );
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).not.toContain(
+        "$GITEA_URL",
+      );
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).not.toContain("gh");
+      expect(manager!.envExample).toContain("FORGEJO_URL=");
+      expect(manager!.envExample).toContain("FORGEJO_TOKEN=");
+      expect(manager!.envExample).toContain("FORGEJO_REPO=");
+    });
+
     it("getBacklogManager returns undefined for unknown manager", () => {
       expect(getBacklogManager("nonexistent")).toBeUndefined();
     });
@@ -1242,6 +1324,67 @@ describe("InitService scaffold", () => {
       expect(prompt).not.toContain("gh issue close");
       expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
       expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+    });
+
+    it("simple-loop with gitea-issues produces prompt with curl-based commands", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("gitea-issues"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("curl");
+      expect(prompt).toContain("$GITEA_URL/api/v1/repos/$GITEA_REPO/issues");
+      expect(prompt).toContain("$GITEA_TOKEN");
+      expect(prompt).toContain("Completed by Sandcastle");
+      expect(prompt).not.toContain("gh issue list");
+      expect(prompt).not.toContain("gh issue close");
+      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+    });
+
+    it("simple-loop with forgejo-issues produces prompt with curl-based commands", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("forgejo-issues"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("curl");
+      expect(prompt).toContain(
+        "$FORGEJO_URL/api/v1/repos/$FORGEJO_REPO/issues",
+      );
+      expect(prompt).toContain("$FORGEJO_TOKEN");
+      expect(prompt).not.toContain("$GITEA_URL");
+      expect(prompt).not.toContain("gh issue list");
+      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+    });
+
+    it("gitea-issues Dockerfile does not install the GitHub CLI", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("gitea-issues"),
+      });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfile).not.toContain("apt-get install -y gh");
+      expect(dockerfile).not.toContain("cli.github.com");
+      // curl + jq remain — they are part of the base image install above
+      expect(dockerfile).toContain("curl");
+      expect(dockerfile).toContain("jq");
+      expect(dockerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
     });
 
     it("simple-loop with beads skips --label Sandcastle (no label to strip)", async () => {

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -257,6 +257,37 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \\
   && apt-get update && apt-get install -y gh \\
   && rm -rf /var/lib/apt/lists/*`;
 
+// Gitea and Forgejo expose the same REST API at /api/v1. Forgejo is a soft-fork
+// of Gitea (2022) and remains API-compatible for issue/PR operations, so a
+// single set of curl-based commands targets both — only the configured
+// GITEA_URL / FORGEJO_URL differs.
+const GITEA_API_TOOLS = `# Gitea/Forgejo backlog uses the REST API via curl + jq (already installed above).
+# No additional CLI is needed.`;
+
+// One-line shell commands embedded in markdown templates. They produce JSON
+// shaped identically to the GitHub Issues output so downstream prompts don't
+// need to branch on the backlog manager.
+const giteaListTasksCommand = (
+  urlVar: string,
+  tokenVar: string,
+  repoVar: string,
+): string =>
+  `for n in $(curl -fsSL -H "Authorization: token $${tokenVar}" "$${urlVar}/api/v1/repos/$${repoVar}/issues?state=open&type=issues&labels=Sandcastle&limit=50" | jq '.[].number'); do c=$(curl -fsSL -H "Authorization: token $${tokenVar}" "$${urlVar}/api/v1/repos/$${repoVar}/issues/$n/comments" | jq '[.[] | {body}]'); curl -fsSL -H "Authorization: token $${tokenVar}" "$${urlVar}/api/v1/repos/$${repoVar}/issues/$n" | jq --argjson comments "$c" '{number, title, body, labels: [.labels[] | {name}], comments: $comments}'; done | jq -s '.'`;
+
+const giteaViewTaskCommand = (
+  urlVar: string,
+  tokenVar: string,
+  repoVar: string,
+): string =>
+  `curl -fsSL -H "Authorization: token $${tokenVar}" "$${urlVar}/api/v1/repos/$${repoVar}/issues/<ID>" | jq '{number, title, state, body, labels: [.labels[].name]}'`;
+
+const giteaCloseTaskCommand = (
+  urlVar: string,
+  tokenVar: string,
+  repoVar: string,
+): string =>
+  `curl -fsSL -H "Authorization: token $${tokenVar}" -H "Content-Type: application/json" -X POST "$${urlVar}/api/v1/repos/$${repoVar}/issues/<ID>/comments" -d '{"body":"Completed by Sandcastle"}' >/dev/null && curl -fsSL -H "Authorization: token $${tokenVar}" -H "Content-Type: application/json" -X PATCH "$${urlVar}/api/v1/repos/$${repoVar}/issues/<ID>" -d '{"state":"closed"}' >/dev/null`;
+
 const BEADS_TOOLS = `# Install system dependencies for Beads
 RUN apt-get update && apt-get install -y \\
   dpkg-dev \\
@@ -283,6 +314,62 @@ const BACKLOG_MANAGER_REGISTRY: BacklogManagerEntry[] = [
     },
     envExample: `# GitHub personal access token
 GH_TOKEN=`,
+  },
+  {
+    name: "gitea-issues",
+    label: "Gitea Issues",
+    templateArgs: {
+      LIST_TASKS_COMMAND: giteaListTasksCommand(
+        "GITEA_URL",
+        "GITEA_TOKEN",
+        "GITEA_REPO",
+      ),
+      VIEW_TASK_COMMAND: giteaViewTaskCommand(
+        "GITEA_URL",
+        "GITEA_TOKEN",
+        "GITEA_REPO",
+      ),
+      CLOSE_TASK_COMMAND: giteaCloseTaskCommand(
+        "GITEA_URL",
+        "GITEA_TOKEN",
+        "GITEA_REPO",
+      ),
+      BACKLOG_MANAGER_TOOLS: GITEA_API_TOOLS,
+    },
+    envExample: `# Gitea instance URL (e.g. https://gitea.example.com) and personal access token
+GITEA_URL=
+GITEA_TOKEN=
+# Repository in owner/repo form (e.g. acme/widgets)
+GITEA_REPO=`,
+  },
+  // Forgejo is a soft-fork of Gitea with a compatible REST API at /api/v1, so
+  // the only difference from the Gitea entry is the env var names users see.
+  {
+    name: "forgejo-issues",
+    label: "Forgejo Issues",
+    templateArgs: {
+      LIST_TASKS_COMMAND: giteaListTasksCommand(
+        "FORGEJO_URL",
+        "FORGEJO_TOKEN",
+        "FORGEJO_REPO",
+      ),
+      VIEW_TASK_COMMAND: giteaViewTaskCommand(
+        "FORGEJO_URL",
+        "FORGEJO_TOKEN",
+        "FORGEJO_REPO",
+      ),
+      CLOSE_TASK_COMMAND: giteaCloseTaskCommand(
+        "FORGEJO_URL",
+        "FORGEJO_TOKEN",
+        "FORGEJO_REPO",
+      ),
+      BACKLOG_MANAGER_TOOLS: GITEA_API_TOOLS,
+    },
+    envExample: `# Forgejo instance URL (e.g. https://codeberg.org) and personal access token
+FORGEJO_URL=
+FORGEJO_TOKEN=
+# Repository in owner/repo form (e.g. acme/widgets)
+FORGEJO_REPO=`,
   },
   {
     name: "beads",


### PR DESCRIPTION
## Summary

Adds **Gitea Issues** and **Forgejo Issues** as selectable backlog managers in `sandcastle init`, alongside the existing GitHub Issues and Beads options.

Forgejo is a soft-fork of Gitea (2022) and remains API-compatible at `/api/v1` for issue and PR operations, so both entries share a single curl + jq based adapter — the only difference is which env vars users see (`GITEA_URL` / `GITEA_TOKEN` / `GITEA_REPO` vs `FORGEJO_URL` / `FORGEJO_TOKEN` / `FORGEJO_REPO`). No second adapter, no plugin system — just two registry entries pointing at the same parameterized command builders.

The list/view/close commands emit JSON shaped identically to the GitHub Issues path (`{number, title, body, labels: [{name}], comments: [{body}]}`), so the existing templates (`simple-loop`, `sequential-reviewer`, `parallel-planner`, `parallel-planner-with-review`) work unchanged. Issue comments aren't returned inline by Gitea's list endpoint, so the list command fetches them per-issue and merges them into the same output shape the planner already expects.

## Why one PR for both

Gitea and Forgejo speak the same REST API. Two separate adapters would duplicate the same curl invocations under different names and create a maintenance hazard. Treating Forgejo as a Gitea-compatible alias is both more honest and easier to keep in sync as either project evolves.

## What's new

- Two new entries in the `BACKLOG_MANAGER_REGISTRY` in `src/InitService.ts`: `gitea-issues` ("Gitea Issues") and `forgejo-issues` ("Forgejo Issues").
- The Dockerfile path for Gitea/Forgejo skips the GitHub CLI install step — `curl` and `jq` are already installed by the agent base layers.
- Each scaffolds an `.env.example` with the appropriate URL / token / repo vars.
- Mirrored unit tests in `src/InitService.test.ts` covering the registry lookups, `.env.example` contents, prompt template substitution, and the Dockerfile shape.

## Files changed

```
.changeset/gitea-forgejo-backlog.md  | new
README.md                             |   2 +-  (updates the one-line backlog manager list)
src/InitService.ts                    |  87 +++++++
src/InitService.test.ts               | 145 +++++++++++++
```

## Init transcript (after the change)

```
$ sandcastle init
? Select a sandbox provider:  Docker
? Select a backlog manager:
  GitHub Issues
> Gitea Issues
  Forgejo Issues
  Beads
? Select a template:  simple-loop
...
.sandcastle/.env.example now contains:
  GITEA_URL=
  GITEA_TOKEN=
  GITEA_REPO=
```

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npx vitest run src/InitService.test.ts` — 156 / 156 passing (149 baseline + 7 new)
- [x] `npx vitest run src/cli.test.ts` — 14 / 14 passing
- [x] Verified locally that a scaffolded Gitea config runs against `gitea.beaulieu.sh` end-to-end (issue listing, view, close all work; agents pick up issues and close them with the comment `Completed by Sandcastle`)
- [ ] Maintainer to review API command shape — happy to swap `&type=issues` for `&type=all` or otherwise tune the list query if you have a preference

## Notes / non-goals

- No new top-level dependencies. `curl` and `jq` are already installed by every agent's Dockerfile.
- Behavior for existing GitHub Issues users is unchanged — the registry just gets two more entries appended.
- Label-creation prompt is GitHub-specific (relies on `gh label create`) and remains GitHub-only. Gitea / Forgejo bake `&labels=Sandcastle` into the list URL; users who don't want a label filter can edit the prompt or remove that query parameter.
- I deliberately did not introduce any new abstractions — Gitea and Forgejo are just registry entries, exactly like Beads.

Thanks for sandcastle — happy to iterate on whatever feels off.