### PR TITLE
fix: handle pre-existing GID in Dockerfile templates for macOS hosts

### DIFF
--- a/.changeset/fix-macos-gid-conflict.md
+++ b/.changeset/fix-macos-gid-conflict.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix Docker image build failure on macOS hosts where the host GID (e.g. macOS `staff` GID 20) conflicts with a system group in the Debian base image (e.g. `dialout` GID 20). The `-o` (non-unique) flag is now passed to `groupmod` and `usermod` to allow the reassignment without error.

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -22,7 +22,10 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+# -o (non-unique) allows GID/UID values already used by another group/user in the
+# base image (e.g. GID 20 = "dialout" on Debian bookworm, which collides with the
+# macOS "staff" GID). The collision is harmless — dialout is unused in agent containers.
+RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 USER ${AGENT_UID}:${AGENT_GID}
 
 # Install Claude Code CLI

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -74,7 +74,10 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+# -o (non-unique) allows GID/UID values already used by another group/user in the
+# base image (e.g. GID 20 = "dialout" on Debian bookworm, which collides with the
+# macOS "staff" GID). The collision is harmless — dialout is unused in agent containers.
+RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 USER \${AGENT_UID}:\${AGENT_GID}
 
 # Install Claude Code CLI
@@ -109,7 +112,10 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+# -o (non-unique) allows GID/UID values already used by another group/user in the
+# base image (e.g. GID 20 = "dialout" on Debian bookworm, which collides with the
+# macOS "staff" GID). The collision is harmless — dialout is unused in agent containers.
+RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 
 # Install pi coding agent (run as root before USER agent)
 RUN npm install -g @mariozechner/pi-coding-agent
@@ -142,7 +148,10 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+# -o (non-unique) allows GID/UID values already used by another group/user in the
+# base image (e.g. GID 20 = "dialout" on Debian bookworm, which collides with the
+# macOS "staff" GID). The collision is harmless — dialout is unused in agent containers.
+RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 
 # Install Codex CLI (run as root before USER agent)
 RUN npm install -g @openai/codex
@@ -175,7 +184,10 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+# -o (non-unique) allows GID/UID values already used by another group/user in the
+# base image (e.g. GID 20 = "dialout" on Debian bookworm, which collides with the
+# macOS "staff" GID). The collision is harmless — dialout is unused in agent containers.
+RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 
 # Install OpenCode CLI (run as root before USER agent)
 RUN npm install -g opencode-ai@latest


### PR DESCRIPTION
## Summary

- Adds `-o` (`--non-unique`) to `groupmod` and `usermod` in all four Dockerfile templates in `InitService.ts` (claude-code, pi, codex, opencode) and in the repo's own `.sandcastle/Dockerfile`

## Root cause

On macOS, the host GID is typically `20` (`staff`). The base `node:22-bookworm` image already has GID `20` assigned to the `dialout` group. When sandcastle passes `AGENT_GID=20` at image build time, `groupmod` refuses with:

```
groupmod: GID '20' already exists
exit code: 4
```

## Fix

Adding `-o` (`--non-unique`) to both `groupmod` and `usermod` allows the `node` group to share GID 20 with `dialout`. The collision is harmless — `dialout` is unused in agent containers.

```dockerfile
RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
```

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)