### PR TITLE
Bump default model from claude-opus-4-6 to claude-opus-4-7

### DIFF
--- a/.changeset/bump-default-model-to-opus-4-7.md
+++ b/.changeset/bump-default-model-to-opus-4-7.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Bump default Claude Code model from `claude-opus-4-6` to `claude-opus-4-7`.

--- a/.factory/implement-task.ts
+++ b/.factory/implement-task.ts
@@ -48,7 +48,7 @@ await using sandbox = await worktree.createSandbox({
 
 const result = await sandbox.run({
   name: "Implementer #" + issueNumber,
-  agent: sandcastle.claudeCode("claude-opus-4-6"),
+  agent: sandcastle.claudeCode("claude-opus-4-7"),
   promptFile: "./.sandcastle/implement-prompt.md",
   promptArgs: {
     ISSUE_NUMBER: String(issueNumber),
@@ -60,7 +60,7 @@ const result = await sandbox.run({
 if (result.commits.length > 0) {
   await sandbox.run({
     name: "Reviewer #" + issueNumber,
-    agent: sandcastle.claudeCode("claude-opus-4-6"),
+    agent: sandcastle.claudeCode("claude-opus-4-7"),
     promptFile: "./.sandcastle/review-prompt.md",
     promptArgs: {
       ISSUE_NUMBER: String(issueNumber),

--- a/.sandcastle/run.ts
+++ b/.sandcastle/run.ts
@@ -11,7 +11,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   const plan = await sandcastle.run({
     sandbox: docker(),
     name: "Planner",
-    agent: sandcastle.claudeCode("claude-opus-4-6"),
+    agent: sandcastle.claudeCode("claude-opus-4-7"),
     promptFile: "./.sandcastle/plan-prompt.md",
   });
 
@@ -71,7 +71,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
 
         const result = await sandbox.run({
           name: "Implementer #" + issue.number,
-          agent: sandcastle.claudeCode("claude-opus-4-6"),
+          agent: sandcastle.claudeCode("claude-opus-4-7"),
           promptFile: "./.sandcastle/implement-prompt.md",
           promptArgs: {
             TASK_ID: String(issue.number),
@@ -83,7 +83,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
         if (result.commits.length > 0) {
           await sandbox.run({
             name: "Reviewer #" + issue.number,
-            agent: sandcastle.claudeCode("claude-opus-4-6"),
+            agent: sandcastle.claudeCode("claude-opus-4-7"),
             promptFile: "./.sandcastle/review-prompt.md",
             promptArgs: {
               TASK_ID: String(issue.number),
@@ -143,7 +143,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     sandbox: docker(),
     name: "Merger",
     maxIterations: 10,
-    agent: sandcastle.claudeCode("claude-opus-4-6"),
+    agent: sandcastle.claudeCode("claude-opus-4-7"),
     promptFile: "./.sandcastle/merge-prompt.md",
     promptArgs: {
       BRANCHES: completedBranches.map((b) => `- ${b}`).join("\n"),

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import { run, claudeCode } from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 
 await run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: docker(), // or podman(), vercel(), or your own provider
   promptFile: ".sandcastle/prompt.md",
 });
@@ -84,14 +84,14 @@ import { noSandbox } from "@ai-hero/sandcastle/sandboxes/no-sandbox";
 
 // Docker, Podman, and Vercel are interchangeable in run() and createSandbox():
 await run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: docker(),
   prompt: "...",
 });
 
 // No-sandbox runs the agent directly on the host — interactive() only:
 await interactive({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: noSandbox(),
   prompt: "...", // optional — omit to launch the TUI with no initial prompt
   cwd: "/path/to/other-repo", // optional — defaults to process.cwd()
@@ -109,7 +109,7 @@ import { run, claudeCode } from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 
 const result = await run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: docker(),
   promptFile: ".sandcastle/prompt.md",
 });
@@ -129,7 +129,7 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 const result = await run({
   // Agent provider — required. Pass a model string to claudeCode().
   // Optional second arg for provider-specific options like effort level.
-  agent: claudeCode("claude-opus-4-6", { effort: "high" }),
+  agent: claudeCode("claude-opus-4-7", { effort: "high" }),
 
   // Sandbox provider — required. Any SandboxProvider works (docker, podman, vercel, or custom).
   // Provider-specific config (like imageName, mounts) lives inside the provider factory call.
@@ -252,7 +252,7 @@ await using sandbox = await createSandbox({
 });
 
 const result = await sandbox.run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   prompt: "Fix issue #42 in this repo.",
 });
 
@@ -273,7 +273,7 @@ await using sandbox = await createSandbox({
 
 // Step 1: implement
 const implResult = await sandbox.run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   promptFile: ".sandcastle/implement.md",
   maxIterations: 5,
 });
@@ -331,7 +331,7 @@ if (closeResult.preservedWorktreePath) {
 
 | Option               | Type               | Default                       | Description                                                         |
 | -------------------- | ------------------ | ----------------------------- | ------------------------------------------------------------------- |
-| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-6")`) |
+| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-7")`) |
 | `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                |
 | `promptFile`         | string             | —                             | Path to prompt file (mutually exclusive with `prompt`)              |
 | `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                |
@@ -380,13 +380,13 @@ console.log(wt.branch); // "agent/fix-42"
 
 // Run an interactive session in the worktree (defaults to noSandbox)
 await wt.interactive({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   prompt: "Explore the codebase and understand the bug.",
 });
 
 // Run an AFK agent in the worktree (sandbox is required)
 const result = await wt.run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: docker({ imageName: "sandcastle:myrepo" }),
   prompt: "Fix issue #42.",
   maxIterations: 3,
@@ -612,7 +612,7 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 import { z } from "zod";
 
 const result = await run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: docker(),
   prompt: `Analyze the code, and output the result as JSON inside <result> tags.
     The result must match this schema:
@@ -707,7 +707,7 @@ Removes the Podman image.
 
 | Option               | Type               | Default                       | Description                                                                                                                                                     |
 | -------------------- | ------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-6")`, `pi("claude-sonnet-4-6")`, `codex("gpt-5.4-mini")`, `opencode("opencode/big-pickle")`)      |
+| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-7")`, `pi("claude-sonnet-4-6")`, `codex("gpt-5.4-mini")`, `opencode("opencode/big-pickle")`)      |
 | `sandbox`            | SandboxProvider    | —                             | **Required.** Sandbox provider (e.g. `docker()`, `podman()`, `docker({ imageName: "sandcastle:local" })`)                                                       |
 | `cwd`                | string             | `process.cwd()`               | Host repo directory — anchor for `.sandcastle/` artifacts and git operations. Relative paths resolve against `process.cwd()`.                                   |
 | `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                                                                                                            |
@@ -767,7 +767,7 @@ Pass `resumeSession` to `run()` to continue a prior Claude Code conversation ins
 
 ```typescript
 const result = await run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: docker(),
   prompt: "Continue where you left off",
   resumeSession: "abc-123-def",
@@ -788,7 +788,7 @@ Constraints:
 The `claudeCode()` factory accepts an optional second argument for provider-specific options:
 
 ```typescript
-agent: claudeCode("claude-opus-4-6", { effort: "high" });
+agent: claudeCode("claude-opus-4-7", { effort: "high" });
 ```
 
 | Option            | Type                                         | Default | Description                                               |
@@ -816,7 +816,7 @@ Both **agent providers** and **sandbox providers** accept an optional `env: Reco
 
 ```typescript
 await run({
-  agent: claudeCode("claude-opus-4-6", {
+  agent: claudeCode("claude-opus-4-7", {
     env: { ANTHROPIC_API_KEY: "sk-ant-..." },
   }),
   sandbox: docker({
@@ -1097,19 +1097,19 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 
 // head — direct write, bind-mount only (default for bind-mount providers)
 await run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: docker(),
   prompt: "…",
 });
 // merge-to-head — temp branch, merge back (default for isolated providers)
 await run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: tempDir(),
   prompt: "…",
 });
 // branch — explicit named branch
 await run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: docker(),
   branchStrategy: { type: "branch", branch: "agent/fix-42" },
   prompt: "…",
@@ -1124,7 +1124,7 @@ Pass your custom provider via the `sandbox` option — it works the same as the 
 import { run, claudeCode } from "@ai-hero/sandcastle";
 
 const result = await run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: localProcess(), // your custom provider
   prompt: "Fix issue #42 in this repo.",
 });

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -10,12 +10,12 @@ const opts = (prompt: string): AgentCommandOptions => ({
 
 describe("claudeCode factory", () => {
   it("returns a provider with name 'claude-code'", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     expect(provider.name).toBe("claude-code");
   });
 
   it("does not expose envManifest or dockerfileTemplate", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     expect(provider).not.toHaveProperty("envManifest");
     expect(provider).not.toHaveProperty("dockerfileTemplate");
   });
@@ -29,7 +29,7 @@ describe("claudeCode factory", () => {
   });
 
   it("buildPrintCommand delivers prompt via stdin, not argv", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const { command, stdin } = provider.buildPrintCommand(opts("do something"));
     expect(command).toContain("-p -");
     expect(command).not.toContain("'do something'");
@@ -37,13 +37,13 @@ describe("claudeCode factory", () => {
   });
 
   it("buildPrintCommand shell-escapes the model", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const { command } = provider.buildPrintCommand(opts("do something"));
-    expect(command).toContain("--model 'claude-opus-4-6'");
+    expect(command).toContain("--model 'claude-opus-4-7'");
   });
 
   it("parseStreamLine extracts text from assistant message", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const line = JSON.stringify({
       type: "assistant",
       message: { content: [{ type: "text", text: "Hello world" }] },
@@ -54,7 +54,7 @@ describe("claudeCode factory", () => {
   });
 
   it("parseStreamLine extracts result from result message", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const line = JSON.stringify({
       type: "result",
       result: "Final answer <promise>COMPLETE</promise>",
@@ -68,13 +68,13 @@ describe("claudeCode factory", () => {
   });
 
   it("parseStreamLine returns empty array for non-JSON lines", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     expect(provider.parseStreamLine("not json")).toEqual([]);
     expect(provider.parseStreamLine("")).toEqual([]);
   });
 
   it("parseStreamLine extracts tool_use block (Bash → command arg)", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const line = JSON.stringify({
       type: "assistant",
       message: {
@@ -103,26 +103,26 @@ describe("claudeCode factory", () => {
   });
 
   it("buildPrintCommand includes --effort when specified", () => {
-    const provider = claudeCode("claude-opus-4-6", { effort: "high" });
+    const provider = claudeCode("claude-opus-4-7", { effort: "high" });
     const { command } = provider.buildPrintCommand(opts("do something"));
     expect(command).toContain("--effort high");
   });
 
   it("buildPrintCommand omits --effort when not specified", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const { command } = provider.buildPrintCommand(opts("do something"));
     expect(command).not.toContain("--effort");
   });
 
   it("buildPrintCommand omits --effort when options is empty", () => {
-    const provider = claudeCode("claude-opus-4-6", {});
+    const provider = claudeCode("claude-opus-4-7", {});
     const { command } = provider.buildPrintCommand(opts("do something"));
     expect(command).not.toContain("--effort");
   });
 
   it("supports all effort levels", () => {
     for (const effort of ["low", "medium", "high", "max"] as const) {
-      const provider = claudeCode("claude-opus-4-6", { effort });
+      const provider = claudeCode("claude-opus-4-7", { effort });
       expect(provider.buildPrintCommand(opts("test")).command).toContain(
         `--effort ${effort}`,
       );
@@ -130,21 +130,21 @@ describe("claudeCode factory", () => {
   });
 
   it("accepts an env option and exposes it on the provider", () => {
-    const provider = claudeCode("claude-opus-4-6", {
+    const provider = claudeCode("claude-opus-4-7", {
       env: { ANTHROPIC_API_KEY: "sk-test" },
     });
     expect(provider.env).toEqual({ ANTHROPIC_API_KEY: "sk-test" });
   });
 
   it("defaults env to empty object when not provided", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     expect(provider.env).toEqual({});
   });
 
   // --- dangerouslySkipPermissions conditional tests ---
 
   it("buildPrintCommand includes --dangerously-skip-permissions when true", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const { command } = provider.buildPrintCommand({
       prompt: "test",
       dangerouslySkipPermissions: true,
@@ -153,7 +153,7 @@ describe("claudeCode factory", () => {
   });
 
   it("parseStreamLine emits session_id from Claude Code init line", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const line = JSON.stringify({
       type: "system",
       subtype: "init",
@@ -165,7 +165,7 @@ describe("claudeCode factory", () => {
   });
 
   it("parseStreamLine ignores system events without subtype init", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const line = JSON.stringify({
       type: "system",
       subtype: "other",
@@ -175,7 +175,7 @@ describe("claudeCode factory", () => {
   });
 
   it("parseStreamLine ignores system init without session_id", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const line = JSON.stringify({
       type: "system",
       subtype: "init",
@@ -184,7 +184,7 @@ describe("claudeCode factory", () => {
   });
 
   it("buildPrintCommand includes --resume when resumeSession is set", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const { command } = provider.buildPrintCommand({
       prompt: "test",
       dangerouslySkipPermissions: true,
@@ -194,7 +194,7 @@ describe("claudeCode factory", () => {
   });
 
   it("buildPrintCommand omits --resume when resumeSession is not set", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const { command } = provider.buildPrintCommand({
       prompt: "test",
       dangerouslySkipPermissions: true,
@@ -203,7 +203,7 @@ describe("claudeCode factory", () => {
   });
 
   it("buildPrintCommand omits --dangerously-skip-permissions when false", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const { command } = provider.buildPrintCommand({
       prompt: "test",
       dangerouslySkipPermissions: false,
@@ -212,7 +212,7 @@ describe("claudeCode factory", () => {
   });
 
   it("buildInteractiveArgs includes --dangerously-skip-permissions when true", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const args = provider.buildInteractiveArgs!({
       prompt: "test",
       dangerouslySkipPermissions: true,
@@ -221,7 +221,7 @@ describe("claudeCode factory", () => {
   });
 
   it("buildInteractiveArgs omits --dangerously-skip-permissions when false", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const args = provider.buildInteractiveArgs!({
       prompt: "test",
       dangerouslySkipPermissions: false,
@@ -846,14 +846,14 @@ describe("resumeSession on non-Claude providers", () => {
 });
 
 describe("parseSessionUsage (Claude Code)", () => {
-  const provider = claudeCode("claude-opus-4-6");
+  const provider = claudeCode("claude-opus-4-7");
 
   it("extracts usage from the last assistant message in a JSONL string", () => {
     const content = [
       JSON.stringify({
         type: "assistant",
         message: {
-          model: "claude-opus-4-6",
+          model: "claude-opus-4-7",
           usage: {
             input_tokens: 100,
             cache_creation_input_tokens: 200,
@@ -865,7 +865,7 @@ describe("parseSessionUsage (Claude Code)", () => {
       JSON.stringify({
         type: "assistant",
         message: {
-          model: "claude-opus-4-6",
+          model: "claude-opus-4-7",
           usage: {
             input_tokens: 3,
             cache_creation_input_tokens: 9294,
@@ -900,7 +900,7 @@ describe("parseSessionUsage (Claude Code)", () => {
     const content = JSON.stringify({
       type: "assistant",
       message: {
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         content: [{ type: "text", text: "hi" }],
       },
     });
@@ -918,7 +918,7 @@ describe("parseSessionUsage (Claude Code)", () => {
       JSON.stringify({
         type: "assistant",
         message: {
-          model: "claude-opus-4-6",
+          model: "claude-opus-4-7",
           usage: {
             input_tokens: 10,
             cache_creation_input_tokens: 20,
@@ -952,12 +952,12 @@ describe("parseSessionUsage (Claude Code)", () => {
 
 describe("captureSessions flag", () => {
   it("claudeCode defaults captureSessions to true", () => {
-    expect(claudeCode("claude-opus-4-6").captureSessions).toBe(true);
+    expect(claudeCode("claude-opus-4-7").captureSessions).toBe(true);
   });
 
   it("claudeCode allows opting out of captureSessions", () => {
     expect(
-      claudeCode("claude-opus-4-6", { captureSessions: false }).captureSessions,
+      claudeCode("claude-opus-4-7", { captureSessions: false }).captureSessions,
     ).toBe(false);
   });
 

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -121,7 +121,7 @@ export interface AgentProvider {
   parseSessionUsage?(content: string): IterationUsage | undefined;
 }
 
-export const DEFAULT_MODEL = "claude-opus-4-6";
+export const DEFAULT_MODEL = "claude-opus-4-7";
 
 // ---------------------------------------------------------------------------
 // Pi agent provider

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -28,7 +28,7 @@ const opencodeAgent = getAgent("opencode")!;
 
 const defaultOptions: ScaffoldOptions = {
   agent: claudeCodeAgent,
-  model: "claude-opus-4-6",
+  model: "claude-opus-4-7",
 };
 
 const runScaffold = (repoDir: string, options?: Partial<ScaffoldOptions>) =>
@@ -52,7 +52,7 @@ describe("Agent registry", () => {
     const agent = getAgent("claude-code");
     expect(agent).toBeDefined();
     expect(agent!.name).toBe("claude-code");
-    expect(agent!.defaultModel).toBe("claude-opus-4-6");
+    expect(agent!.defaultModel).toBe("claude-opus-4-7");
     expect(agent!.factoryImport).toBe("claudeCode");
     expect(agent!.dockerfileTemplate).toContain("FROM");
   });
@@ -335,7 +335,7 @@ describe("InitService scaffold", () => {
     );
     expect(mainTs).toContain('claudeCode("claude-sonnet-4-6")');
     // Should not contain the template's original model
-    expect(mainTs).not.toContain('claudeCode("claude-opus-4-6")');
+    expect(mainTs).not.toContain('claudeCode("claude-opus-4-7")');
   });
 
   it("scaffolds main.mts with default model when using agent default", async () => {
@@ -346,7 +346,7 @@ describe("InitService scaffold", () => {
       join(dir, ".sandcastle", "main.mts"),
       "utf-8",
     );
-    expect(mainTs).toContain('claudeCode("claude-opus-4-6")');
+    expect(mainTs).toContain('claudeCode("claude-opus-4-7")');
   });
 
   // --- Template-specific tests ---
@@ -384,7 +384,7 @@ describe("InitService scaffold", () => {
     expect(mainTs).toContain("run(");
     expect(mainTs).toContain("maxIterations");
     expect(mainTs).toContain("3");
-    // When scaffolded with default model, simple-loop uses claude-opus-4-6
+    // When scaffolded with default model, simple-loop uses claude-opus-4-7
     // (rewritten from template's claude-sonnet-4-6)
     expect(mainTs).toContain("promptFile");
     expect(mainTs).toContain("npm install");
@@ -855,8 +855,8 @@ describe("InitService scaffold", () => {
         join(dir, ".sandcastle", "main.mts"),
         "utf-8",
       );
-      // All factory calls should use the specified model (default: claude-opus-4-6)
-      expect(mainTs).toContain("claude-opus-4-6");
+      // All factory calls should use the specified model (default: claude-opus-4-7)
+      expect(mainTs).toContain("claude-opus-4-7");
     });
 
     it("implement-prompt.md contains {{TASK_ID}}, {{ISSUE_TITLE}}, {{BRANCH}} prompt arguments", async () => {
@@ -1108,7 +1108,7 @@ describe("InitService scaffold", () => {
         join(dir, ".sandcastle", "main.mts"),
         "utf-8",
       );
-      expect(mainTs).toContain("claude-opus-4-6");
+      expect(mainTs).toContain("claude-opus-4-7");
     });
 
     it("scaffolds CODING_STANDARDS.md with minimal starter content", async () => {
@@ -1852,7 +1852,7 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(mainContent).toContain("@ai-hero/sandcastle");
-      expect(mainContent).toContain('claudeCode("claude-opus-4-6")');
+      expect(mainContent).toContain('claudeCode("claude-opus-4-7")');
     });
 
     it("main.ts scaffolded with type: module rewrites agent factory correctly", async () => {

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -194,7 +194,7 @@ const AGENT_REGISTRY: AgentEntry[] = [
   {
     name: "claude-code",
     label: "Claude Code",
-    defaultModel: "claude-opus-4-6",
+    defaultModel: "claude-opus-4-7",
     factoryImport: "claudeCode",
     dockerfileTemplate: CLAUDE_CODE_DOCKERFILE,
     envExample: `# Anthropic API key

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -3589,7 +3589,7 @@ describe("Session capture integration", () => {
             JSON.stringify({
               type: "assistant",
               message: {
-                model: "claude-opus-4-6",
+                model: "claude-opus-4-7",
                 usage: {
                   input_tokens: 3,
                   cache_creation_input_tokens: 9294,

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -85,7 +85,7 @@ export interface CreateSandboxOptions {
 }
 
 export interface SandboxRunOptions {
-  /** Agent provider to use (e.g. claudeCode("claude-opus-4-6")). */
+  /** Agent provider to use (e.g. claudeCode("claude-opus-4-7")). */
   readonly agent: AgentProvider;
   /** Inline prompt string (mutually exclusive with promptFile). */
   readonly prompt?: string;
@@ -129,7 +129,7 @@ export interface SandboxRunResult {
 }
 
 export interface SandboxInteractiveOptions {
-  /** Agent provider to use (e.g. claudeCode("claude-opus-4-6")). */
+  /** Agent provider to use (e.g. claudeCode("claude-opus-4-7")). */
   readonly agent: AgentProvider;
   /** Inline prompt string (mutually exclusive with promptFile). */
   readonly prompt?: string;

--- a/src/createWorktree.test.ts
+++ b/src/createWorktree.test.ts
@@ -339,7 +339,7 @@ describe("worktree.interactive()", () => {
 
     try {
       const result = await ws.interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         prompt: "test prompt",
       });
@@ -372,7 +372,7 @@ describe("worktree.interactive()", () => {
 
     try {
       const result = await ws.interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         prompt: "fix the bug",
       });
@@ -406,7 +406,7 @@ describe("worktree.interactive()", () => {
 
     try {
       await ws.interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         prompt: "add a file",
       });
@@ -447,7 +447,7 @@ describe("worktree.interactive()", () => {
 
       await expect(
         ws.interactive({
-          agent: claudeCode("claude-opus-4-6"),
+          agent: claudeCode("claude-opus-4-7"),
           sandbox: provider,
           prompt: "test prompt",
           signal: ac.signal,
@@ -480,7 +480,7 @@ describe("worktree.interactive()", () => {
       // First call: aborted
       await expect(
         ws.interactive({
-          agent: claudeCode("claude-opus-4-6"),
+          agent: claudeCode("claude-opus-4-7"),
           sandbox: provider,
           prompt: "test",
           signal: ac.signal,
@@ -492,7 +492,7 @@ describe("worktree.interactive()", () => {
 
       // Handle still usable
       const result = await ws.interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         prompt: "test again",
       });
@@ -505,7 +505,7 @@ describe("worktree.interactive()", () => {
 
   it("signal option has correct type on WorktreeInteractiveOptions", () => {
     const _options: WorktreeInteractiveOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       prompt: "test",
       signal: new AbortController().signal,
     };
@@ -531,7 +531,7 @@ describe("worktree.interactive()", () => {
 
     try {
       const result = await ws.interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         prompt: "test",
       });
@@ -624,7 +624,7 @@ describe("worktree.run()", () => {
 
     try {
       const result = await ws.run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox,
         prompt: "do something",
         maxIterations: 1,
@@ -659,7 +659,7 @@ describe("worktree.run()", () => {
 
     try {
       await ws.run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox,
         prompt: "create a file",
         maxIterations: 1,
@@ -698,7 +698,7 @@ describe("worktree.run()", () => {
 
     try {
       const result = await ws.run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox,
         prompt: "create a file",
         maxIterations: 1,
@@ -716,7 +716,7 @@ describe("worktree.run()", () => {
   it("sandbox is required (type error if omitted)", () => {
     // This test validates at the type level — sandbox is required in WorktreeRunOptions
     const _options = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       prompt: "test",
       // @ts-expect-error — sandbox is required
     } satisfies WorktreeRunOptions;
@@ -744,7 +744,7 @@ describe("worktree.run()", () => {
 
       await expect(
         ws.run({
-          agent: claudeCode("claude-opus-4-6"),
+          agent: claudeCode("claude-opus-4-7"),
           sandbox,
           prompt: "do something",
           signal: ac.signal,
@@ -779,7 +779,7 @@ describe("worktree.run()", () => {
     try {
       await expect(
         ws.run({
-          agent: claudeCode("claude-opus-4-6"),
+          agent: claudeCode("claude-opus-4-7"),
           sandbox,
           prompt: "do something",
           signal: ac.signal,
@@ -813,7 +813,7 @@ describe("worktree.run()", () => {
       // First call: aborted
       await expect(
         ws.run({
-          agent: claudeCode("claude-opus-4-6"),
+          agent: claudeCode("claude-opus-4-7"),
           sandbox,
           prompt: "do something",
           signal: ac.signal,
@@ -822,7 +822,7 @@ describe("worktree.run()", () => {
 
       // Second call: should succeed without signal
       const result = await ws.run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox,
         prompt: "do something else",
       });
@@ -837,7 +837,7 @@ describe("worktree.run()", () => {
 
   it("signal option has the correct type on WorktreeRunOptions", () => {
     const _options: WorktreeRunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
       signal: new AbortController().signal,

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -84,7 +84,7 @@ export interface CreateWorktreeOptions {
 }
 
 export interface WorktreeInteractiveOptions {
-  /** Agent provider to use (e.g. claudeCode("claude-opus-4-6")) */
+  /** Agent provider to use (e.g. claudeCode("claude-opus-4-7")) */
   readonly agent: AgentProvider;
   /** Sandbox provider (e.g. docker(), noSandbox()). Defaults to noSandbox(). */
   readonly sandbox?: AnySandboxProvider;
@@ -114,7 +114,7 @@ export interface WorktreeInteractiveOptions {
 }
 
 export interface WorktreeRunOptions {
-  /** Agent provider to use (e.g. claudeCode("claude-opus-4-6")) */
+  /** Agent provider to use (e.g. claudeCode("claude-opus-4-7")) */
   readonly agent: AgentProvider;
   /** Sandbox provider (e.g. docker()). Required — AFK agents should always be sandboxed. */
   readonly sandbox: SandboxProvider;

--- a/src/interactive.test.ts
+++ b/src/interactive.test.ts
@@ -20,14 +20,14 @@ const interactiveOpts = (prompt: string) => ({
 
 describe("buildInteractiveArgs with prompts", () => {
   it("claudeCode includes prompt as positional argument", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const args = provider.buildInteractiveArgs!(interactiveOpts("fix the bug"));
     expect(args[0]).toBe("claude");
     expect(args[args.length - 1]).toBe("fix the bug");
   });
 
   it("claudeCode omits prompt when empty string", () => {
-    const provider = claudeCode("claude-opus-4-6");
+    const provider = claudeCode("claude-opus-4-7");
     const args = provider.buildInteractiveArgs!(interactiveOpts(""));
     expect(args[args.length - 1]).not.toBe("");
     expect(args).toContain("--model");
@@ -143,7 +143,7 @@ describe("interactive()", () => {
     });
 
     const result = await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "test prompt",
       name: "test-session",
@@ -166,7 +166,7 @@ describe("interactive()", () => {
     });
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "fix the login bug",
     });
@@ -187,7 +187,7 @@ describe("interactive()", () => {
     });
 
     const result = await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "add a file",
     });
@@ -202,7 +202,7 @@ describe("interactive()", () => {
     });
 
     const result = await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "test",
     });
@@ -232,7 +232,7 @@ describe("interactive()", () => {
 
     await expect(
       interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         prompt: "test",
       }),
@@ -257,7 +257,7 @@ describe("interactive()", () => {
     // but head strategy is not supported
     await expect(
       interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: isolatedProvider,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -274,7 +274,7 @@ describe("interactive()", () => {
     });
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "test",
     });
@@ -297,7 +297,7 @@ describe("interactive()", () => {
     });
 
     const result = await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
     });
 
@@ -318,7 +318,7 @@ describe("interactive()", () => {
 
     // This should NOT throw even though promptArgs has keys — there's no prompt to substitute into
     const result = await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       promptArgs: { COMPONENT: "LoginForm" },
     });
@@ -335,7 +335,7 @@ describe("interactive()", () => {
     });
 
     const result = await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
     });
 
@@ -358,7 +358,7 @@ describe("interactive()", () => {
     });
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       promptFile: promptPath,
     });
@@ -374,7 +374,7 @@ describe("interactive()", () => {
 
     await expect(
       interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         prompt: "inline prompt",
         promptFile: promptPath,
@@ -393,7 +393,7 @@ describe("interactive()", () => {
     });
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       promptFile: promptPath,
       promptArgs: { COMPONENT: "LoginForm" },
@@ -422,7 +422,7 @@ describe("interactive()", () => {
     }).trim();
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       promptFile: promptPath,
     });
@@ -446,7 +446,7 @@ describe("interactive()", () => {
     });
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       promptFile: promptPath,
     });
@@ -465,7 +465,7 @@ describe("interactive()", () => {
 
     await expect(
       interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         promptFile: promptPath,
         promptArgs: { SOURCE_BRANCH: "custom" },
@@ -490,7 +490,7 @@ describe("interactive()", () => {
     }).trim();
 
     const result = await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "test",
       branchStrategy: { type: "head" },
@@ -515,7 +515,7 @@ describe("interactive()", () => {
     }).trim();
 
     const result = await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "test",
       branchStrategy: { type: "merge-to-head" },
@@ -543,7 +543,7 @@ describe("interactive()", () => {
     });
 
     const result = await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "test",
       branchStrategy: { type: "branch", branch: "feature/test-branch" },
@@ -576,7 +576,7 @@ describe("interactive()", () => {
     });
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "test",
       hooks: {
@@ -596,7 +596,7 @@ describe("interactive()", () => {
 
     await expect(
       interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -617,7 +617,7 @@ describe("interactive()", () => {
 
     await expect(
       interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -637,7 +637,7 @@ describe("interactive()", () => {
 
     try {
       await interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -664,7 +664,7 @@ describe("interactive()", () => {
 
     await expect(
       interactive({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: provider,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -675,7 +675,7 @@ describe("interactive()", () => {
 
   it("allows signal to be omitted", () => {
     const opts: InteractiveOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       prompt: "test",
     };
     expect(opts.signal).toBeUndefined();
@@ -684,7 +684,7 @@ describe("interactive()", () => {
   it("allows signal to be specified on InteractiveOptions", () => {
     const ac = new AbortController();
     const opts: InteractiveOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       prompt: "test",
       signal: ac.signal,
     };
@@ -717,7 +717,7 @@ describe("interactive()", () => {
     });
 
     const result = await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "test",
       cwd: otherRepo,
@@ -738,7 +738,7 @@ describe("interactive()", () => {
     });
 
     const result = await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "test",
       // no cwd option
@@ -765,7 +765,7 @@ describe("interactive()", () => {
     });
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       prompt: "test",
       branchStrategy: { type: "merge-to-head" },

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -44,7 +44,7 @@ import { resolveCwd } from "./resolveCwd.js";
 import type { Timeouts } from "./run.js";
 
 export interface InteractiveOptions {
-  /** Agent provider to use (e.g. claudeCode("claude-opus-4-6")) */
+  /** Agent provider to use (e.g. claudeCode("claude-opus-4-7")) */
   readonly agent: AgentProvider;
   /** Sandbox provider (e.g. docker(), noSandbox()). */
   readonly sandbox?: AnySandboxProvider;

--- a/src/interactiveArgCollection.test.ts
+++ b/src/interactiveArgCollection.test.ts
@@ -93,7 +93,7 @@ describe("interactive arg collection", () => {
     });
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       promptFile: writePrompt("Fix bug in {{COMPONENT}}"),
     });
@@ -116,7 +116,7 @@ describe("interactive arg collection", () => {
     });
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       promptFile: writePrompt("Fix bug in {{COMPONENT}}"),
       promptArgs: { COMPONENT: "LoginForm" },
@@ -131,7 +131,7 @@ describe("interactive arg collection", () => {
     const provider = makeTestProvider(async () => ({ exitCode: 0 }));
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       promptFile: writePrompt("A plain prompt with no placeholders"),
     });
@@ -143,7 +143,7 @@ describe("interactive arg collection", () => {
     const provider = makeTestProvider(async () => ({ exitCode: 0 }));
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       promptFile: writePrompt(
         "Branch {{SOURCE_BRANCH}} target {{TARGET_BRANCH}}",
@@ -163,7 +163,7 @@ describe("interactive arg collection", () => {
     });
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       promptFile: writePrompt("Fix {{COMPONENT}} issue #{{ISSUE_NUM}}"),
     });
@@ -192,7 +192,7 @@ describe("interactive arg collection", () => {
     });
 
     await interactive({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: provider,
       promptFile: writePrompt("Fix {{COMPONENT}} issue #{{ISSUE_NUM}}"),
       promptArgs: { COMPONENT: "LoginForm" },

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -249,14 +249,14 @@ describe("RunOptions", () => {
   it("requires sandbox field typed as SandboxProvider", () => {
     // @ts-expect-error sandbox is required
     const _opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       prompt: "test",
     };
   });
 
   it("allows idleTimeoutSeconds to be specified", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
       idleTimeoutSeconds: 120,
@@ -266,7 +266,7 @@ describe("RunOptions", () => {
 
   it("allows idleTimeoutSeconds to be omitted (uses default)", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
     };
@@ -275,7 +275,7 @@ describe("RunOptions", () => {
 
   it("allows name to be specified", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
       name: "my-run",
@@ -285,7 +285,7 @@ describe("RunOptions", () => {
 
   it("allows name to be omitted", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
     };
@@ -294,7 +294,7 @@ describe("RunOptions", () => {
 
   it("does not accept a worktree field", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
     };
@@ -304,7 +304,7 @@ describe("RunOptions", () => {
 
   it("allows cwd to be specified", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
       cwd: "/some/repo",
@@ -314,7 +314,7 @@ describe("RunOptions", () => {
 
   it("allows cwd to be omitted (defaults to process.cwd())", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
     };
@@ -323,7 +323,7 @@ describe("RunOptions", () => {
 
   it("does not accept a top-level branch field", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
     };
@@ -333,7 +333,7 @@ describe("RunOptions", () => {
 
   it("does not accept a top-level imageName field", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
     };
@@ -346,7 +346,7 @@ describe("signal (AbortSignal)", () => {
   it("allows signal to be specified on RunOptions", () => {
     const ac = new AbortController();
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
       signal: ac.signal,
@@ -356,7 +356,7 @@ describe("signal (AbortSignal)", () => {
 
   it("allows signal to be omitted", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
     };
@@ -368,7 +368,7 @@ describe("signal (AbortSignal)", () => {
     ac.abort("cancelled before start");
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -383,7 +383,7 @@ describe("signal (AbortSignal)", () => {
     ac.abort(reason);
     try {
       await run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -400,7 +400,7 @@ describe("resumeSession validation", () => {
   it("throws when resumeSession is set with maxIterations > 1", async () => {
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -415,7 +415,7 @@ describe("resumeSession validation", () => {
   it("throws when resumeSession file does not exist on host", async () => {
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -429,7 +429,7 @@ describe("resumeSession validation", () => {
     // not the maxIterations validation
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -443,7 +443,7 @@ describe("copyToWorktree with head branch strategy", () => {
   it("throws a runtime error when copyToWorktree is provided with head strategy", async () => {
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -470,7 +470,7 @@ describe("branchStrategy on RunOptions", () => {
 
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: isolatedSandbox,
         prompt: "test",
         branchStrategy: { type: "head" },
@@ -643,7 +643,7 @@ describe("promptFile resolution with cwd", () => {
 
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         promptFile: relativePromptFile,
         branchStrategy: { type: "head" },
@@ -657,7 +657,7 @@ describe("inline prompt passthrough", () => {
   it("errors when promptArgs is passed alongside an inline prompt", async () => {
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "do the work",
         branchStrategy: { type: "head" },
@@ -674,7 +674,7 @@ describe("inline prompt passthrough", () => {
     // The run still fails (fake sandbox can't actually run the agent) but the
     // failure must not be a prompt-substitution error.
     const promise = run({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "Issue body mentions {{BRANCH}} in its content.",
       branchStrategy: { type: "head" },
@@ -691,7 +691,7 @@ describe("inline prompt passthrough", () => {
     // pattern. An empty args object is semantically the same as "not provided"
     // and must not trigger the inline-prompt guard.
     const promise = run({
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "do the work",
       branchStrategy: { type: "head" },
@@ -724,7 +724,7 @@ describe("run() error logging to file", () => {
 
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         promptFile,
         branchStrategy: { type: "head" },
@@ -746,7 +746,7 @@ describe("run() error logging to file", () => {
 
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         promptFile,
         branchStrategy: { type: "head" },
@@ -931,7 +931,7 @@ describe("structured output entry-time validation", () => {
   it("throws when output is set with maxIterations !== 1", async () => {
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "emit <result>...</result>",
         branchStrategy: { type: "head" },
@@ -945,7 +945,7 @@ describe("structured output entry-time validation", () => {
     // Should pass maxIterations check and fail later for a different reason
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "emit <result>...</result>",
         branchStrategy: { type: "head" },
@@ -957,7 +957,7 @@ describe("structured output entry-time validation", () => {
   it("throws when output tag is not in the resolved prompt", async () => {
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "do some work",
         branchStrategy: { type: "head" },
@@ -971,7 +971,7 @@ describe("structured output entry-time validation", () => {
     // (the mock sandbox produces empty stdout, so extraction fails — but not the prompt check)
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "emit your answer inside <result> tags",
         branchStrategy: { type: "head" },
@@ -983,7 +983,7 @@ describe("structured output entry-time validation", () => {
   it("validates tag presence for Output.string as well", async () => {
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         prompt: "do some work",
         branchStrategy: { type: "head" },
@@ -999,7 +999,7 @@ describe("structured output entry-time validation", () => {
 
     await expect(
       run({
-        agent: claudeCode("claude-opus-4-6"),
+        agent: claudeCode("claude-opus-4-7"),
         sandbox: testSandbox,
         promptFile,
         branchStrategy: { type: "head" },
@@ -1012,7 +1012,7 @@ describe("structured output entry-time validation", () => {
 describe("RunOptions with output", () => {
   it("allows output field on RunOptions", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "emit <result>...</result>",
       output: Output.object({ tag: "result", schema: mockSchema() }),
@@ -1022,7 +1022,7 @@ describe("RunOptions with output", () => {
 
   it("allows output to be omitted", () => {
     const opts: RunOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       sandbox: testSandbox,
       prompt: "test",
     };
@@ -1033,7 +1033,7 @@ describe("RunOptions with output", () => {
 describe("output type-level exclusion", () => {
   it("InteractiveOptions does not accept output", () => {
     const opts: InteractiveOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       prompt: "test",
     };
     // @ts-expect-error output is not a field on InteractiveOptions
@@ -1042,7 +1042,7 @@ describe("output type-level exclusion", () => {
 
   it("WorktreeInteractiveOptions does not accept output", () => {
     const opts: WorktreeInteractiveOptions = {
-      agent: claudeCode("claude-opus-4-6"),
+      agent: claudeCode("claude-opus-4-7"),
       prompt: "test",
     };
     // @ts-expect-error output is not a field on WorktreeInteractiveOptions

--- a/src/run.ts
+++ b/src/run.ts
@@ -205,7 +205,7 @@ export interface Timeouts {
 }
 
 export interface RunOptions {
-  /** Agent provider to use (e.g. claudeCode("claude-opus-4-6")) */
+  /** Agent provider to use (e.g. claudeCode("claude-opus-4-7")) */
   readonly agent: AgentProvider;
   /** Sandbox provider (e.g. docker({ imageName: "sandcastle:myrepo" })). */
   readonly sandbox: SandboxProvider;

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -3,7 +3,7 @@
  *
  * Usage:
  *   import { docker } from "sandcastle/sandboxes/docker";
- *   await run({ agent: claudeCode("claude-opus-4-6"), sandbox: docker() });
+ *   await run({ agent: claudeCode("claude-opus-4-7"), sandbox: docker() });
  */
 
 import {

--- a/src/sandboxes/no-sandbox.ts
+++ b/src/sandboxes/no-sandbox.ts
@@ -3,7 +3,7 @@
  *
  * Usage:
  *   import { noSandbox } from "sandcastle/sandboxes/no-sandbox";
- *   await interactive({ agent: claudeCode("claude-opus-4-6"), sandbox: noSandbox() });
+ *   await interactive({ agent: claudeCode("claude-opus-4-7"), sandbox: noSandbox() });
  *
  * Only valid for `interactive()` — not accepted by `run()` or `createSandbox()`.
  * Does not pass `--dangerously-skip-permissions` to the agent — the user manages

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -3,7 +3,7 @@
  *
  * Usage:
  *   import { podman } from "sandcastle/sandboxes/podman";
- *   await run({ agent: claudeCode("claude-opus-4-6"), sandbox: podman() });
+ *   await run({ agent: claudeCode("claude-opus-4-7"), sandbox: podman() });
  */
 
 import {

--- a/src/sandboxes/vercel.ts
+++ b/src/sandboxes/vercel.ts
@@ -3,7 +3,7 @@
  *
  * Usage:
  *   import { vercel } from "sandcastle/sandboxes/vercel";
- *   await run({ agent: claudeCode("claude-opus-4-6"), sandbox: vercel() });
+ *   await run({ agent: claudeCode("claude-opus-4-7"), sandbox: vercel() });
  */
 
 import { execSync } from "node:child_process";

--- a/src/templates/blank/main.mts
+++ b/src/templates/blank/main.mts
@@ -6,7 +6,7 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 // Or add to package.json scripts: "sandcastle": "npx tsx .sandcastle/main.mts"
 
 await run({
-  agent: claudeCode("claude-opus-4-6"),
+  agent: claudeCode("claude-opus-4-7"),
   sandbox: docker(),
   promptFile: "./.sandcastle/prompt.md",
 });

--- a/src/templates/parallel-planner-with-review/main.mts
+++ b/src/templates/parallel-planner-with-review/main.mts
@@ -67,7 +67,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     // not write code.
     maxIterations: 1,
     // Opus for planning: dependency analysis benefits from deeper reasoning.
-    agent: sandcastle.claudeCode("claude-opus-4-6"),
+    agent: sandcastle.claudeCode("claude-opus-4-7"),
     promptFile: "./.sandcastle/plan-prompt.md",
   });
 

--- a/src/templates/parallel-planner/main.mts
+++ b/src/templates/parallel-planner/main.mts
@@ -62,7 +62,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     // not write code.
     maxIterations: 1,
     // Opus for planning: dependency analysis benefits from deeper reasoning.
-    agent: sandcastle.claudeCode("claude-opus-4-6"),
+    agent: sandcastle.claudeCode("claude-opus-4-7"),
     promptFile: "./.sandcastle/plan-prompt.md",
   });
 

--- a/src/templates/simple-loop/main.mts
+++ b/src/templates/simple-loop/main.mts
@@ -13,7 +13,7 @@ await run({
   sandbox: docker(),
 
   // The agent provider. Pass a model string to claudeCode() — sonnet balances
-  // capability and speed for most tasks. Switch to claude-opus-4-6 for harder
+  // capability and speed for most tasks. Switch to claude-opus-4-7 for harder
   // problems, or claude-haiku-4-5-20251001 for speed.
   agent: claudeCode("claude-sonnet-4-6"),
 


### PR DESCRIPTION
## Summary

- Replaces all references to `claude-opus-4-6` with `claude-opus-4-7` across source, templates, sandboxes, README, tests, and the example `.sandcastle` / `.factory` workflows.
- Updates `DEFAULT_MODEL` in `src/AgentProvider.ts` and the Claude Code provider entry in `src/InitService.ts`.
- Adds a patch-level changeset.

Closes #619.

## Test plan

- [x] `npm test` passes locally