### PR TITLE
feat: add allowIterResume flag to chain sessions across iterations

### DIFF
--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -189,8 +189,17 @@ export interface OrchestrateOptions {
   readonly name?: string;
   /** @internal Test-only override for the idle warning interval in milliseconds. Default: 60000 (1 minute). */
   readonly _idleWarningIntervalMs?: number;
-  /** Resume a prior Claude Code session by ID. Applied to iteration 1 only. */
+  /** Resume a prior Claude Code session by ID. Applied to iteration 1 only (unless allowIterResume is true). */
   readonly resumeSession?: string;
+  /**
+   * When true, chain the sessionId from each iteration forward as the
+   * resumeSession for the next iteration. This lets iter 2..N resume from the
+   * prior iter's warm prompt-cache instead of starting cold.
+   *
+   * Requires `iterations > 1` to have any effect. When false (default),
+   * only iteration 1 resumes from `resumeSession` (original behaviour).
+   */
+  readonly allowIterResume?: boolean;
   /** An AbortSignal that cancels the orchestration when aborted. */
   readonly signal?: AbortSignal;
   /** When true, skip prompt expansion (shell expression evaluation). Set for dynamic inline prompts. */
@@ -258,6 +267,10 @@ export const orchestrate = (
     const checkAbort = (): Effect.Effect<void> =>
       options.signal?.aborted ? Effect.die(options.signal.reason) : Effect.void;
 
+    // When allowIterResume is true, chain each iteration's sessionId forward.
+    // Starts from options.resumeSession (may be undefined); updated after each iter.
+    let currentResumeSession = options.resumeSession;
+
     for (let i = 1; i <= iterations; i++) {
       yield* checkAbort();
       yield* display.status(label(`Iteration ${i}/${iterations}`), "info");
@@ -276,9 +289,12 @@ export const orchestrate = (
             },
             (ctx) =>
               Effect.gen(function* () {
-                // Resume session: transfer JSONL from host to sandbox before iteration 1
-                const iterationResumeSession =
-                  i === 1 ? options.resumeSession : undefined;
+                // Resume session: when allowIterResume is true, chain the
+                // sessionId from the prior iteration (warm cache). Otherwise
+                // apply resumeSession to iteration 1 only (original behaviour).
+                const iterationResumeSession = options.allowIterResume
+                  ? currentResumeSession
+                  : i === 1 ? options.resumeSession : undefined;
                 if (iterationResumeSession && bindMountHandle) {
                   yield* display.status(label("Resuming session"), "info");
                   const sbStore = sandboxSessionStore(
@@ -426,6 +442,12 @@ export const orchestrate = (
         sessionFilePath: lifecycleResult.result.sessionFilePath,
         usage: lifecycleResult.result.usage,
       });
+
+      // When allowIterResume is enabled, carry this iteration's sessionId
+      // forward so the next iteration resumes from the warm cache.
+      if (options.allowIterResume && lifecycleResult.result.sessionId) {
+        currentResumeSession = lifecycleResult.result.sessionId;
+      }
 
       if (lifecycleResult.result.completionSignal !== undefined) {
         yield* display.status(

--- a/src/run.ts
+++ b/src/run.ts
@@ -248,8 +248,17 @@ export interface RunOptions {
   /** Branch strategy — controls how the agent's changes relate to branches.
    * Defaults to { type: "head" } for bind-mount providers and { type: "merge-to-head" } for isolated providers. */
   readonly branchStrategy?: BranchStrategy;
-  /** Resume a prior Claude Code session by ID. The session JSONL must exist on the host. Incompatible with maxIterations > 1. */
+  /** Resume a prior Claude Code session by ID. The session JSONL must exist on the host. Incompatible with maxIterations > 1 unless allowIterResume is set. */
   readonly resumeSession?: string;
+  /**
+   * When true, chain each iteration's sessionId forward as the resumeSession
+   * for the next iteration. This lets iter 2..N resume from the prior iter's
+   * warm prompt-cache, reducing token cost for multi-iteration runs.
+   *
+   * Requires `maxIterations > 1` to have any effect. When false (default),
+   * only iteration 1 resumes from `resumeSession` (original behaviour).
+   */
+  readonly allowIterResume?: boolean;
   /**
    * An `AbortSignal` that cancels the run when aborted.
    *
@@ -349,11 +358,13 @@ export async function run(options: RunOptions): Promise<RunResult & { output?: u
     );
   }
 
-  // Validate: resumeSession + maxIterations > 1 is not allowed
-  if (options.resumeSession && maxIterations > 1) {
+  // Validate: resumeSession + maxIterations > 1 is not allowed unless
+  // allowIterResume is set (which chains sessions across iterations).
+  if (options.resumeSession && maxIterations > 1 && !options.allowIterResume) {
     throw new Error(
       "resumeSession cannot be combined with maxIterations > 1. " +
-        "Resume applies to iteration 1 only; multi-iteration resume semantics are not supported.",
+        "Resume applies to iteration 1 only; multi-iteration resume semantics are not supported. " +
+        "Set allowIterResume: true to chain sessions across iterations.",
     );
   }
 
@@ -542,6 +553,7 @@ export async function run(options: RunOptions): Promise<RunResult & { output?: u
       idleTimeoutSeconds: options.idleTimeoutSeconds,
       name: options.name,
       resumeSession: options.resumeSession,
+      allowIterResume: options.allowIterResume,
       signal: options.signal,
       skipPromptExpansion: isInlinePrompt,
     });


### PR DESCRIPTION
## Problem

Currently `resumeSession` is applied to iteration 1 only:

```ts
// Orchestrator.ts line 281
const iterationResumeSession = i === 1 ? options.resumeSession : undefined;
```

For multi-iteration runs (maxIterations > 1), iter 2..N start cold — discarding the warm prompt-cache from the prior iteration. This increases token cost on every iteration beyond the first.

## Solution

Add an opt-in `allowIterResume?: boolean` flag to `RunOptions` and `OrchestrateOptions`. When true, each iteration's `sessionId` is chained forward as the next iteration's `resumeSession`:

```ts
// after the change
const iterationResumeSession = options.allowIterResume
  ? currentResumeSession   // chains from prior iter
  : i === 1 ? options.resumeSession : undefined;

// ...and after each iter:
if (options.allowIterResume && lifecycleResult.result.sessionId) {
  currentResumeSession = lifecycleResult.result.sessionId;
}
```

`run()` also relaxes its existing `resumeSession + maxIterations > 1` guard when `allowIterResume: true` is set.

## Behaviour

- **Default (allowIterResume: false / omitted)**: exactly the same as before — no behaviour change.
- **allowIterResume: true**: iter N+1 receives iter N's `sessionId` as `resumeSession`. Requires `maxIterations > 1` to have any effect.

## Motivation

Filed on behalf of [lbrmi/yard](https://github.com/lbrmi/yard) — a fleet orchestrator that runs Claude Code agents with multi-iteration implementer passes. We currently vendor a patched copy of `Orchestrator.js`; if this lands upstream the vendor can be removed.