### PR TITLE
feat: add claudeCodeVertex agent provider for Google Vertex AI

### DIFF
--- a/.changeset/add-claude-code-vertex-provider.md
+++ b/.changeset/add-claude-code-vertex-provider.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add `claudeCodeVertex` agent provider for running Claude Code through Google Vertex AI. Accepts `region` (required) and `projectId` (optional) as routing config; Google credentials are supplied via the sandbox environment (`GOOGLE_APPLICATION_CREDENTIALS` or Application Default Credentials). The `model` argument is passed to `claude --model` and must match a model ID enabled in your project's Vertex AI Model Garden — these IDs often need a dated suffix (e.g. `claude-opus-4-1@20250805`). Supports `effort`, `captureSessions`, and session resume — identical behaviour to `claudeCode`.

--- a/README.md
+++ b/README.md
@@ -705,26 +705,26 @@ Removes the Podman image.
 
 ### `RunOptions`
 
-| Option               | Type               | Default                       | Description                                                                                                                                                     |
-| -------------------- | ------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-7")`, `pi("claude-sonnet-4-6")`, `codex("gpt-5.4-mini")`, `opencode("opencode/big-pickle")`)      |
-| `sandbox`            | SandboxProvider    | —                             | **Required.** Sandbox provider (e.g. `docker()`, `podman()`, `docker({ imageName: "sandcastle:local" })`)                                                       |
-| `cwd`                | string             | `process.cwd()`               | Host repo directory — anchor for `.sandcastle/` artifacts and git operations. Relative paths resolve against `process.cwd()`.                                   |
-| `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                                                                                                            |
-| `promptFile`         | string             | —                             | Path to prompt file (mutually exclusive with `prompt`). Resolves against `process.cwd()`, **not** `cwd`.                                                        |
-| `maxIterations`      | number             | `1`                           | Maximum iterations to run                                                                                                                                       |
-| `hooks`              | SandboxHooks       | —                             | Lifecycle hooks (`host.*`, `sandbox.*`)                                                                                                                         |
-| `name`               | string             | —                             | Display name for the run, shown as a prefix in log output                                                                                                       |
-| `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                                                                                                            |
-| `branchStrategy`     | BranchStrategy     | per-provider default          | Branch strategy: `{ type: 'head' }`, `{ type: 'merge-to-head' }`, or `{ type: 'branch', branch: '…' }`                                                          |
-| `copyToWorktree`     | string[]           | —                             | Host-relative file paths to copy into the sandbox before start (not supported with `branchStrategy: { type: 'head' }`)                                          |
-| `logging`            | object             | file (auto-generated)         | `{ type: 'file', path }` or `{ type: 'stdout' }`                                                                                                                |
-| `completionSignal`   | string \| string[] | `<promise>COMPLETE</promise>` | String or array of strings the agent emits to stop the iteration loop early                                                                                     |
-| `idleTimeoutSeconds` | number             | `600`                         | Idle timeout in seconds — resets on each agent output event                                                                                                     |
-| `resumeSession`      | string             | —                             | Resume a prior Claude Code session by ID. Incompatible with `maxIterations > 1`. Session file must exist on host.                                               |
-| `signal`             | AbortSignal        | —                             | Cancel the run when aborted. Kills the in-flight agent subprocess and cancels lifecycle hooks; the worktree is preserved on disk. Rejects with `signal.reason`. |
-| `timeouts`           | Timeouts           | —                             | Override default timeouts for built-in lifecycle steps. Currently supports `{ copyToWorktreeMs?: number }` (default: 60 000).                                   |
-| `output`             | OutputDefinition   | —                             | Structured output definition (`Output.object(…)` or `Output.string(…)`). Requires `maxIterations === 1`. See [Structured output](#structured-output).           |
+| Option               | Type               | Default                       | Description                                                                                                                                                                                                                        |
+| -------------------- | ------------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent`              | AgentProvider      | —                             | **Required.** Agent provider (e.g. `claudeCode("claude-opus-4-7")`, `claudeCodeVertex("claude-opus-4-1@20250805", { region: "us-east5" })`, `pi("claude-sonnet-4-6")`, `codex("gpt-5.4-mini")`, `opencode("opencode/big-pickle")`) |
+| `sandbox`            | SandboxProvider    | —                             | **Required.** Sandbox provider (e.g. `docker()`, `podman()`, `docker({ imageName: "sandcastle:local" })`)                                                                                                                          |
+| `cwd`                | string             | `process.cwd()`               | Host repo directory — anchor for `.sandcastle/` artifacts and git operations. Relative paths resolve against `process.cwd()`.                                                                                                      |
+| `prompt`             | string             | —                             | Inline prompt (mutually exclusive with `promptFile`)                                                                                                                                                                               |
+| `promptFile`         | string             | —                             | Path to prompt file (mutually exclusive with `prompt`). Resolves against `process.cwd()`, **not** `cwd`.                                                                                                                           |
+| `maxIterations`      | number             | `1`                           | Maximum iterations to run                                                                                                                                                                                                          |
+| `hooks`              | SandboxHooks       | —                             | Lifecycle hooks (`host.*`, `sandbox.*`)                                                                                                                                                                                            |
+| `name`               | string             | —                             | Display name for the run, shown as a prefix in log output                                                                                                                                                                          |
+| `promptArgs`         | PromptArgs         | —                             | Key-value map for `{{KEY}}` placeholder substitution                                                                                                                                                                               |
+| `branchStrategy`     | BranchStrategy     | per-provider default          | Branch strategy: `{ type: 'head' }`, `{ type: 'merge-to-head' }`, or `{ type: 'branch', branch: '…' }`                                                                                                                             |
+| `copyToWorktree`     | string[]           | —                             | Host-relative file paths to copy into the sandbox before start (not supported with `branchStrategy: { type: 'head' }`)                                                                                                             |
+| `logging`            | object             | file (auto-generated)         | `{ type: 'file', path }` or `{ type: 'stdout' }`                                                                                                                                                                                   |
+| `completionSignal`   | string \| string[] | `<promise>COMPLETE</promise>` | String or array of strings the agent emits to stop the iteration loop early                                                                                                                                                        |
+| `idleTimeoutSeconds` | number             | `600`                         | Idle timeout in seconds — resets on each agent output event                                                                                                                                                                        |
+| `resumeSession`      | string             | —                             | Resume a prior Claude Code session by ID. Incompatible with `maxIterations > 1`. Session file must exist on host.                                                                                                                  |
+| `signal`             | AbortSignal        | —                             | Cancel the run when aborted. Kills the in-flight agent subprocess and cancels lifecycle hooks; the worktree is preserved on disk. Rejects with `signal.reason`.                                                                    |
+| `timeouts`           | Timeouts           | —                             | Override default timeouts for built-in lifecycle steps. Currently supports `{ copyToWorktreeMs?: number }` (default: 60 000).                                                                                                      |
+| `output`             | OutputDefinition   | —                             | Structured output definition (`Output.object(…)` or `Output.string(…)`). Requires `maxIterations === 1`. See [Structured output](#structured-output).                                                                              |
 
 ### `RunResult`
 
@@ -759,7 +759,7 @@ Removes the Podman image.
 
 After each Claude Code iteration, Sandcastle automatically captures the agent's session JSONL from the sandbox to the host at `~/.claude/projects/<encoded-path>/sessions/<session-id>.jsonl`. The `cwd` fields inside each JSONL entry are rewritten to match the host repo root, so `claude --resume` works natively.
 
-Session capture is enabled by default for `claudeCode()` and can be opted out via `captureSessions: false`. Non-Claude agent providers never attempt capture. Capture failure fails the run.
+Session capture is enabled by default for `claudeCode()` and `claudeCodeVertex()` and can be opted out via `captureSessions: false`. Non-Claude agent providers never attempt capture. Capture failure fails the run.
 
 ### Session resume
 
@@ -796,6 +796,41 @@ agent: claudeCode("claude-opus-4-7", { effort: "high" });
 | `effort`          | `"low"` \| `"medium"` \| `"high"` \| `"max"` | —       | Claude Code reasoning effort level (`max` is Opus only)   |
 | `env`             | `Record<string, string>`                     | `{}`    | Environment variables injected by this agent provider     |
 | `captureSessions` | `boolean`                                    | `true`  | Capture agent session JSONL to host for `claude --resume` |
+
+### `ClaudeCodeVertexOptions`
+
+The `claudeCodeVertex()` factory routes Claude Code through [Google Vertex AI](https://code.claude.com/docs/en/google-vertex-ai). It uses the same `claude` CLI binary as `claudeCode()` and produces an identical session format, so all `claudeCode()` features (session capture, `resumeSession`, `effort`) work the same way.
+
+```typescript
+agent: claudeCodeVertex("claude-opus-4-1@20250805", {
+  region: "eu",
+  projectId: "my-gcp-project",
+});
+```
+
+| Option            | Type                                         | Default | Description                                                                                                                                                                       |
+| ----------------- | -------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `region`          | `string`                                     | —       | **Required.** Vertex AI region (e.g. `"global"`, `"eu"`, `"us"`, `"us-east5"`). Sets `CLOUD_ML_REGION`.                                                                           |
+| `projectId`       | `string`                                     | —       | GCP project ID. Sets `ANTHROPIC_VERTEX_PROJECT_ID`. Optional — if omitted, the project resolves from `GOOGLE_APPLICATION_CREDENTIALS`, `gcloud`, or the attached service account. |
+| `effort`          | `"low"` \| `"medium"` \| `"high"` \| `"max"` | —       | Claude Code reasoning effort level (`max` is Opus only)                                                                                                                           |
+| `env`             | `Record<string, string>`                     | `{}`    | Environment variables injected by this agent provider                                                                                                                             |
+| `captureSessions` | `boolean`                                    | `true`  | Capture agent session JSONL to host for `claude --resume`                                                                                                                         |
+
+**Model IDs on Vertex AI.** The `model` argument is passed to `claude --model` and must match a model ID that is **enabled in your project's [Vertex AI Model Garden](https://console.cloud.google.com/vertex-ai/model-garden)**. These IDs do not always match Anthropic API names — Vertex commonly requires a dated suffix (e.g. `claude-opus-4-1@20250805`, `claude-haiku-4-5@20251001`). For AFK / unattended runs, pin a dated version so deployments stay reproducible across model rollouts. If the requested model is not enabled in your project, Claude Code fails with: _"The model `<id>` is not available on your vertex deployment."_
+
+**Region must match model availability.** `region` selects the Vertex AI endpoint (`global`, multi-region like `eu`/`us`, or specific like `us-east5`). A model enabled in your Model Garden is not automatically available on every endpoint — many newer Claude models are only served by the `global` endpoint. If you get an error like _"model `<id>` is not available on your vertex deployment"_ but the model is enabled in your project, try `region: "global"` first. See [Vertex AI partner model locations](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#genai-partner-models).
+
+**Small/fast model.** At startup, Claude Code [verifies access](https://code.claude.com/docs/en/google-vertex-ai#startup-model-checks) to **both** the primary model and a small/fast "haiku" model (default: `claude-haiku-4-5@20251001`). If that haiku ID is not enabled in your project, startup fails with _"There's an issue with the selected model (`<id>`). It may not exist or you may not have access to it."_ — even when the primary model is fine. Pin the small/fast model via `env` to any model your project can invoke:
+
+```typescript
+claudeCodeVertex("claude-opus-4-7", {
+  region: "global",
+  projectId: "my-gcp-project",
+  env: { ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5@20251001" },
+});
+```
+
+**Credentials.** Google credentials are supplied via the sandbox environment, never through factory options. Use either `GOOGLE_APPLICATION_CREDENTIALS` (path to a service account JSON file) or Application Default Credentials from `gcloud auth application-default login`. The factory injects only non-secret routing config (`CLAUDE_CODE_USE_VERTEX=1`, `CLOUD_ML_REGION`, and `ANTHROPIC_VERTEX_PROJECT_ID` when provided).
 
 ### `CodexOptions`
 

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { claudeCode, codex, opencode, pi } from "./AgentProvider.js";
+import {
+  claudeCode,
+  claudeCodeVertex,
+  codex,
+  opencode,
+  pi,
+} from "./AgentProvider.js";
 import type { AgentCommandOptions } from "./AgentProvider.js";
 
 /** Shorthand: build options with dangerouslySkipPermissions: true (mirrors existing sandbox callers). */
@@ -759,7 +765,9 @@ describe("opencode factory", () => {
   });
 
   it("buildPrintCommand shell-escapes the variant value", () => {
-    const provider = opencode("opencode/big-pickle", { variant: "it's tricky" });
+    const provider = opencode("opencode/big-pickle", {
+      variant: "it's tricky",
+    });
     const { command } = provider.buildPrintCommand(opts("test"));
     expect(command).toContain("--variant 'it'\\''s tricky'");
   });
@@ -971,5 +979,263 @@ describe("captureSessions flag", () => {
 
   it("opencode has captureSessions false", () => {
     expect(opencode("opencode-model").captureSessions).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claudeCodeVertex factory
+// ---------------------------------------------------------------------------
+
+describe("claudeCodeVertex factory", () => {
+  it("returns a provider with name 'claude-code-vertex'", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    expect(provider.name).toBe("claude-code-vertex");
+  });
+
+  it("env always contains CLAUDE_CODE_USE_VERTEX=1", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    expect(provider.env).toMatchObject({ CLAUDE_CODE_USE_VERTEX: "1" });
+  });
+
+  it("env always contains CLOUD_ML_REGION from options", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    expect(provider.env).toMatchObject({ CLOUD_ML_REGION: "us-east5" });
+  });
+
+  it("env includes ANTHROPIC_VERTEX_PROJECT_ID when projectId provided", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+      projectId: "my-gcp-project",
+    });
+    expect(provider.env).toMatchObject({
+      ANTHROPIC_VERTEX_PROJECT_ID: "my-gcp-project",
+    });
+  });
+
+  it("env omits ANTHROPIC_VERTEX_PROJECT_ID when projectId not provided", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    expect(provider.env).not.toHaveProperty("ANTHROPIC_VERTEX_PROJECT_ID");
+  });
+
+  it("env merges caller-provided env (e.g. GOOGLE_APPLICATION_CREDENTIALS)", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "global",
+      env: { GOOGLE_APPLICATION_CREDENTIALS: "/secrets/sa.json" },
+    });
+    expect(provider.env).toMatchObject({
+      CLAUDE_CODE_USE_VERTEX: "1",
+      CLOUD_ML_REGION: "global",
+      GOOGLE_APPLICATION_CREDENTIALS: "/secrets/sa.json",
+    });
+  });
+
+  it("buildPrintCommand includes the model, --print, and stream-json format", () => {
+    const provider = claudeCodeVertex("claude-sonnet-4-6", { region: "eu" });
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).toContain("claude-sonnet-4-6");
+    expect(command).toContain("--print");
+    expect(command).toContain("--output-format stream-json");
+  });
+
+  it("buildPrintCommand delivers prompt via stdin, not argv", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const { command, stdin } = provider.buildPrintCommand(opts("do something"));
+    expect(command).toContain("-p -");
+    expect(command).not.toContain("'do something'");
+    expect(stdin).toBe("do something");
+  });
+
+  it("buildPrintCommand includes --dangerously-skip-permissions when true", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const { command } = provider.buildPrintCommand({
+      prompt: "test",
+      dangerouslySkipPermissions: true,
+    });
+    expect(command).toContain("--dangerously-skip-permissions");
+  });
+
+  it("buildPrintCommand omits --dangerously-skip-permissions when false", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const { command } = provider.buildPrintCommand({
+      prompt: "test",
+      dangerouslySkipPermissions: false,
+    });
+    expect(command).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("buildPrintCommand includes --effort when specified", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+      effort: "high",
+    });
+    const { command } = provider.buildPrintCommand(opts("test"));
+    expect(command).toContain("--effort high");
+  });
+
+  it("buildPrintCommand omits --effort when not specified", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const { command } = provider.buildPrintCommand(opts("test"));
+    expect(command).not.toContain("--effort");
+  });
+
+  it("supports all effort levels", () => {
+    for (const effort of ["low", "medium", "high", "max"] as const) {
+      const provider = claudeCodeVertex("claude-opus-4-7", {
+        region: "us-east5",
+        effort,
+      });
+      expect(provider.buildPrintCommand(opts("test")).command).toContain(
+        `--effort ${effort}`,
+      );
+    }
+  });
+
+  it("buildPrintCommand includes --resume when resumeSession is set", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const { command } = provider.buildPrintCommand({
+      prompt: "test",
+      dangerouslySkipPermissions: true,
+      resumeSession: "abc-123",
+    });
+    expect(command).toContain("--resume 'abc-123'");
+  });
+
+  it("buildPrintCommand omits --resume when resumeSession is not set", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const { command } = provider.buildPrintCommand({
+      prompt: "test",
+      dangerouslySkipPermissions: true,
+    });
+    expect(command).not.toContain("--resume");
+  });
+
+  it("parseStreamLine extracts text from assistant message", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "Hello world" }] },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "text", text: "Hello world" },
+    ]);
+  });
+
+  it("parseStreamLine emits session_id from init line", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "init",
+      session_id: "vertex-session-1",
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "session_id", sessionId: "vertex-session-1" },
+    ]);
+  });
+
+  it("parseSessionUsage extracts token usage from JSONL content", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const content = JSON.stringify({
+      type: "assistant",
+      message: {
+        usage: {
+          input_tokens: 10,
+          cache_creation_input_tokens: 20,
+          cache_read_input_tokens: 30,
+          output_tokens: 40,
+        },
+      },
+    });
+    expect(provider.parseSessionUsage!(content)).toEqual({
+      inputTokens: 10,
+      cacheCreationInputTokens: 20,
+      cacheReadInputTokens: 30,
+      outputTokens: 40,
+    });
+  });
+
+  it("captureSessions defaults to true", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    expect(provider.captureSessions).toBe(true);
+  });
+
+  it("captureSessions can be set to false", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+      captureSessions: false,
+    });
+    expect(provider.captureSessions).toBe(false);
+  });
+
+  it("buildInteractiveArgs includes claude and model", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const args = provider.buildInteractiveArgs!(opts("test"));
+    expect(args[0]).toBe("claude");
+    expect(args).toContain("claude-opus-4-7");
+  });
+
+  it("buildInteractiveArgs includes --dangerously-skip-permissions when true", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const args = provider.buildInteractiveArgs!({
+      prompt: "test",
+      dangerouslySkipPermissions: true,
+    });
+    expect(args).toContain("--dangerously-skip-permissions");
+  });
+
+  it("buildInteractiveArgs omits --dangerously-skip-permissions when false", () => {
+    const provider = claudeCodeVertex("claude-opus-4-7", {
+      region: "us-east5",
+    });
+    const args = provider.buildInteractiveArgs!({
+      prompt: "test",
+      dangerouslySkipPermissions: false,
+    });
+    expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("bakes model into each provider instance independently", () => {
+    const provider1 = claudeCodeVertex("model-a", { region: "us-east5" });
+    const provider2 = claudeCodeVertex("model-b", { region: "us-east5" });
+    expect(provider1.buildPrintCommand(opts("test")).command).toContain(
+      "model-a",
+    );
+    expect(provider2.buildPrintCommand(opts("test")).command).toContain(
+      "model-b",
+    );
+    expect(provider1.buildPrintCommand(opts("test")).command).not.toContain(
+      "model-b",
+    );
   });
 });

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -21,7 +21,11 @@ const TOOL_ARG_FIELDS: Record<string, string> = {
 const extractErrorMessage = (obj: any): string | undefined => {
   const err = obj.error;
   if (typeof err === "string") return err;
-  if (typeof err === "object" && err !== null && typeof err.message === "string") {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    typeof err.message === "string"
+  ) {
     return err.message;
   }
   if (typeof obj.message === "string") return obj.message;
@@ -384,6 +388,98 @@ export const claudeCode = (
     if (dangerouslySkipPermissions) args.push("--dangerously-skip-permissions");
     args.push("--model", model);
     if (options?.effort) args.push("--effort", options.effort);
+    if (prompt) args.push(prompt);
+    return args;
+  },
+
+  parseStreamLine(line: string): ParsedStreamEvent[] {
+    return parseStreamJsonLine(line);
+  },
+
+  parseSessionUsage(content: string): IterationUsage | undefined {
+    const lines = content.split("\n");
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i]!;
+      if (!line.startsWith("{")) continue;
+      try {
+        const obj = JSON.parse(line);
+        if (obj.type === "assistant" && obj.message?.usage) {
+          const u = obj.message.usage;
+          if (
+            typeof u.input_tokens === "number" &&
+            typeof u.cache_creation_input_tokens === "number" &&
+            typeof u.cache_read_input_tokens === "number" &&
+            typeof u.output_tokens === "number"
+          ) {
+            return {
+              inputTokens: u.input_tokens,
+              cacheCreationInputTokens: u.cache_creation_input_tokens,
+              cacheReadInputTokens: u.cache_read_input_tokens,
+              outputTokens: u.output_tokens,
+            };
+          }
+        }
+      } catch {
+        // Not valid JSON — skip
+      }
+    }
+    return undefined;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Claude Code (Vertex AI) agent provider
+// ---------------------------------------------------------------------------
+
+export interface ClaudeCodeVertexOptions {
+  readonly projectId?: string;
+  readonly region: string;
+  readonly effort?: "low" | "medium" | "high" | "max";
+  readonly env?: Record<string, string>;
+  readonly captureSessions?: boolean;
+}
+
+export const claudeCodeVertex = (
+  model: string,
+  options: ClaudeCodeVertexOptions,
+): AgentProvider => ({
+  name: "claude-code-vertex",
+  env: {
+    CLAUDE_CODE_USE_VERTEX: "1",
+    CLOUD_ML_REGION: options.region,
+    ...(options.projectId
+      ? { ANTHROPIC_VERTEX_PROJECT_ID: options.projectId }
+      : {}),
+    ...options.env,
+  },
+  captureSessions: options.captureSessions ?? true,
+
+  buildPrintCommand({
+    prompt,
+    dangerouslySkipPermissions,
+    resumeSession,
+  }: AgentCommandOptions): PrintCommand {
+    const skipPerms = dangerouslySkipPermissions
+      ? " --dangerously-skip-permissions"
+      : "";
+    const effortFlag = options.effort ? ` --effort ${options.effort}` : "";
+    const resumeFlag = resumeSession
+      ? ` --resume ${shellEscape(resumeSession)}`
+      : "";
+    return {
+      command: `claude --print --verbose${skipPerms} --output-format stream-json --model ${shellEscape(model)}${effortFlag}${resumeFlag} -p -`,
+      stdin: prompt,
+    };
+  },
+
+  buildInteractiveArgs({
+    prompt,
+    dangerouslySkipPermissions,
+  }: AgentCommandOptions): string[] {
+    const args = ["claude"];
+    if (dangerouslySkipPermissions) args.push("--dangerously-skip-permissions");
+    args.push("--model", model);
+    if (options.effort) args.push("--effort", options.effort);
     if (prompt) args.push(prompt);
     return args;
   },

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -190,6 +190,41 @@ WORKDIR /home/agent
 ENTRYPOINT ["sleep", "infinity"]
 `;
 
+const CLAUDE_CODE_VERTEX_DOCKERFILE = `FROM node:22-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \\
+  git \\
+  curl \\
+  jq \\
+  && rm -rf /var/lib/apt/lists/*
+
+{{BACKLOG_MANAGER_TOOLS}}
+
+# Build-args for UID/GID alignment: sandcastle docker build-image
+# defaults these to the host user's UID/GID so image-built files
+# and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+# Rename the base image's "node" user to "agent" and align UID/GID.
+RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+USER \${AGENT_UID}:\${AGENT_GID}
+
+# Install Claude Code CLI
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Add Claude to PATH
+ENV PATH="/home/agent/.local/bin:$PATH"
+
+WORKDIR /home/agent
+
+# In worktree sandbox mode, Sandcastle bind-mounts the git worktree at \${SANDBOX_REPO_DIR}
+# and overrides the working directory to \${SANDBOX_REPO_DIR} at container start.
+# Structure your Dockerfile so that \${SANDBOX_REPO_DIR} can serve as the project root.
+ENTRYPOINT ["sleep", "infinity"]
+`;
+
 const AGENT_REGISTRY: AgentEntry[] = [
   {
     name: "claude-code",
@@ -227,6 +262,17 @@ OPENAI_KEY=`,
     dockerfileTemplate: OPENCODE_DOCKERFILE,
     envExample: `# OpenCode API key
 OPENCODE_API_KEY=`,
+  },
+  {
+    name: "claude-code-vertex",
+    label: "Claude Code (Vertex AI)",
+    defaultModel: "claude-opus-4-7",
+    factoryImport: "claudeCodeVertex",
+    dockerfileTemplate: CLAUDE_CODE_VERTEX_DOCKERFILE,
+    envExample: `# Google Cloud project ID for Vertex AI
+ANTHROPIC_VERTEX_PROJECT_ID=
+# Google credentials — path to service account JSON (or use Application Default Credentials)
+GOOGLE_APPLICATION_CREDENTIALS=`,
   },
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,12 +51,19 @@ export type {
   OutputStringDefinition,
 } from "./Output.js";
 export { CwdError } from "./resolveCwd.js";
-export { claudeCode, codex, opencode, pi } from "./AgentProvider.js";
+export {
+  claudeCode,
+  claudeCodeVertex,
+  codex,
+  opencode,
+  pi,
+} from "./AgentProvider.js";
 export type {
   AgentProvider,
   AgentCommandOptions,
   PrintCommand,
   ClaudeCodeOptions,
+  ClaudeCodeVertexOptions,
   CodexOptions,
   OpenCodeOptions,
   PiOptions,


### PR DESCRIPTION
## Summary

- Adds a new `claudeCodeVertex()` agent provider that routes Claude Code through [Google Vertex AI](https://code.claude.com/docs/en/google-vertex-ai), enabling AFK / unattended runs against models hosted in a customer's GCP project.
- Uses the same `claude` CLI binary as `claudeCode()` and produces an identical session format — session capture, `--resume`, and `effort` work the same way.
- The factory injects only non-secret routing config (`CLAUDE_CODE_USE_VERTEX=1`, `CLOUD_ML_REGION`, `ANTHROPIC_VERTEX_PROJECT_ID`). Google credentials are always supplied via the sandbox environment (`GOOGLE_APPLICATION_CREDENTIALS` or Application Default Credentials), matching the pattern `claudeCode()` uses for `ANTHROPIC_API_KEY`.
- `sandcastle init` offers a "Claude Code (Vertex AI)" template choice with a matching Dockerfile.

## API

```typescript
import { claudeCodeVertex, run } from "@ai-hero/sandcastle";
import { docker } from "@ai-hero/sandcastle/sandboxes/docker";

await run({
  agent: claudeCodeVertex("claude-opus-4-7", {
    region: "global",
    projectId: "my-gcp-project",
    // Optional — Claude Code verifies a small/fast model at startup too:
    env: { ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5@20251001" },
  }),
  sandbox: docker(),
  prompt: "…",
});
```

## Vertex-specific gotchas (documented in the README)

These aren't obvious from the Anthropic Vertex docs and tripped me up during smoke testing — surfaced as explicit callouts in the new `ClaudeCodeVertexOptions` README section:

1. **Model IDs must match Model Garden entries.** Vertex commonly requires a dated suffix (e.g. `claude-opus-4-1@20250805`). For AFK runs, pin a dated version.
2. **Region must match where the model is actually served.** A model enabled in Model Garden isn't automatically on every endpoint — many newer models are only on `region: "global"`. Wrong region surfaces as _"model is not available on your vertex deployment"_.
3. **Claude Code verifies both a primary and a small/fast (haiku) model at startup.** If the default haiku ID isn't enabled in your project, startup fails with _"may not exist or you may not have access to it"_ — even when the primary model is fine. Workaround: set `ANTHROPIC_DEFAULT_HAIKU_MODEL` via `env`.

## Test plan

- [x] `npx vitest run src/AgentProvider.test.ts` — 133 tests pass (23 new tests for `claudeCodeVertex` covering name, env vars with/without `projectId`, `env` merging, `buildPrintCommand` flags, `parseStreamLine`, `parseSessionUsage`, `captureSessions` default/override, `buildInteractiveArgs`, model independence).
- [x] `npm run typecheck` — only pre-existing `@daytona/sdk` errors remain (unrelated to this change).
- [x] End-to-end smoke test against a real GCP project — confirmed Claude Code routes successfully through Vertex AI with the documented config (`region: "global"`, `ANTHROPIC_DEFAULT_HAIKU_MODEL` override). Exit code 0, Claude responded.
- [x] Changeset added (`@ai-hero/sandcastle` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)