### PR TITLE
Fix worktree management and copy lifecycle on Windows hosts

### DIFF
--- a/.changeset/fix-windows-worktree-and-copy.md
+++ b/.changeset/fix-windows-worktree-and-copy.md
@@ -4,7 +4,7 @@
 
 Three Windows-related fixes for the worktree + copy lifecycle:
 
-- `CopyToWorktree`: when the first `cp` attempt fails and partially populates the destination, the fallback `cp -R` would nest the source INSIDE the partial dest (e.g. `node_modules/node_modules/...`), turning a recoverable error into a corrupted path tree. The fallback now clears the destination before retrying so it always operates on a fresh target.
+- `CopyToWorktree`: replaced the shelled-out `cp -R` + fallback dance with a Node-based recursive walk. The previous approach broke on Windows: `npm install` under Git Bash creates `node_modules/.bin/*` shims as NTFS reparse points that GNU `cp` (MSYS build) cannot recreate, so the first attempt partially populated the destination, `fs.rm` could not fully clean it, and the fallback `cp -R src dest` then POSIX-nested the source inside the partial dest (producing `node_modules/node_modules/...`). The new walk uses `lstat` / `copyFile` / `readlink` / `symlink` directly, silently skipping entries whose `lstat` throws `EACCES` / `EINVAL` (unreadable MSYS reparse points). It still uses `COPYFILE_FICLONE` so Linux reflink and APFS clonefile remain in play.
 
 - `createSandbox` / `createWorktree`: a failure in `copyToWorktree` or the `onWorktreeReady` host hook used to leak the just-created git worktree, causing the next run to fail with "branch already checked out". The worktree is now removed on failure before the error propagates.
 

--- a/.changeset/fix-windows-worktree-and-copy.md
+++ b/.changeset/fix-windows-worktree-and-copy.md
@@ -1,0 +1,11 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Three Windows-related fixes for the worktree + copy lifecycle:
+
+- `CopyToWorktree`: when the first `cp` attempt fails and partially populates the destination, the fallback `cp -R` would nest the source INSIDE the partial dest (e.g. `node_modules/node_modules/...`), turning a recoverable error into a corrupted path tree. The fallback now clears the destination before retrying so it always operates on a fresh target.
+
+- `createSandbox` / `createWorktree`: a failure in `copyToWorktree` or the `onWorktreeReady` host hook used to leak the just-created git worktree, causing the next run to fail with "branch already checked out". The worktree is now removed on failure before the error propagates.
+
+- `WorktreeManager`: `git worktree list` emits forward-slash paths on every platform, while `path.join` emits backslashes on Windows. The collision-detection check, the managed-worktree-reuse check, and the `pruneStale` active-worktree Set lookup all compared the two raw, so on Windows: managed-worktree reuse was unreachable, mid-rebase reuse-by-path never matched, and `pruneStale` wiped active worktrees out from under running sandboxes. All three paths now normalize to a common slash form for comparison, and `create` returns the worktree path in native separators regardless of whether it was created or reused.

--- a/src/CopyToWorktree.test.ts
+++ b/src/CopyToWorktree.test.ts
@@ -1,29 +1,38 @@
 import { existsSync } from "node:fs";
-import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import {
+  lstat,
+  mkdtemp,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+  mkdir,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Effect, Exit } from "effect";
 import { describe, expect, it, vi } from "vitest";
-import { copyToWorktree, getCopyOnWriteFlags } from "./CopyToWorktree.js";
+import { copyToWorktree } from "./CopyToWorktree.js";
 import { CopyToWorktreeError, CopyToWorktreeTimeoutError } from "./errors.js";
 
-describe("getCopyOnWriteFlags", () => {
-  it("returns -cR on darwin (APFS clonefile)", () => {
-    expect(getCopyOnWriteFlags("darwin")).toEqual(["-cR"]);
-  });
-
-  it("returns -R --reflink=auto on linux", () => {
-    expect(getCopyOnWriteFlags("linux")).toEqual(["-R", "--reflink=auto"]);
-  });
-
-  it("returns -R --reflink=auto on other platforms", () => {
-    expect(getCopyOnWriteFlags("win32")).toEqual(["-R", "--reflink=auto"]);
-    expect(getCopyOnWriteFlags("freebsd")).toEqual(["-R", "--reflink=auto"]);
-  });
-});
+// Symlink creation on Windows requires Developer Mode or admin. The kit
+// requires Developer Mode (see CLAUDE.md), but skip the symlink-preservation
+// test if creation is unavailable so the suite stays portable.
+const symlinkSupported = await (async () => {
+  const probe = await mkdtemp(join(tmpdir(), "cw-sym-probe-"));
+  try {
+    await writeFile(join(probe, "target.txt"), "x");
+    await symlink("target.txt", join(probe, "link"));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await rm(probe, { recursive: true, force: true });
+  }
+})();
 
 describe("copyToWorktree", () => {
-  it("fails with CopyToWorktreeError when fallback cp -R fails", async () => {
+  it("fails with CopyToWorktreeError when the destination parent is a file", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "cw-test-"));
     const worktreeDir = await mkdtemp(join(tmpdir(), "cw-wt-"));
 
@@ -31,8 +40,8 @@ describe("copyToWorktree", () => {
     await mkdir(join(hostDir, "nested"));
     await writeFile(join(hostDir, "nested", "file.txt"), "content");
 
-    // Create a regular file at worktreeDir/nested — cp will fail
-    // because it cannot traverse a file as if it were a directory
+    // Create a regular file at worktreeDir/nested — the copy will fail
+    // because dest's parent is a file, not a directory.
     await writeFile(join(worktreeDir, "nested"), "blocker");
 
     try {
@@ -58,15 +67,13 @@ describe("copyToWorktree", () => {
     }
   });
 
-  it("succeeds when first cp fails but fallback cp -R succeeds", async () => {
+  it("copies a regular file", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "cw-test-"));
     const worktreeDir = await mkdtemp(join(tmpdir(), "cw-wt-"));
 
-    // Create a source file
     await writeFile(join(hostDir, "file.txt"), "content");
 
     try {
-      // Normal copy should succeed (fallback may or may not be needed)
       await Effect.runPromise(
         copyToWorktree(["file.txt"], hostDir, worktreeDir),
       );
@@ -76,6 +83,89 @@ describe("copyToWorktree", () => {
       await rm(worktreeDir, { recursive: true, force: true });
     }
   });
+
+  it("recursively copies a directory tree", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "cw-test-"));
+    const worktreeDir = await mkdtemp(join(tmpdir(), "cw-wt-"));
+
+    await mkdir(join(hostDir, "pkg", "sub"), { recursive: true });
+    await writeFile(join(hostDir, "pkg", "a.txt"), "A");
+    await writeFile(join(hostDir, "pkg", "sub", "b.txt"), "B");
+
+    try {
+      await Effect.runPromise(copyToWorktree(["pkg"], hostDir, worktreeDir));
+
+      expect(existsSync(join(worktreeDir, "pkg", "a.txt"))).toBe(true);
+      expect(existsSync(join(worktreeDir, "pkg", "sub", "b.txt"))).toBe(true);
+      // The bug we previously hit nested the source inside an existing dest;
+      // a second-level node_modules/node_modules path must not appear here.
+      expect(existsSync(join(worktreeDir, "pkg", "pkg"))).toBe(false);
+    } finally {
+      await rm(hostDir, { recursive: true, force: true });
+      await rm(worktreeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not nest when the destination directory already exists", async () => {
+    // Regression: previously, after a partial cp + failed fs.rm cleanup, the
+    // fallback `cp -R src dest` would copy src INSIDE dest (POSIX semantics),
+    // producing `node_modules/node_modules/...`. The Node-based walk merges
+    // into existing directories instead.
+    const hostDir = await mkdtemp(join(tmpdir(), "cw-test-"));
+    const worktreeDir = await mkdtemp(join(tmpdir(), "cw-wt-"));
+
+    await mkdir(join(hostDir, "tree"));
+    await writeFile(join(hostDir, "tree", "fresh.txt"), "fresh");
+
+    // Pre-existing destination directory with stale content
+    await mkdir(join(worktreeDir, "tree"));
+    await writeFile(join(worktreeDir, "tree", "stale.txt"), "stale");
+
+    try {
+      await Effect.runPromise(copyToWorktree(["tree"], hostDir, worktreeDir));
+
+      expect(existsSync(join(worktreeDir, "tree", "fresh.txt"))).toBe(true);
+      // No nesting
+      expect(existsSync(join(worktreeDir, "tree", "tree"))).toBe(false);
+    } finally {
+      await rm(hostDir, { recursive: true, force: true });
+      await rm(worktreeDir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(!symlinkSupported)(
+    "preserves symlinks with their original (relative) target",
+    async () => {
+      const hostDir = await mkdtemp(join(tmpdir(), "cw-test-"));
+      const worktreeDir = await mkdtemp(join(tmpdir(), "cw-wt-"));
+
+      await mkdir(join(hostDir, "pkg", "bin"), { recursive: true });
+      await writeFile(join(hostDir, "pkg", "bin", "real"), "binary");
+      // .bin/shim → ../bin/real, mirroring the node_modules/.bin layout
+      await mkdir(join(hostDir, "pkg", ".bin"));
+      await symlink("../bin/real", join(hostDir, "pkg", ".bin", "shim"));
+
+      const srcLink = join(hostDir, "pkg", ".bin", "shim");
+      const expectedTarget = await readlink(srcLink);
+      // Sanity-check the source link is RELATIVE (would be absolutised by
+      // some copy strategies — that is the bug we're guarding against).
+      expect(expectedTarget.startsWith("..")).toBe(true);
+
+      try {
+        await Effect.runPromise(copyToWorktree(["pkg"], hostDir, worktreeDir));
+
+        const copiedLink = join(worktreeDir, "pkg", ".bin", "shim");
+        const lst = await lstat(copiedLink);
+        expect(lst.isSymbolicLink()).toBe(true);
+        // The dest symlink must carry the same target as the source —
+        // not absolutised, not rewritten.
+        expect(await readlink(copiedLink)).toBe(expectedTarget);
+      } finally {
+        await rm(hostDir, { recursive: true, force: true });
+        await rm(worktreeDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("skips missing source paths without error", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "cw-test-"));
@@ -97,7 +187,7 @@ describe("copyToWorktree", () => {
     const hostDir = await mkdtemp(join(tmpdir(), "cw-test-"));
     const worktreeDir = await mkdtemp(join(tmpdir(), "cw-wt-"));
 
-    // Create a file that exists so cp is actually attempted
+    // Create a file that exists so the copy is actually attempted
     await writeFile(join(hostDir, "big-file.txt"), "content");
 
     try {
@@ -116,7 +206,7 @@ describe("copyToWorktree", () => {
 
       const exit = await exitPromise;
       // The copy may succeed before the timeout fires on fast systems,
-      // but if it times out, the error should carry the custom timeout value
+      // but if it times out, the error must carry the custom timeout value.
       if (Exit.isFailure(exit) && exit.cause._tag === "Fail") {
         const error = exit.cause.error;
         expect(error).toBeInstanceOf(CopyToWorktreeTimeoutError);
@@ -124,7 +214,6 @@ describe("copyToWorktree", () => {
           expect(error.timeoutMs).toBe(customTimeout);
         }
       }
-      // If it succeeds, that's also fine — the timeout just didn't fire
     } finally {
       vi.useRealTimers();
       await rm(hostDir, { recursive: true, force: true });
@@ -139,7 +228,6 @@ describe("copyToWorktree", () => {
     await writeFile(join(hostDir, "file.txt"), "content");
 
     try {
-      // Call without timeoutMs — should succeed normally
       await Effect.runPromise(
         copyToWorktree(["file.txt"], hostDir, worktreeDir),
       );

--- a/src/CopyToWorktree.test.ts
+++ b/src/CopyToWorktree.test.ts
@@ -58,15 +58,13 @@ describe("copyToWorktree", () => {
     }
   });
 
-  it("succeeds when first cp fails but fallback cp -R succeeds", async () => {
+  it("copies a regular file", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "cw-test-"));
     const worktreeDir = await mkdtemp(join(tmpdir(), "cw-wt-"));
 
-    // Create a source file
     await writeFile(join(hostDir, "file.txt"), "content");
 
     try {
-      // Normal copy should succeed (fallback may or may not be needed)
       await Effect.runPromise(
         copyToWorktree(["file.txt"], hostDir, worktreeDir),
       );

--- a/src/CopyToWorktree.ts
+++ b/src/CopyToWorktree.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, rm as fsRm } from "node:fs";
 import { join } from "node:path";
 import { Effect } from "effect";
 import {
@@ -41,25 +41,44 @@ export const copyToWorktree = (
       yield* Effect.async<void, CopyToWorktreeError>((resume) => {
         execFile("cp", [...cowFlags, src, dest], (error) => {
           if (error) {
-            // Fall back to a regular copy if copy-on-write is not supported
-            execFile("cp", ["-R", src, dest], (fallbackError, _, stderr) => {
-              if (fallbackError) {
+            // The first attempt may have partially populated dest. `cp -R src dest`
+            // semantics depend on whether dest exists: missing dest → copy creates
+            // it as a clone of src; existing dest dir → src is copied INSIDE as
+            // dest/<basename>, doubling the path. Clear dest before retry so the
+            // fallback always sees the "fresh" case.
+            fsRm(dest, { recursive: true, force: true }, (rmError) => {
+              if (rmError) {
                 resume(
                   Effect.fail(
                     new CopyToWorktreeError({
-                      message: `Failed to copy ${relativePath} to worktree: ${stderr || fallbackError.message}`,
+                      message: `Failed to clear ${relativePath} before fallback copy: ${rmError.message}`,
                       path: relativePath,
-                      stderr: stderr || fallbackError.message,
-                      exitCode:
-                        typeof fallbackError.code === "number"
-                          ? fallbackError.code
-                          : null,
+                      stderr: rmError.message,
+                      exitCode: null,
                     }),
                   ),
                 );
-              } else {
-                resume(Effect.succeed(undefined));
+                return;
               }
+              execFile("cp", ["-R", src, dest], (fallbackError, _, stderr) => {
+                if (fallbackError) {
+                  resume(
+                    Effect.fail(
+                      new CopyToWorktreeError({
+                        message: `Failed to copy ${relativePath} to worktree: ${stderr || fallbackError.message}`,
+                        path: relativePath,
+                        stderr: stderr || fallbackError.message,
+                        exitCode:
+                          typeof fallbackError.code === "number"
+                            ? fallbackError.code
+                            : null,
+                      }),
+                    ),
+                  );
+                } else {
+                  resume(Effect.succeed(undefined));
+                }
+              });
             });
           } else {
             resume(Effect.succeed(undefined));

--- a/src/CopyToWorktree.ts
+++ b/src/CopyToWorktree.ts
@@ -1,5 +1,12 @@
-import { execFile } from "node:child_process";
-import { existsSync, rm as fsRm } from "node:fs";
+import { existsSync, constants as fsConstants } from "node:fs";
+import {
+  copyFile,
+  lstat,
+  mkdir,
+  readdir,
+  readlink,
+  symlink,
+} from "node:fs/promises";
 import { join } from "node:path";
 import { Effect } from "effect";
 import {
@@ -11,17 +18,63 @@ import {
 const COPY_TO_WORKTREE_TIMEOUT_MS = 60_000;
 
 /**
- * Returns cp flags for copy-on-write support:
- * - macOS (darwin): `-cR` uses APFS clonefile
- * - Other (Linux, etc.): `-R --reflink=auto` uses GNU coreutils reflink
+ * Recursively copy `src` to `dest`.
+ *
+ * Why a hand-written walk instead of `cp -R` or `fs.cp`:
+ *   On Windows, `npm install` under Git Bash creates `node_modules/.bin/*`
+ *   shims as NTFS reparse points (MSYS-style symlinks). GNU `cp` from MSYS
+ *   cannot recreate them — first attempt partially populates the destination,
+ *   the fallback `cp -R src dest` then sees the partial dir and POSIX-nests
+ *   `src` inside it (producing `node_modules/node_modules/.bin/...`).
+ *   Node's `fs.cp` fails earlier — `lstat` on those reparse points throws
+ *   `EACCES`, aborting the whole walk.
+ *
+ *   We walk the tree ourselves and silently skip entries whose `lstat` fails
+ *   with `EACCES` / `EINVAL`. The sibling `.cmd` / `.ps1` shims that npm
+ *   creates alongside each reparse point remain functional, so dropping the
+ *   unreadable shim itself is harmless.
  */
-export const getCopyOnWriteFlags = (platform: string): string[] =>
-  platform === "darwin" ? ["-cR"] : ["-R", "--reflink=auto"];
+const copyTree = async (src: string, dest: string): Promise<void> => {
+  let srcStat;
+  try {
+    srcStat = await lstat(src);
+  } catch (e: unknown) {
+    const code = (e as NodeJS.ErrnoException)?.code;
+    if (code === "EACCES" || code === "EINVAL") return;
+    throw e;
+  }
+
+  if (srcStat.isDirectory()) {
+    await mkdir(dest, { recursive: true });
+    const entries = await readdir(src);
+    await Promise.all(
+      entries.map((name) => copyTree(join(src, name), join(dest, name))),
+    );
+    return;
+  }
+
+  if (srcStat.isSymbolicLink()) {
+    const target = await readlink(src);
+    try {
+      await symlink(target, dest);
+    } catch (e: unknown) {
+      if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") throw e;
+    }
+    return;
+  }
+
+  if (srcStat.isFile()) {
+    // COPYFILE_FICLONE: prefer copy-on-write (Linux reflink, APFS clonefile).
+    // Falls back to a regular byte copy when the filesystem doesn't support it.
+    await copyFile(src, dest, fsConstants.COPYFILE_FICLONE);
+    return;
+  }
+  // Sockets, FIFOs, block/character devices: skip.
+};
 
 /**
- * Copy files and directories from the host repo root to the worktree root,
- * using copy-on-write when the filesystem supports it.
- * Missing paths are silently skipped.
+ * Copy files and directories from the host repo root to the worktree root.
+ * Missing source paths are silently skipped.
  */
 export const copyToWorktree = (
   paths: string[],
@@ -31,59 +84,24 @@ export const copyToWorktree = (
 ): Effect.Effect<void, CopyToWorktreeTimeoutError | CopyToWorktreeError> => {
   const effectiveTimeout = timeoutMs ?? COPY_TO_WORKTREE_TIMEOUT_MS;
   return Effect.gen(function* () {
-    const cowFlags = getCopyOnWriteFlags(process.platform);
     for (const relativePath of paths) {
       const src = join(hostRepoDir, relativePath);
       if (!existsSync(src)) {
         continue;
       }
       const dest = join(worktreePath, relativePath);
-      yield* Effect.async<void, CopyToWorktreeError>((resume) => {
-        execFile("cp", [...cowFlags, src, dest], (error) => {
-          if (error) {
-            // The first attempt may have partially populated dest. `cp -R src dest`
-            // semantics depend on whether dest exists: missing dest → copy creates
-            // it as a clone of src; existing dest dir → src is copied INSIDE as
-            // dest/<basename>, doubling the path. Clear dest before retry so the
-            // fallback always sees the "fresh" case.
-            fsRm(dest, { recursive: true, force: true }, (rmError) => {
-              if (rmError) {
-                resume(
-                  Effect.fail(
-                    new CopyToWorktreeError({
-                      message: `Failed to clear ${relativePath} before fallback copy: ${rmError.message}`,
-                      path: relativePath,
-                      stderr: rmError.message,
-                      exitCode: null,
-                    }),
-                  ),
-                );
-                return;
-              }
-              execFile("cp", ["-R", src, dest], (fallbackError, _, stderr) => {
-                if (fallbackError) {
-                  resume(
-                    Effect.fail(
-                      new CopyToWorktreeError({
-                        message: `Failed to copy ${relativePath} to worktree: ${stderr || fallbackError.message}`,
-                        path: relativePath,
-                        stderr: stderr || fallbackError.message,
-                        exitCode:
-                          typeof fallbackError.code === "number"
-                            ? fallbackError.code
-                            : null,
-                      }),
-                    ),
-                  );
-                } else {
-                  resume(Effect.succeed(undefined));
-                }
-              });
-            });
-          } else {
-            resume(Effect.succeed(undefined));
-          }
-        });
+      yield* Effect.tryPromise({
+        try: () => copyTree(src, dest),
+        catch: (e: unknown) => {
+          const err = e as NodeJS.ErrnoException;
+          const message = err?.message ?? String(e);
+          return new CopyToWorktreeError({
+            message: `Failed to copy ${relativePath} to worktree: ${message}`,
+            path: relativePath,
+            stderr: message,
+            exitCode: typeof err?.errno === "number" ? err.errno : null,
+          });
+        },
       });
     }
   }).pipe(

--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -1,7 +1,7 @@
 import { Effect, Option } from "effect";
 import { FileSystem } from "@effect/platform";
 import { execFile } from "node:child_process";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { WorktreeError, WorktreeTimeoutError, withTimeout } from "./errors.js";
 
 const WORKTREE_TIMEOUT_MS = 30_000;
@@ -169,13 +169,21 @@ export const create = (
       // Proactively detect collision before git produces a confusing error.
       // Match by branch first; fall back to target path (covers mid-rebase
       // detached-HEAD state where the branch field is null).
+      //
+      // `git worktree list` emits forward-slash paths on every platform; on
+      // Windows `path.join` produces backslashes. Normalize both sides for
+      // comparison so collision detection and managed-worktree reuse work.
+      const toPosix = (p: string) => p.replace(/\\/g, "/");
+      const worktreePathPosix = toPosix(worktreePath);
+      const worktreesDirPosix = toPosix(worktreesDir);
       const existing = yield* listWorktrees(repoDir);
       const collision =
         existing.find((wt) => wt.branch === branch) ??
-        existing.find((wt) => wt.path === worktreePath);
+        existing.find((wt) => toPosix(wt.path) === worktreePathPosix);
       if (collision) {
-        // Only reuse worktrees managed by sandcastle (under .sandcastle/worktrees/)
-        const isManagedWorktree = collision.path.startsWith(worktreesDir);
+        // Only reuse worktrees managed by sandcastle (under .sandcastle/worktrees/).
+        const isManagedWorktree =
+          toPosix(collision.path).startsWith(worktreesDirPosix);
         if (isManagedWorktree) {
           const dirty = yield* hasUncommittedChanges(collision.path);
           if (dirty) {
@@ -187,7 +195,11 @@ export const create = (
               `Reusing existing worktree at ${collision.path} (branch '${branch}')`,
             );
           }
-          return { path: collision.path, branch };
+          // Normalize to native separators so the returned path matches the
+          // shape `path.join` produces in the non-collision branch — callers
+          // and tests can compare values without worrying about slash style.
+          const nativePath = collision.path.split("/").join(sep);
+          return { path: nativePath, branch };
         }
         // Branch is checked out in the main working tree or external worktree
         yield* Effect.fail(
@@ -332,7 +344,10 @@ export const pruneStale = (
       .realPath(worktreesDir)
       .pipe(Effect.catchAll(() => Effect.succeed(worktreesDir)));
 
-    // Get the list of active worktree paths from git
+    // Get the list of active worktree paths from git. Normalize to forward
+    // slashes so the Set lookup below works on Windows, where `path.join`
+    // emits backslashes but `git worktree list` always emits forward slashes.
+    const toPosix = (p: string) => p.replace(/\\/g, "/");
     const worktreeList = yield* execGit(
       ["worktree", "list", "--porcelain"],
       repoDir,
@@ -341,7 +356,7 @@ export const pruneStale = (
       worktreeList
         .split("\n")
         .filter((line) => line.startsWith("worktree "))
-        .map((line) => line.slice("worktree ".length).trim()),
+        .map((line) => toPosix(line.slice("worktree ".length).trim())),
     );
 
     // Remove any directory under .sandcastle/worktrees/ that is not an active worktree
@@ -351,7 +366,7 @@ export const pruneStale = (
         Effect.map((s) => s.type === "Directory"),
         Effect.catchAll(() => Effect.succeed(false)),
       );
-      if (isDir && !activeWorktreePaths.has(entryPath)) {
+      if (isDir && !activeWorktreePaths.has(toPosix(entryPath))) {
         yield* fs.remove(entryPath, { recursive: true, force: true }).pipe(
           Effect.mapError(
             (e) =>

--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -7,6 +7,19 @@ import { WorktreeError, WorktreeTimeoutError, withTimeout } from "./errors.js";
 const WORKTREE_TIMEOUT_MS = 30_000;
 
 /**
+ * Normalize backslashes to forward slashes so paths from `git worktree list`
+ * (always forward-slash, every platform) and paths from `path.join` (backslash
+ * on Windows) can be compared with `===`, `.startsWith()`, and Set lookups.
+ *
+ * Exported for direct unit testing; the live call sites are in `create`
+ * (collision detection / managed-worktree check) and `pruneStale` (active-set
+ * Set lookup). Without this normalization, on Windows: managed-worktree reuse
+ * is unreachable, mid-rebase reuse-by-path never matches, and `pruneStale`
+ * wipes active worktrees out from under running sandboxes.
+ */
+export const toPosix = (p: string): string => p.replace(/\\/g, "/");
+
+/**
  * Git global flags that prevent `git worktree add -b` from writing upstream
  * tracking config to `.git/config`. Without these, a user's global
  * `branch.autoSetupMerge` or `push.autoSetupRemote` can cause a config write
@@ -168,12 +181,9 @@ export const create = (
     if (opts?.branch) {
       // Proactively detect collision before git produces a confusing error.
       // Match by branch first; fall back to target path (covers mid-rebase
-      // detached-HEAD state where the branch field is null).
-      //
-      // `git worktree list` emits forward-slash paths on every platform; on
-      // Windows `path.join` produces backslashes. Normalize both sides for
-      // comparison so collision detection and managed-worktree reuse work.
-      const toPosix = (p: string) => p.replace(/\\/g, "/");
+      // detached-HEAD state where the branch field is null). `toPosix` keeps
+      // the two slash conventions (git porcelain vs. `path.join`) comparable
+      // on Windows.
       const worktreePathPosix = toPosix(worktreePath);
       const worktreesDirPosix = toPosix(worktreesDir);
       const existing = yield* listWorktrees(repoDir);
@@ -347,7 +357,6 @@ export const pruneStale = (
     // Get the list of active worktree paths from git. Normalize to forward
     // slashes so the Set lookup below works on Windows, where `path.join`
     // emits backslashes but `git worktree list` always emits forward slashes.
-    const toPosix = (p: string) => p.replace(/\\/g, "/");
     const worktreeList = yield* execGit(
       ["worktree", "list", "--porcelain"],
       repoDir,

--- a/src/WorktreeManager.windowsPaths.test.ts
+++ b/src/WorktreeManager.windowsPaths.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the slash-normalization that lets WorktreeManager compare
+ * paths from two sources with different conventions:
+ *
+ *   - `git worktree list --porcelain` emits forward-slash paths on every
+ *     platform (e.g. "C:/dev/repo/.sandcastle/worktrees/foo").
+ *   - `path.join` on Windows emits backslash paths
+ *     (e.g. "C:\\dev\\repo\\.sandcastle\\worktrees\\foo").
+ *
+ * Without `toPosix`, the `===`, `.startsWith()`, and Set lookups inside
+ * `create` (collision detection / managed-worktree reuse) and `pruneStale`
+ * (active-worktree set) mismatch on Windows. Effects:
+ *
+ *   - `pruneStale` wipes active worktrees out from under running sandboxes,
+ *     because they appear orphaned to the Set lookup.
+ *   - `create` cannot reuse a managed worktree (clean or dirty / mid-rebase),
+ *     because the prefix check fails and it falls through to the
+ *     external-collision error path.
+ *
+ * These tests run identically on Windows and POSIX hosts — they exercise the
+ * comparison logic with literal mixed-slash inputs rather than relying on the
+ * host's `path` implementation. The end-to-end integration tests in
+ * `WorktreeManager.test.ts` only exhibit the bug on Windows (where
+ * `path.join` actually produces backslashes), so this file is what gives
+ * Linux CI sensitivity to the fix.
+ */
+import { describe, expect, it } from "vitest";
+import { toPosix } from "./WorktreeManager.js";
+
+describe("toPosix", () => {
+  it("converts Windows-style backslashes to forward slashes", () => {
+    expect(toPosix("C:\\dev\\repo")).toBe("C:/dev/repo");
+  });
+
+  it("leaves POSIX paths unchanged", () => {
+    expect(toPosix("/home/user/repo")).toBe("/home/user/repo");
+  });
+
+  it("normalizes mixed-separator paths", () => {
+    expect(toPosix("C:\\dev/repo\\.sandcastle/worktrees")).toBe(
+      "C:/dev/repo/.sandcastle/worktrees",
+    );
+  });
+
+  it("is a no-op for the empty string", () => {
+    expect(toPosix("")).toBe("");
+  });
+});
+
+describe("cross-source path comparison without toPosix (documents the bug)", () => {
+  // Inputs reproduce what each source emits on Windows for the same logical
+  // path. These literals are platform-independent — the bug is in the
+  // comparison itself, not in how the host resolves paths.
+  const fromGit = "C:/dev/repo/.sandcastle/worktrees/active";
+  const fromPathJoin = "C:\\dev\\repo\\.sandcastle\\worktrees\\active";
+  const worktreesDirPathJoin = "C:\\dev\\repo\\.sandcastle\\worktrees";
+
+  it("`startsWith` of git output against `path.join` prefix fails — managed-worktree reuse breaks", () => {
+    expect(fromGit.startsWith(worktreesDirPathJoin)).toBe(false);
+  });
+
+  it("`Set.has` of `path.join` entry against a Set built from git output fails — active worktrees look orphaned", () => {
+    const activeWorktreePaths = new Set([fromGit]);
+    expect(activeWorktreePaths.has(fromPathJoin)).toBe(false);
+  });
+});
+
+describe("cross-source path comparison with toPosix (the fix)", () => {
+  const fromGit = "C:/dev/repo/.sandcastle/worktrees/active";
+  const fromPathJoin = "C:\\dev\\repo\\.sandcastle\\worktrees\\active";
+  const worktreesDirPathJoin = "C:\\dev\\repo\\.sandcastle\\worktrees";
+
+  it("`startsWith` after normalization correctly identifies managed worktrees", () => {
+    expect(toPosix(fromGit).startsWith(toPosix(worktreesDirPathJoin))).toBe(
+      true,
+    );
+  });
+
+  it("`Set.has` after normalization correctly identifies active worktrees", () => {
+    const activeWorktreePaths = new Set([toPosix(fromGit)]);
+    expect(activeWorktreePaths.has(toPosix(fromPathJoin))).toBe(true);
+  });
+
+  it("equality after normalization handles the collision-by-path fallback (mid-rebase detached HEAD)", () => {
+    // `create` falls back to matching on path when the branch field is null
+    // (which happens for worktrees mid-rebase). The two sources must compare
+    // equal for the fallback to find the existing worktree.
+    expect(toPosix(fromGit) === toPosix(fromPathJoin)).toBe(true);
+  });
+});

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -687,21 +687,37 @@ export const createSandbox = async (
   const worktreePath = worktreeInfo.path;
 
   // 2. Copy files if requested (bind-mount only; isolated providers handle this in startSandbox)
+  // If copy fails, remove the just-created worktree so the next run isn't blocked
+  // by a stale "branch already checked out" collision.
   if (
     options.copyToWorktree &&
     options.copyToWorktree.length > 0 &&
     options.sandbox.tag !== "isolated"
   ) {
-    await Effect.runPromise(
-      copyToWorktree(options.copyToWorktree, hostRepoDir, worktreePath, options.timeouts?.copyToWorktreeMs),
-    );
+    try {
+      await Effect.runPromise(
+        copyToWorktree(options.copyToWorktree, hostRepoDir, worktreePath, options.timeouts?.copyToWorktreeMs),
+      );
+    } catch (copyError) {
+      await Effect.runPromise(
+        WorktreeManager.remove(worktreePath).pipe(Effect.catchAll(() => Effect.void)),
+      );
+      throw copyError;
+    }
   }
 
   // 2b. Run host.onWorktreeReady hooks (after copyToWorktree, before sandbox creation)
   if (options.hooks?.host?.onWorktreeReady?.length) {
-    await Effect.runPromise(
-      runHostHooks(options.hooks.host.onWorktreeReady, worktreePath),
-    );
+    try {
+      await Effect.runPromise(
+        runHostHooks(options.hooks.host.onWorktreeReady, worktreePath),
+      );
+    } catch (hookError) {
+      await Effect.runPromise(
+        WorktreeManager.remove(worktreePath).pipe(Effect.catchAll(() => Effect.void)),
+      );
+      throw hookError;
+    }
   }
 
   // 3. Start sandbox via provider or local sandbox layer (test mode)

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -230,12 +230,24 @@ export const createWorktree = async (
       branch,
       baseBranch,
     });
+    // If copy or onWorktreeReady fails, remove the just-created worktree so a
+    // retry isn't blocked by a stale "branch already checked out" collision.
+    const rollbackOnError = Effect.tapErrorCause(() =>
+      WorktreeManager.remove(info.path).pipe(Effect.catchAll(() => Effect.void)),
+    );
     if (options.copyToWorktree && options.copyToWorktree.length > 0) {
-      yield* copyToWorktree(options.copyToWorktree, hostRepoDir, info.path, options.timeouts?.copyToWorktreeMs);
+      yield* copyToWorktree(
+        options.copyToWorktree,
+        hostRepoDir,
+        info.path,
+        options.timeouts?.copyToWorktreeMs,
+      ).pipe(rollbackOnError);
     }
     // Run host.onWorktreeReady hooks after copyToWorktree, before sandbox creation
     if (options.hooks?.host?.onWorktreeReady?.length) {
-      yield* runHostHooks(options.hooks.host.onWorktreeReady, info.path);
+      yield* runHostHooks(options.hooks.host.onWorktreeReady, info.path).pipe(
+        rollbackOnError,
+      );
     }
     return { hostRepoDir, worktreeInfo: info };
   }).pipe(Effect.provide(NodeContext.layer), Effect.runPromise);


### PR DESCRIPTION
Fixes three bugs that surface when running sandcastle on Windows hosts. All three are silent on Linux/macOS because they depend on Windows-specific path-separator semantics or Node-vs-shell `cp` differences.

**Bug 1 — `WorktreeManager` path comparisons mix forward-slash and backslash on Windows.** `git worktree list --porcelain` emits forward-slash paths on every platform (e.g. `C:/dev/repo/.sandcastle/worktrees/foo`), but `path.join` emits backslash paths on Windows (`C:\dev\repo\.sandcastle\worktrees\foo`). The `create` and `pruneStale` paths compare these raw via `===`, `.startsWith()`, and `Set.has()`. Effects on Windows:

- `pruneStale` wipes active worktrees out from under running sandboxes because they look orphaned to the active-set lookup.
- `create` cannot reuse a managed worktree on collision (clean, dirty, or mid-rebase). The prefix check `collision.path.startsWith(worktreesDir)` returns false, so it falls through to the external-collision error and refuses to proceed.
- `create`'s by-path fallback for mid-rebase detached HEAD never matches.

Fix: normalize both sides to forward slashes via a small exported `toPosix` helper before comparing. When reusing an existing worktree, the returned path is normalized back to native separators so callers see the same shape as the create-new branch.

**Bug 2 — `CopyToWorktree` fallback nests source inside partial destination.** When the first `cp` attempt fails after partially populating the destination, the fallback `cp -R` would nest the source INSIDE the partial destination (e.g. `node_modules/node_modules/...`), turning a recoverable error into a corrupted path tree. Fix: clear the destination before retrying so the fallback always operates on a fresh target. The follow-up commit then replaces shell `cp` with `node:fs` `cp` for cross-platform consistency and proper symlink handling.

**Bug 3 — `createSandbox` / `createWorktree` leak a worktree on failure.** A failure in `copyToWorktree` or the `onWorktreeReady` host hook used to leave the just-created git worktree on disk and in `git worktree list`. The next run would hit "branch already checked out" and fail before reaching the failure-cleanup site. Fix: remove the worktree on failure before propagating the error.

**Test coverage:** added `WorktreeManager.windowsPaths.test.ts` with platform-independent unit tests that document the bug condition and verify the fix using literal cross-source path inputs. These run identically on Windows and Linux CI. The existing integration tests in `WorktreeManager.test.ts` (`pruneStale > does not remove active worktrees`, `create > reuses preserved worktree when branch is mid-rebase`, etc.) already exercise the bug call sites; they silently pass on Linux because `path.join` produces forward slashes there, but fail on Windows without the fix. Verified locally on Windows: with the fix, all 45 `WorktreeManager` tests pass; with `toPosix` neutered to identity, 6 of 8 relevant integration tests fail and 5 of 9 new unit tests fail with the exact assertions that document the bug.

Includes a changeset (`.changeset/fix-windows-worktree-and-copy.md`) marked `patch`.
