### PR TITLE
Add GitLab Issues as a backlog manager option

### DIFF
--- a/.changeset/add-gitlab-backlog-manager.md
+++ b/.changeset/add-gitlab-backlog-manager.md
@@ -1,0 +1,9 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add GitLab Issues as a backlog manager option for `sandcastle init`.
+
+Selecting `gitlab-issues` scaffolds prompts that drive the `glab` CLI, installs `glab` in the sandbox Dockerfile, and writes a `GITLAB_TOKEN` (plus optional `GITLAB_HOST`) entry into `.env.example`. `glab issue close` does not accept a comment, so `CLOSE_TASK_COMMAND` is now `readonly string[]` and renders as a `&&`-joined shell pipeline (`glab issue note <ID> -m "..." && glab issue close <ID>`); the GitHub and Beads entries also become single-element arrays.
+
+A new `--backlog-manager <name>` flag on `sandcastle init` skips the interactive selection.

--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ console.log(result.output.score); // typed as number
 
 ### Templates
 
-`sandcastle init` prompts you to choose a sandbox provider (Docker or Podman), a backlog manager (GitHub Issues or Beads), and a template, which scaffolds a ready-to-use prompt and `main.mts` suited to a specific workflow. If your project's `package.json` has `"type": "module"`, the file will be named `main.ts` instead. Five templates are available:
+`sandcastle init` prompts you to choose a sandbox provider (Docker or Podman), a backlog manager (GitHub Issues, GitLab Issues, or Beads), and a template, which scaffolds a ready-to-use prompt and `main.mts` suited to a specific workflow. If your project's `package.json` has `"type": "module"`, the file will be named `main.ts` instead. Five templates are available:
 
 | Template                       | Description                                                               |
 | ------------------------------ | ------------------------------------------------------------------------- |
@@ -1151,7 +1151,8 @@ The `.sandcastle/Dockerfile` controls the sandbox environment. The default templ
 
 - **Node.js 22** (base image)
 - **git**, **curl**, **jq** (system dependencies)
-- **GitHub CLI** (`gh`)
+- **GitHub CLI** (`gh`) — when the backlog manager is `github-issues` (the default)
+- **GitLab CLI** (`glab`) — when the backlog manager is `gitlab-issues`
 - **Claude Code CLI**
 - A non-root `agent` user (required — Claude runs as this user)
 
@@ -1159,7 +1160,7 @@ When customizing the Dockerfile, ensure you keep:
 
 - A non-root user (the default `agent` user) for Claude to run as
 - `git` (required for commits and branch operations)
-- `gh` (required for issue fetching)
+- The backlog-manager CLI you picked (`gh` for GitHub, `glab` for GitLab, `bd` for Beads — required for issue fetching)
 - Claude Code CLI installed and on PATH
 
 Add your project-specific dependencies (e.g., language runtimes, build tools) to the Dockerfile as needed.

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -201,6 +201,22 @@ describe("InitService scaffold", () => {
     expect(envExample).not.toContain("GH_TOKEN=");
   });
 
+  it("generates .env.example with GITLAB_TOKEN (and commented GITLAB_HOST) when backlog manager is gitlab-issues", async () => {
+    const dir = await makeDir();
+    await runScaffold(dir, {
+      backlogManager: getBacklogManager("gitlab-issues"),
+    });
+
+    const envExample = await readFile(
+      join(dir, ".sandcastle", ".env.example"),
+      "utf-8",
+    );
+    expect(envExample).toContain("GITLAB_TOKEN=");
+    expect(envExample).not.toContain("GH_TOKEN=");
+    // GITLAB_HOST is offered for self-hosted instances but commented out by default
+    expect(envExample).toContain("# GITLAB_HOST=");
+  });
+
   it("does not scaffold config.json for blank template", async () => {
     const dir = await makeDir();
     await runScaffold(dir);
@@ -1170,7 +1186,7 @@ describe("InitService scaffold", () => {
       expect(manager!.templateArgs.VIEW_TASK_COMMAND).toContain(
         "gh issue view",
       );
-      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain(
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND.join(" && ")).toContain(
         "gh issue close",
       );
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(
@@ -1179,13 +1195,48 @@ describe("InitService scaffold", () => {
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain("gh");
     });
 
+    it("getBacklogManager returns gitlab-issues entry with expected templateArgs", () => {
+      const manager = getBacklogManager("gitlab-issues");
+      expect(manager).toBeDefined();
+      expect(manager!.label).toBe("GitLab Issues");
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "glab issue list",
+      );
+      // GitLab's raw JSON shape is reshaped via jq into the same {number,title,body,labels,comments}
+      // schema produced by github-issues, so templates stay provider-agnostic.
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain("jq");
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "number: .iid",
+      );
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "body: .description",
+      );
+      expect(manager!.templateArgs.VIEW_TASK_COMMAND).toContain(
+        "glab issue view",
+      );
+      // glab `issue close` does not accept --comment, so the close step is a 2-command array.
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toHaveLength(2);
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND[0]).toContain(
+        "glab issue note",
+      );
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND[1]).toContain(
+        "glab issue close",
+      );
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(
+        "GitLab CLI",
+      );
+      expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain("glab");
+    });
+
     it("getBacklogManager returns beads entry with expected templateArgs", () => {
       const manager = getBacklogManager("beads");
       expect(manager).toBeDefined();
       expect(manager!.label).toBe("Beads");
       expect(manager!.templateArgs.LIST_TASKS_COMMAND).toBe("bd ready --json");
       expect(manager!.templateArgs.VIEW_TASK_COMMAND).toContain("bd show");
-      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain("bd close");
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND.join(" && ")).toContain(
+        "bd close",
+      );
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain("beads");
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain("libicu72");
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(
@@ -1198,6 +1249,11 @@ describe("InitService scaffold", () => {
       expect(manager!.templateArgs.BACKLOG_MANAGER_TOOLS).toContain(
         "dpkg-architecture -qDEB_HOST_MULTIARCH",
       );
+    });
+
+    it("listBacklogManagers includes gitlab-issues", () => {
+      const managers = listBacklogManagers();
+      expect(managers.some((m) => m.name === "gitlab-issues")).toBe(true);
     });
 
     it("getBacklogManager returns undefined for unknown manager", () => {
@@ -1242,6 +1298,58 @@ describe("InitService scaffold", () => {
       expect(prompt).not.toContain("gh issue close");
       expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
       expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+    });
+
+    it("simple-loop with gitlab-issues produces prompt with glab commands and `&&`-joined close", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("gitlab-issues"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("glab issue list");
+      // Two-step close rendered as a single `&&`-joined shell pipeline
+      expect(prompt).toContain("glab issue note");
+      expect(prompt).toContain("&&");
+      expect(prompt).toContain("glab issue close");
+      expect(prompt).not.toContain("gh issue list");
+      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+    });
+
+    it("simple-loop with gitlab-issues retains --label Sandcastle when createLabel is true", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("gitlab-issues"),
+        createLabel: true,
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("--label Sandcastle");
+    });
+
+    it("simple-loop with gitlab-issues strips --label Sandcastle when createLabel is false", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        backlogManager: getBacklogManager("gitlab-issues"),
+        createLabel: false,
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).not.toContain("--label Sandcastle");
+      expect(prompt).toContain("glab issue list");
     });
 
     it("simple-loop with beads skips --label Sandcastle (no label to strip)", async () => {
@@ -1353,6 +1461,25 @@ describe("InitService scaffold", () => {
       expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
     });
 
+    it("sequential-reviewer with gitlab-issues produces implement-prompt with glab commands", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "sequential-reviewer",
+        backlogManager: getBacklogManager("gitlab-issues"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "implement-prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("glab issue list");
+      expect(prompt).toContain("glab issue note");
+      expect(prompt).toContain("glab issue close");
+      expect(prompt).not.toContain("gh issue list");
+      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+    });
+
     it("sequential-reviewer implement-prompt uses backlog-agnostic language", async () => {
       const dir = await makeDir();
       await runScaffold(dir, { templateName: "sequential-reviewer" });
@@ -1397,6 +1524,21 @@ describe("InitService scaffold", () => {
       expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
     });
 
+    it("blank with gitlab-issues produces prompt with glab issue list example", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "blank",
+        backlogManager: getBacklogManager("gitlab-issues"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("glab issue list");
+      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+    });
+
     // --- parallel-planner ---
 
     it("parallel-planner with github-issues produces plan-prompt with gh issue commands", async () => {
@@ -1430,6 +1572,37 @@ describe("InitService scaffold", () => {
       expect(planPrompt).toContain("bd ready --json");
       expect(planPrompt).not.toContain("gh issue");
       expect(planPrompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+    });
+
+    it("parallel-planner with gitlab-issues produces plan/implement/merge prompts with glab commands", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner",
+        backlogManager: getBacklogManager("gitlab-issues"),
+      });
+
+      const planPrompt = await readFile(
+        join(dir, ".sandcastle", "plan-prompt.md"),
+        "utf-8",
+      );
+      expect(planPrompt).toContain("glab issue list");
+      expect(planPrompt).not.toContain("gh issue");
+      expect(planPrompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+
+      const implementPrompt = await readFile(
+        join(dir, ".sandcastle", "implement-prompt.md"),
+        "utf-8",
+      );
+      expect(implementPrompt).toContain("glab issue view");
+      expect(implementPrompt).not.toContain("{{VIEW_TASK_COMMAND}}");
+
+      const mergePrompt = await readFile(
+        join(dir, ".sandcastle", "merge-prompt.md"),
+        "utf-8",
+      );
+      expect(mergePrompt).toContain("glab issue note");
+      expect(mergePrompt).toContain("glab issue close");
+      expect(mergePrompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
     });
 
     it("parallel-planner main.mts uses id:string and TASK_ID", async () => {
@@ -1583,6 +1756,35 @@ describe("InitService scaffold", () => {
       expect(planPrompt).toContain("bd ready --json");
       expect(planPrompt).not.toContain("gh issue");
       expect(planPrompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+    });
+
+    it("parallel-planner-with-review with gitlab-issues produces plan/implement/merge prompts with glab commands", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "parallel-planner-with-review",
+        backlogManager: getBacklogManager("gitlab-issues"),
+      });
+
+      const planPrompt = await readFile(
+        join(dir, ".sandcastle", "plan-prompt.md"),
+        "utf-8",
+      );
+      expect(planPrompt).toContain("glab issue list");
+      expect(planPrompt).not.toContain("gh issue");
+
+      const implementPrompt = await readFile(
+        join(dir, ".sandcastle", "implement-prompt.md"),
+        "utf-8",
+      );
+      expect(implementPrompt).toContain("glab issue view");
+
+      const mergePrompt = await readFile(
+        join(dir, ".sandcastle", "merge-prompt.md"),
+        "utf-8",
+      );
+      expect(mergePrompt).toContain("glab issue note");
+      expect(mergePrompt).toContain("glab issue close");
+      expect(mergePrompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
     });
 
     it("parallel-planner-with-review main.mts uses id:string and TASK_ID", async () => {
@@ -1776,6 +1978,44 @@ describe("InitService scaffold", () => {
       expect(dockerfile).toContain("beads");
       expect(dockerfile).toContain("@mariozechner/pi-coding-agent");
       expect(dockerfile).not.toContain("GitHub CLI");
+    });
+
+    it("scaffold with gitlab-issues produces Dockerfile with GitLab CLI install (no GitHub CLI)", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        backlogManager: getBacklogManager("gitlab-issues"),
+      });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfile).toContain("GitLab CLI");
+      expect(dockerfile).toContain("glab");
+      // The glab install downloads a versioned .deb from gitlab.com — verify the
+      // arch-aware download line is present so the install works on amd64 + arm64.
+      expect(dockerfile).toContain("dpkg --print-architecture");
+      expect(dockerfile).toContain("gitlab.com/gitlab-org/cli/-/releases");
+      expect(dockerfile).not.toContain("GitHub CLI");
+      expect(dockerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
+    });
+
+    it("scaffold with gitlab-issues + podman produces Containerfile with GitLab CLI install", async () => {
+      const dir = await makeDir();
+      const podmanProvider = getSandboxProvider("podman")!;
+      await runScaffold(dir, {
+        backlogManager: getBacklogManager("gitlab-issues"),
+        sandboxProvider: podmanProvider,
+      });
+
+      const containerfile = await readFile(
+        join(dir, ".sandcastle", "Containerfile"),
+        "utf-8",
+      );
+      expect(containerfile).toContain("GitLab CLI");
+      expect(containerfile).toContain("glab");
+      expect(containerfile).not.toContain("GitHub CLI");
+      expect(containerfile).not.toContain("{{BACKLOG_MANAGER_TOOLS}}");
     });
   });
 

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -242,7 +242,10 @@ export interface BacklogManagerEntry {
   readonly templateArgs: {
     readonly LIST_TASKS_COMMAND: string;
     readonly VIEW_TASK_COMMAND: string;
-    readonly CLOSE_TASK_COMMAND: string;
+    // Some backlog managers (e.g. GitLab) need multiple commands to close a task —
+    // a separate "add comment" step and a "close" step. Rendered as a `&&`-joined
+    // shell pipeline in templates.
+    readonly CLOSE_TASK_COMMAND: readonly string[];
     readonly BACKLOG_MANAGER_TOOLS: string;
   };
   /** Lines to append to `.env.example` for this backlog manager, or empty string if none needed. */
@@ -255,6 +258,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \\
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \\
   | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \\
   && apt-get update && apt-get install -y gh \\
+  && rm -rf /var/lib/apt/lists/*`;
+
+const GITLAB_CLI_TOOLS = `# Install GitLab CLI (glab)
+RUN ARCH=$(dpkg --print-architecture) \\
+  && GLAB_VERSION=$(curl -fsSL https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest | jq -r '.tag_name | sub("^v"; "")') \\
+  && curl -fsSL "https://gitlab.com/gitlab-org/cli/-/releases/v\${GLAB_VERSION}/downloads/glab_\${GLAB_VERSION}_linux_\${ARCH}.deb" -o /tmp/glab.deb \\
+  && apt-get update && apt-get install -y /tmp/glab.deb \\
+  && rm /tmp/glab.deb \\
   && rm -rf /var/lib/apt/lists/*`;
 
 const BEADS_TOOLS = `# Install system dependencies for Beads
@@ -278,11 +289,34 @@ const BACKLOG_MANAGER_REGISTRY: BacklogManagerEntry[] = [
     templateArgs: {
       LIST_TASKS_COMMAND: `gh issue list --state open --label Sandcastle --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`,
       VIEW_TASK_COMMAND: "gh issue view <ID>",
-      CLOSE_TASK_COMMAND: `gh issue close <ID> --comment "Completed by Sandcastle"`,
+      CLOSE_TASK_COMMAND: [
+        `gh issue close <ID> --comment "Completed by Sandcastle"`,
+      ],
       BACKLOG_MANAGER_TOOLS: GITHUB_CLI_TOOLS,
     },
     envExample: `# GitHub personal access token
 GH_TOKEN=`,
+  },
+  {
+    name: "gitlab-issues",
+    label: "GitLab Issues",
+    templateArgs: {
+      // Reshape `glab issue list -O json` into the same {number, title, body, labels, comments}
+      // schema as github-issues so templates remain provider-agnostic. `comments` is empty here;
+      // the agent fetches them via VIEW_TASK_COMMAND when it picks an issue.
+      LIST_TASKS_COMMAND: `glab issue list --label Sandcastle -O json -P 100 | jq -c '[.[] | {number: .iid, title, body: .description, labels: [.labels[]?], comments: []}]'`,
+      VIEW_TASK_COMMAND: "glab issue view <ID> --comments",
+      // glab's `issue close` does not accept --comment, so close is two steps.
+      CLOSE_TASK_COMMAND: [
+        `glab issue note <ID> --message "Completed by Sandcastle"`,
+        `glab issue close <ID>`,
+      ],
+      BACKLOG_MANAGER_TOOLS: GITLAB_CLI_TOOLS,
+    },
+    envExample: `# GitLab personal access token (https://gitlab.com/-/user_settings/personal_access_tokens — needs the 'api' scope)
+GITLAB_TOKEN=
+# Optional: only needed for self-hosted GitLab instances
+# GITLAB_HOST=gitlab.example.com`,
   },
   {
     name: "beads",
@@ -290,7 +324,7 @@ GH_TOKEN=`,
     templateArgs: {
       LIST_TASKS_COMMAND: "bd ready --json",
       VIEW_TASK_COMMAND: "bd show <ID>",
-      CLOSE_TASK_COMMAND: `bd close <ID> "Completed by Sandcastle"`,
+      CLOSE_TASK_COMMAND: [`bd close <ID> "Completed by Sandcastle"`],
       BACKLOG_MANAGER_TOOLS: BEADS_TOOLS,
     },
     envExample: "",
@@ -550,6 +584,14 @@ const isTextFile = (filename: string): boolean => {
 };
 
 /**
+ * Render a backlog manager `templateArg` value as a single string for substitution.
+ * Single-command values pass through; arrays are rendered as `cmd1 && cmd2 && ...`
+ * so templates can keep close steps inline (e.g. inside backticks).
+ */
+const renderTemplateArg = (value: string | readonly string[]): string =>
+  Array.isArray(value) ? value.join(" && ") : (value as string);
+
+/**
  * Replace `{{KEY}}` template arguments from the backlog manager's
  * `templateArgs` map in all text files in the scaffolded config directory.
  */
@@ -576,7 +618,7 @@ const substituteTemplateArgs = (
           )) {
             content = content.replace(
               new RegExp(`\\{\\{${key}\\}\\}`, "g"),
-              value,
+              renderTemplateArg(value as string | readonly string[]),
             );
           }
           if (content !== original) {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -166,4 +166,28 @@ describe("sandcastle CLI", () => {
       expect(output).toContain("claude-code");
     }
   });
+
+  it("init --help exposes --backlog-manager flag", async () => {
+    const { stdout } = await runCli("init --help", process.cwd());
+    expect(stdout).toContain("--backlog-manager");
+  });
+
+  it("init --backlog-manager nonexistent produces error listing available managers", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "cli-host-"));
+    await initRepo(hostDir);
+
+    try {
+      await runCli(
+        "init --agent claude-code --backlog-manager nonexistent",
+        hostDir,
+      );
+      expect.fail("Expected command to fail");
+    } catch (err: unknown) {
+      const { stdout, stderr } = err as { stdout: string; stderr: string };
+      const output = stdout + stderr;
+      expect(output).toContain("nonexistent");
+      expect(output).toContain("github-issues");
+      expect(output).toContain("gitlab-issues");
+    }
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,6 +101,13 @@ const initModelOption = Options.text("model").pipe(
   Options.optional,
 );
 
+const backlogManagerOption = Options.text("backlog-manager").pipe(
+  Options.withDescription(
+    "Backlog manager to use (e.g. github-issues, gitlab-issues, beads)",
+  ),
+  Options.optional,
+);
+
 const initCommand = Command.make(
   "init",
   {
@@ -108,12 +115,14 @@ const initCommand = Command.make(
     template: templateOption,
     agent: agentOption,
     model: initModelOption,
+    backlogManager: backlogManagerOption,
   },
   ({
     imageName: imageNameFlag,
     template,
     agent: agentFlag,
     model: modelFlag,
+    backlogManager: backlogManagerFlag,
   }) =>
     Effect.gen(function* () {
       const d = yield* Display;
@@ -197,10 +206,21 @@ const initCommand = Command.make(
         selectedSandboxProvider = getSandboxProvider(selected as string)!;
       }
 
-      // Resolve backlog manager: interactive select
+      // Resolve backlog manager: CLI flag > interactive select
       const backlogManagers = listBacklogManagers();
       let selectedBacklogManager: BacklogManagerEntry;
-      {
+      if (backlogManagerFlag._tag === "Some") {
+        const entry = getBacklogManager(backlogManagerFlag.value);
+        if (!entry) {
+          const names = backlogManagers.map((b) => b.name).join(", ");
+          yield* Effect.fail(
+            new InitError({
+              message: `Unknown backlog manager "${backlogManagerFlag.value}". Available: ${names}`,
+            }),
+          );
+        }
+        selectedBacklogManager = entry!;
+      } else {
         const selected = yield* Effect.promise(() =>
           clack.select({
             message: "Select a backlog manager:",
@@ -245,7 +265,8 @@ const initCommand = Command.make(
         selectedTemplate = selected as string;
       }
 
-      // Offer to create the "Sandcastle" label on the repo (skip for non-GitHub backlog managers)
+      // Offer to create the "Sandcastle" label on the repo (skip for backlog managers
+      // that don't use labels, e.g. beads).
       let shouldCreateLabel: boolean | symbol = false;
       if (selectedBacklogManager.name === "github-issues") {
         shouldCreateLabel = yield* Effect.promise(() =>
@@ -261,6 +282,25 @@ const initCommand = Command.make(
             try: () =>
               execSync(
                 'gh label create "Sandcastle" --description "Issues for Sandcastle to work on" --color "F9A825" 2>/dev/null',
+                { cwd, stdio: "ignore" },
+              ),
+            catch: () => undefined,
+          }).pipe(Effect.ignore);
+        }
+      } else if (selectedBacklogManager.name === "gitlab-issues") {
+        shouldCreateLabel = yield* Effect.promise(() =>
+          clack.confirm({
+            message:
+              'Create a "Sandcastle" GitLab label? (Templates filter issues by this label)',
+            initialValue: true,
+          }),
+        );
+
+        if (shouldCreateLabel === true) {
+          yield* Effect.try({
+            try: () =>
+              execSync(
+                'glab label create --name "Sandcastle" --description "Issues for Sandcastle to work on" --color "#F9A825" 2>/dev/null',
                 { cwd, stdio: "ignore" },
               ),
             catch: () => undefined,


### PR DESCRIPTION
## Summary

- Adds a new `gitlab-issues` backlog manager that drives the `glab` CLI: `sandcastle init` offers it alongside GitHub Issues and Beads, the sandbox `Dockerfile`/`Containerfile` installs `glab`, and the scaffold writes `GITLAB_TOKEN` (with a commented `GITLAB_HOST` for self-hosted instances) into `.env.example`.
- `glab issue close` does not accept a comment, so `CLOSE_TASK_COMMAND` widens from `string` to `readonly string[]` and renders as a ` && `-joined shell pipeline (`glab issue note <ID> -m "..." && glab issue close <ID>`). The GitHub and Beads entries become single-element arrays.
- New `--backlog-manager <name>` flag on `sandcastle init` skips the interactive prompt (parallels the existing `--agent` / `--template` flags).

## Design notes

- **JSON shape parity.** GitHub's `LIST_TASKS_COMMAND` produces `[{number, title, body, labels, comments}]`. To keep the templates provider-agnostic, GitLab's command reshapes `glab issue list -O json` via `jq` into the same shape (`number: .iid`, `body: .description`). `comments` is rendered as `[]`; agents fetch full comments via `VIEW_TASK_COMMAND` (`glab issue view <ID> --comments`).
- **Arch-aware install.** The GitLab CLI install resolves the latest release at build time and downloads the matching `.deb` for the container architecture (`amd64` / `arm64`), so the same `Dockerfile` works on both Apple Silicon and Linux hosts.
- **Label flow.** `cli.ts` gains a `glab label create` branch alongside the existing `gh label create` one, gated on `selectedBacklogManager.name`. The `--label Sandcastle` stripping in `rewritePromptFiles` already handles the long-form flag, so it works for GitLab too without changes.

## Test plan

- [x] `npx vitest run src/InitService.test.ts` — 161/161 pass, including 11 new tests covering registry shape, scaffold output across all 5 templates, Dockerfile install, and `.env.example` shape for GitLab.
- [x] `src/cli.test.ts` — added 2 tests for `--backlog-manager` flag (`--help` exposure + unknown-value error).
- [x] `prettier --check` clean on changed files; lint-staged ran on commit.
- [x] `tsgo --noEmit` — no new errors; only the pre-existing `@daytona/sdk` errors remain.
- [ ] Manual sandbox build with `gitlab-issues` selected (not run in this PR — the CI image build will exercise it).

## Changeset

`.changeset/add-gitlab-backlog-manager.md` (patch).