### PR TITLE
fix: gate merge phase on "branch ahead of main", not "this iteration's commits"

### DIFF
--- a/.changeset/merge-gate-on-branch-ahead-of-main.md
+++ b/.changeset/merge-gate-on-branch-ahead-of-main.md
@@ -1,0 +1,16 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix `parallel-planner` and `parallel-planner-with-review` templates (and the
+repo's own self-driving `.sandcastle/run.ts`): the merge-phase filter
+incorrectly gated on the implementer's `commits.length` from the current
+iteration. A branch that had already been advanced by a previous iteration
+whose merger never landed it would then disappear from the merger's input
+forever — each subsequent iteration's implementer would find the fix in
+place, produce zero new commits, and the orchestrator would filter the
+branch out before the merger ever saw it.
+
+Now asks git directly via `git rev-list --count main..<branch>` so any
+branch ahead of `main` reaches the merge phase, regardless of which
+iteration produced the commits.

--- a/.sandcastle/run.ts
+++ b/.sandcastle/run.ts
@@ -1,8 +1,33 @@
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
 import * as sandcastle from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 
+const execFile = promisify(execFileCb);
+
 const MAX_ITERATIONS = 10;
 const MAX_PARALLEL = 4;
+
+// True if `branch` has commits not yet on `main`. We ask git directly rather
+// than relying on the implementer's `commits.length` from this iteration —
+// a branch may already be ahead from a previous iteration whose merger
+// never picked it up, in which case the next iteration's implementer finds
+// the fix already in place, produces zero new commits, and (without this
+// check) the branch silently drops out of the merger's input forever.
+async function branchIsAheadOfMain(branch: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFile("git", [
+      "rev-list",
+      "--count",
+      `main..${branch}`,
+    ]);
+    return parseInt(stdout.trim(), 10) > 0;
+  } catch (err) {
+    console.warn(`  ⚠ couldn't check ${branch} ahead-of-main: ${err}`);
+    return false;
+  }
+}
 
 for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   console.log(`\n=== Iteration ${iteration}/${MAX_ITERATIONS} ===\n`);
@@ -108,33 +133,26 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     }
   }
 
-  const completedIssues = settled
+  const fulfilledIssues = settled
     .map((outcome, i) => ({ outcome, issue: issues[i] }))
-    .filter(
-      (
-        entry,
-      ): entry is {
-        outcome: PromiseFulfilledResult<
-          Awaited<ReturnType<typeof sandcastle.run>>
-        >;
-        issue: (typeof issues)[number];
-      } =>
-        entry.outcome.status === "fulfilled" &&
-        entry.outcome.value.commits.length > 0,
-    )
+    .filter((entry) => entry.outcome.status === "fulfilled")
     .map((entry) => entry.issue);
 
+  const aheadFlags = await Promise.all(
+    fulfilledIssues.map((issue) => branchIsAheadOfMain(issue.branch)),
+  );
+  const completedIssues = fulfilledIssues.filter((_, i) => aheadFlags[i]);
   const completedBranches = completedIssues.map((i) => i.branch);
 
   console.log(
-    `\nExecution complete. ${completedBranches.length} branch(es) with commits:`,
+    `\nExecution complete. ${completedBranches.length} branch(es) ahead of main:`,
   );
   for (const branch of completedBranches) {
     console.log(`  ${branch}`);
   }
 
   if (completedBranches.length === 0) {
-    console.log("No commits produced. Nothing to merge.");
+    console.log("No branches ahead of main. Nothing to merge.");
     continue;
   }
 

--- a/src/templates/parallel-planner-with-review/main.mts
+++ b/src/templates/parallel-planner-with-review/main.mts
@@ -21,8 +21,33 @@
 // Or add to package.json:
 //   "scripts": { "sandcastle": "npx tsx .sandcastle/main.mts" }
 
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
 import * as sandcastle from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+
+const execFile = promisify(execFileCb);
+
+// True if `branch` has commits not yet on `main`. We ask git directly rather
+// than relying on the implementer's `commits.length` from this iteration —
+// a branch may already be ahead from a previous iteration whose merger
+// never picked it up, in which case the next iteration's implementer finds
+// the fix already in place, produces zero new commits, and (without this
+// check) the branch silently drops out of the merger's input forever.
+async function branchIsAheadOfMain(branch: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFile("git", [
+      "rev-list",
+      "--count",
+      `main..${branch}`,
+    ]);
+    return parseInt(stdout.trim(), 10) > 0;
+  } catch (err) {
+    console.warn(`  ⚠ couldn't check ${branch} ahead-of-main: ${err}`);
+    return false;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -166,29 +191,35 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     }
   }
 
-  // Only pass branches that actually produced commits to the merge phase.
-  // An agent that ran successfully but made no commits has nothing to merge.
-  const completedIssues = settled
+  // Only pass branches whose tip is ahead of `main` to the merge phase. We
+  // ask git directly rather than gating on `commits.length` from this
+  // iteration's implementer — a branch may have been advanced by a previous
+  // iteration whose merger never landed it, in which case the implementer
+  // re-runs, finds the fix already in place, produces zero new commits, and
+  // (without this check) the branch silently disappears from the merger's
+  // input set forever.
+  const fulfilledIssues = settled
     .map((outcome, i) => ({ outcome, issue: issues[i]! }))
-    .filter(
-      (entry) =>
-        entry.outcome.status === "fulfilled" &&
-        entry.outcome.value.commits.length > 0,
-    )
+    .filter((entry) => entry.outcome.status === "fulfilled")
     .map((entry) => entry.issue);
 
+  const aheadFlags = await Promise.all(
+    fulfilledIssues.map((issue) => branchIsAheadOfMain(issue.branch)),
+  );
+  const completedIssues = fulfilledIssues.filter((_, i) => aheadFlags[i]!);
   const completedBranches = completedIssues.map((i) => i.branch);
 
   console.log(
-    `\nExecution complete. ${completedBranches.length} branch(es) with commits:`,
+    `\nExecution complete. ${completedBranches.length} branch(es) ahead of main:`,
   );
   for (const branch of completedBranches) {
     console.log(`  ${branch}`);
   }
 
   if (completedBranches.length === 0) {
-    // All agents ran but none made commits — nothing to merge this cycle.
-    console.log("No commits produced. Nothing to merge.");
+    // Nothing ahead of main — either all agents were no-ops this cycle or
+    // their work has already been merged in a prior cycle.
+    console.log("No branches ahead of main. Nothing to merge.");
     continue;
   }
 

--- a/src/templates/parallel-planner/main.mts
+++ b/src/templates/parallel-planner/main.mts
@@ -16,8 +16,33 @@
 // Or add to package.json:
 //   "scripts": { "sandcastle": "npx tsx .sandcastle/main.mts" }
 
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
 import * as sandcastle from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+
+const execFile = promisify(execFileCb);
+
+// True if `branch` has commits not yet on `main`. We ask git directly rather
+// than relying on the implementer's `commits.length` from this iteration —
+// a branch may already be ahead from a previous iteration whose merger
+// never picked it up, in which case the next iteration's implementer finds
+// the fix already in place, produces zero new commits, and (without this
+// check) the branch silently drops out of the merger's input forever.
+async function branchIsAheadOfMain(branch: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFile("git", [
+      "rev-list",
+      "--count",
+      `main..${branch}`,
+    ]);
+    return parseInt(stdout.trim(), 10) > 0;
+  } catch (err) {
+    console.warn(`  ⚠ couldn't check ${branch} ahead-of-main: ${err}`);
+    return false;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -136,36 +161,35 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     }
   }
 
-  // Only pass branches that actually produced commits to the merge phase.
-  // An agent that ran successfully but made no commits has nothing to merge.
-  const completedIssues = settled
+  // Only pass branches whose tip is ahead of `main` to the merge phase. We
+  // ask git directly rather than gating on `commits.length` from this
+  // iteration's implementer — a branch may have been advanced by a previous
+  // iteration whose merger never landed it, in which case the implementer
+  // re-runs, finds the fix already in place, produces zero new commits, and
+  // (without this check) the branch silently disappears from the merger's
+  // input set forever.
+  const fulfilledIssues = settled
     .map((outcome, i) => ({ outcome, issue: issues[i]! }))
-    .filter(
-      (
-        entry,
-      ): entry is {
-        outcome: PromiseFulfilledResult<
-          Awaited<ReturnType<typeof sandcastle.run>>
-        >;
-        issue: (typeof issues)[number];
-      } =>
-        entry.outcome.status === "fulfilled" &&
-        entry.outcome.value.commits.length > 0,
-    )
+    .filter((entry) => entry.outcome.status === "fulfilled")
     .map((entry) => entry.issue);
 
+  const aheadFlags = await Promise.all(
+    fulfilledIssues.map((issue) => branchIsAheadOfMain(issue.branch)),
+  );
+  const completedIssues = fulfilledIssues.filter((_, i) => aheadFlags[i]!);
   const completedBranches = completedIssues.map((i) => i.branch);
 
   console.log(
-    `\nExecution complete. ${completedBranches.length} branch(es) with commits:`,
+    `\nExecution complete. ${completedBranches.length} branch(es) ahead of main:`,
   );
   for (const branch of completedBranches) {
     console.log(`  ${branch}`);
   }
 
   if (completedBranches.length === 0) {
-    // All agents ran but none made commits — nothing to merge this cycle.
-    console.log("No commits produced. Nothing to merge.");
+    // Nothing ahead of main — either all agents were no-ops this cycle or
+    // their work has already been merged in a prior cycle.
+    console.log("No branches ahead of main. Nothing to merge.");
     continue;
   }
 


### PR DESCRIPTION
## The bug

The `parallel-planner` and `parallel-planner-with-review` templates (and the repo's own `.sandcastle/run.ts`) filter which branches to hand to the merger by checking `entry.outcome.value.commits.length > 0` — i.e. only branches whose **this iteration's** implementer added new commits.

This silently strands any branch that was already advanced by a previous iteration whose merger never landed it. The next iteration's implementer reruns, finds the fix already in place, produces zero new commits, the orchestrator filters the branch out, and the merger never sees it. The branch then sits ready-to-merge forever.

I hit this deterministically on a downstream project — the same branch was skipped across three consecutive merger cycles even though `git log main..<branch>` showed it was one commit ahead the whole time.

## The fix

Replace the in-memory `commits.length` check with `git rev-list --count main..<branch>`. Now any branch ahead of `main` reaches the merger, regardless of which iteration produced the commits.

Per [ADR 0009](docs/adr/0009-templates-no-shared-code.md) (*templates do not share code*), the `branchIsAheadOfMain` helper is copied into each template that needs it rather than extracted.

Also replaces the misleading inline comment *"An agent that ran successfully but made no commits has nothing to merge"* — that's the precise assumption this PR refutes.

## Changes

- `.sandcastle/run.ts` (self-driving config)
- `src/templates/parallel-planner/main.mts`
- `src/templates/parallel-planner-with-review/main.mts`
- `.changeset/merge-gate-on-branch-ahead-of-main.md` (patch)

## Verification

- `npm run typecheck`: clean
- `npm run build`: clean
- `npm test`: 34 pre-existing failures unchanged (confirmed identical on clean main; macOS path-resolution noise unrelated to this change)