### PR TITLE
Fix Dockerfile to handle non-unique GID for macOS compatibility

### DIFF
--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -74,7 +74,7 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+RUN groupmod -g $AGENT_GID --non-unique node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent --non-unique node
 USER \${AGENT_UID}:\${AGENT_GID}
 
 # Install Claude Code CLI
@@ -109,7 +109,7 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+RUN groupmod -g $AGENT_GID --non-unique node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent --non-unique node
 
 # Install pi coding agent (run as root before USER agent)
 RUN npm install -g @mariozechner/pi-coding-agent
@@ -142,7 +142,7 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+RUN groupmod -g $AGENT_GID --non-unique node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent --non-unique node
 
 # Install Codex CLI (run as root before USER agent)
 RUN npm install -g @openai/codex
@@ -175,7 +175,7 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+RUN groupmod -g $AGENT_GID --non-unique node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent --non-unique node
 
 # Install OpenCode CLI (run as root before USER agent)
 RUN npm install -g opencode-ai@latest


### PR DESCRIPTION
Fixes #656

## Problem
On macOS, most user belongs to a group which has GID 20. Sandcastle passes this GID to docker build, but inside the node:22-bookworm image, GID 20 is already used by another group, because of that it was causing the issue.

## Fix
Added --non-unique to both groupmod and usermod in Dockerfile for all the agents.

Before:
`RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node`

After:
`RUN groupmod -g $AGENT_GID --non-unique node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent --non-unique node`