### PR TITLE
feat: support for attaching host devices to Docker and Podman providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ const result = await run({
     env: { DOCKER_SPECIFIC: "value" },
     // Optional: attach container to Docker network(s) — string or string[]
     network: "my-network",
+    // Optional: host devices to attach to the sandbox (e.g. /dev/kvm for KVM, /dev/dri for GPU)
+    // Each entry can specify hostPath, optional sandboxPath (for remapping), and optional permissions.
+    devices: [
+      { hostPath: "/dev/kvm" },
+      { hostPath: "/dev/dri", permissions: "rw" },
+    ],
   }),
 
   // Host repo directory — replaces process.cwd() as the anchor for

--- a/src/DeviceConfig.ts
+++ b/src/DeviceConfig.ts
@@ -1,0 +1,33 @@
+/**
+ * User-facing device configuration for bind-mount sandbox providers.
+ *
+ * Each entry describes a host device to attach to the sandbox container.
+ */
+
+/** A single device descriptor for docker()/podman() providers. */
+export interface DeviceConfig {
+  /**
+   * Path on the host (e.g. `/dev/kvm`, `/dev/dri`).
+   *
+   * Unlike mounts, device paths are NOT validated at construction time —
+   * the host path may point to a device that only exists at container start.
+   */
+  readonly hostPath: string;
+  /**
+   * Path inside the sandbox container.
+   *
+   * When omitted, the device is mounted at the same path as `hostPath`.
+   */
+  readonly sandboxPath?: string;
+  /**
+   * Device permissions inside the container.
+   *
+   * One or more of:
+   * - `"r"` — read
+   * - `"w"` — write
+   * - `"m"` — mknod (create device nodes)
+   *
+   * When omitted, all permissions (`"rwm"`) are granted.
+   */
+  readonly permissions?: string;
+}

--- a/src/DockerLifecycle.test.ts
+++ b/src/DockerLifecycle.test.ts
@@ -62,6 +62,62 @@ describe("buildImage", () => {
 });
 
 describe("startContainer", () => {
+  it("passes --device flag when devices are specified", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer(
+        "ctr",
+        "img",
+        {},
+        {
+          devices: [{ hostPath: "/dev/kvm" }],
+        },
+      ),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    expect(runCall).toBeDefined();
+    const runArgs = runCall![1] as string[];
+    const deviceIdx = runArgs.indexOf("--device");
+    expect(deviceIdx).toBeGreaterThan(-1);
+    expect(runArgs[deviceIdx + 1]).toBe("/dev/kvm");
+  });
+
+  it("passes multiple --device flags when multiple devices are specified", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer(
+        "ctr",
+        "img",
+        {},
+        {
+          devices: [{ hostPath: "/dev/kvm" }, { hostPath: "/dev/dri" }],
+        },
+      ),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const firstIdx = runArgs.indexOf("--device");
+    expect(firstIdx).toBeGreaterThan(-1);
+    expect(runArgs[firstIdx + 1]).toBe("/dev/kvm");
+    const secondIdx = runArgs.indexOf("--device", firstIdx + 1);
+    expect(secondIdx).toBeGreaterThan(-1);
+    expect(runArgs[secondIdx + 1]).toBe("/dev/dri");
+  });
+
   it("passes --network flag when network is a string", async () => {
     mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
       cb(null, "", "");
@@ -104,6 +160,102 @@ describe("startContainer", () => {
     expect(runArgs[secondIdx + 1]).toBe("net2");
   });
 
+  it("passes --device with custom sandboxPath when specified", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer(
+        "ctr",
+        "img",
+        {},
+        {
+          devices: [{ hostPath: "/dev/kvm", sandboxPath: "/dev/foo" }],
+        },
+      ),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const deviceIdx = runArgs.indexOf("--device");
+    expect(runArgs[deviceIdx + 1]).toBe("/dev/kvm:/dev/foo");
+  });
+
+  it("passes --device with permissions when specified", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer(
+        "ctr",
+        "img",
+        {},
+        {
+          devices: [{ hostPath: "/dev/kvm", permissions: "rw" }],
+        },
+      ),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const deviceIdx = runArgs.indexOf("--device");
+    expect(runArgs[deviceIdx + 1]).toBe("/dev/kvm:rw");
+  });
+
+  it("passes --device with sandboxPath and permissions when both specified", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(
+      startContainer(
+        "ctr",
+        "img",
+        {},
+        {
+          devices: [
+            {
+              hostPath: "/dev/kvm",
+              sandboxPath: "/dev/foo",
+              permissions: "rwm",
+            },
+          ],
+        },
+      ),
+    );
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    const deviceIdx = runArgs.indexOf("--device");
+    expect(runArgs[deviceIdx + 1]).toBe("/dev/kvm:/dev/foo:rwm");
+  });
+
+  it("does not pass --device when devices is omitted", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
+      cb(null, "", "");
+      return undefined as any;
+    });
+
+    await Effect.runPromise(startContainer("ctr", "img", {}));
+
+    const runCall = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    );
+    const runArgs = runCall![1] as string[];
+    expect(runArgs).not.toContain("--device");
+  });
+
   it("does not pass --network when network is omitted", async () => {
     mockExecFile.mockImplementation((_cmd, _args, _opts, cb: any) => {
       cb(null, "", "");
@@ -126,11 +278,16 @@ describe("startContainer", () => {
     });
 
     await Effect.runPromise(
-      startContainer("ctr", "img", {}, {
-        volumeMounts: [
-          { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
-        ],
-      }),
+      startContainer(
+        "ctr",
+        "img",
+        {},
+        {
+          volumeMounts: [
+            { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
+          ],
+        },
+      ),
     );
 
     const runCall = mockExecFile.mock.calls.find(
@@ -149,11 +306,20 @@ describe("startContainer", () => {
     });
 
     await Effect.runPromise(
-      startContainer("ctr", "img", {}, {
-        volumeMounts: [
-          { hostPath: "/host/path", sandboxPath: "/sandbox/path", readonly: true },
-        ],
-      }),
+      startContainer(
+        "ctr",
+        "img",
+        {},
+        {
+          volumeMounts: [
+            {
+              hostPath: "/host/path",
+              sandboxPath: "/sandbox/path",
+              readonly: true,
+            },
+          ],
+        },
+      ),
     );
 
     const runCall = mockExecFile.mock.calls.find(
@@ -171,11 +337,16 @@ describe("startContainer", () => {
     });
 
     await Effect.runPromise(
-      startContainer("ctr", "img", {}, {
-        volumeMounts: [
-          { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
-        ],
-      }),
+      startContainer(
+        "ctr",
+        "img",
+        {},
+        {
+          volumeMounts: [
+            { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
+          ],
+        },
+      ),
     );
 
     const runCall = mockExecFile.mock.calls.find(
@@ -193,12 +364,17 @@ describe("startContainer", () => {
     });
 
     await Effect.runPromise(
-      startContainer("ctr", "img", {}, {
-        volumeMounts: [
-          { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
-        ],
-        selinuxLabel: "Z",
-      }),
+      startContainer(
+        "ctr",
+        "img",
+        {},
+        {
+          volumeMounts: [
+            { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
+          ],
+          selinuxLabel: "Z",
+        },
+      ),
     );
 
     const runCall = mockExecFile.mock.calls.find(
@@ -216,12 +392,17 @@ describe("startContainer", () => {
     });
 
     await Effect.runPromise(
-      startContainer("ctr", "img", {}, {
-        volumeMounts: [
-          { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
-        ],
-        selinuxLabel: false,
-      }),
+      startContainer(
+        "ctr",
+        "img",
+        {},
+        {
+          volumeMounts: [
+            { hostPath: "/host/path", sandboxPath: "/sandbox/path" },
+          ],
+          selinuxLabel: false,
+        },
+      ),
     );
 
     const runCall = mockExecFile.mock.calls.find(
@@ -239,12 +420,21 @@ describe("startContainer", () => {
     });
 
     await Effect.runPromise(
-      startContainer("ctr", "img", {}, {
-        volumeMounts: [
-          { hostPath: "/host/path", sandboxPath: "/sandbox/path", readonly: true },
-        ],
-        selinuxLabel: false,
-      }),
+      startContainer(
+        "ctr",
+        "img",
+        {},
+        {
+          volumeMounts: [
+            {
+              hostPath: "/host/path",
+              sandboxPath: "/sandbox/path",
+              readonly: true,
+            },
+          ],
+          selinuxLabel: false,
+        },
+      ),
     );
 
     const runCall = mockExecFile.mock.calls.find(

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { execFile } from "node:child_process";
 import { resolve } from "node:path";
+import type { DeviceConfig } from "./DeviceConfig.js";
 import { DockerError } from "./errors.js";
 import { formatVolumeMount, type SelinuxLabel } from "./mountUtils.js";
 
@@ -74,6 +75,7 @@ export interface VolumeMount {
 
 export interface StartContainerOptions {
   readonly volumeMounts?: readonly VolumeMount[];
+  readonly devices?: readonly DeviceConfig[];
   readonly workdir?: string;
   /** Run the container as this uid:gid instead of the Dockerfile's USER. */
   readonly user?: string;
@@ -128,6 +130,13 @@ export const startContainer = (
       formatVolumeMount(mount, selinuxLabel),
     ]);
 
+    const deviceFlags = (options?.devices ?? []).flatMap((device) => {
+      const parts = [device.hostPath];
+      if (device.sandboxPath) parts.push(device.sandboxPath);
+      if (device.permissions) parts.push(device.permissions);
+      return ["--device", parts.join(":")];
+    });
+
     const workdirFlags = options?.workdir ? ["-w", options.workdir] : [];
     const userFlags = options?.user ? ["--user", options.user] : [];
     const networks = options?.network
@@ -144,6 +153,7 @@ export const startContainer = (
       containerName,
       ...envFlags,
       ...volumeFlags,
+      ...deviceFlags,
       ...workdirFlags,
       ...userFlags,
       ...networkFlags,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export {
   defaultSessionPathsLayer,
 } from "./SessionPaths.js";
 export type { SandboxHooks } from "./SandboxLifecycle.js";
+export type { DeviceConfig } from "./DeviceConfig.js";
 export type { MountConfig } from "./MountConfig.js";
 export { Output, StructuredOutputError } from "./Output.js";
 export type {

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -128,6 +128,55 @@ describe("docker()", () => {
     expect(provider.env).toEqual({});
   });
 
+  it("accepts a devices option", () => {
+    const provider = docker({ devices: [{ hostPath: "/dev/kvm" }] });
+    expect(provider.tag).toBe("bind-mount");
+  });
+
+  it("passes --device flags to docker run when devices are specified", async () => {
+    const capturedRunArgs: string[] = [];
+    mockExecFile.mockImplementation((_command, args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      if (Array.isArray(args) && args[0] === "image" && args[1] === "inspect") {
+        callback(
+          null,
+          `${process.getuid?.() ?? 1000}:${process.getgid?.() ?? 1000}\n`,
+          "",
+        );
+      } else if (Array.isArray(args) && args[0] === "run") {
+        capturedRunArgs.push(...args);
+        callback(null, "", "");
+      } else {
+        callback(null, "", "");
+      }
+      return undefined as any;
+    });
+
+    const provider = docker({
+      devices: [
+        { hostPath: "/dev/kvm" },
+        { hostPath: "/dev/dri", permissions: "rw" },
+      ],
+    });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const deviceIdx = capturedRunArgs.indexOf("--device");
+    expect(deviceIdx).toBeGreaterThan(-1);
+    expect(capturedRunArgs[deviceIdx + 1]).toBe("/dev/kvm");
+    const secondIdx = capturedRunArgs.indexOf("--device", deviceIdx + 1);
+    expect(secondIdx).toBeGreaterThan(-1);
+    expect(capturedRunArgs[secondIdx + 1]).toBe("/dev/dri:rw");
+
+    await handle.close();
+  });
+
   it("accepts a network option as a string", () => {
     const provider = docker({ network: "my-network" });
     expect(provider.tag).toBe("bind-mount");

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -24,6 +24,7 @@ import {
   type ExecResult,
   type InteractiveExecOptions,
 } from "../SandboxProvider.js";
+import type { DeviceConfig } from "../DeviceConfig.js";
 import type { MountConfig } from "../MountConfig.js";
 import type { SelinuxLabel } from "../mountUtils.js";
 import {
@@ -63,6 +64,17 @@ export interface DockerOptions {
    * If `hostPath` does not exist, sandbox creation fails with a clear error.
    */
   readonly mounts?: readonly MountConfig[];
+  /**
+   * Host devices to attach to the sandbox container (e.g. `/dev/kvm`, `/dev/dri`).
+   *
+   * Each entry specifies a `hostPath` and optionally a `sandboxPath` (to remap
+   * inside the container) and `permissions` (`"r"`, `"w"`, `"m"`, or combinations).
+   * Passed as `--device` flags to `docker run`.
+   *
+   * Unlike mounts, device paths are NOT validated at construction time — the
+   * host path may point to a device that only exists at container start.
+   */
+  readonly devices?: readonly DeviceConfig[];
   /** Environment variables injected by this provider. Merged at launch time with env resolver and agent provider env. */
   readonly env?: Record<string, string>;
   /**
@@ -139,6 +151,7 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
           },
           {
             volumeMounts,
+            devices: options?.devices,
             workdir: worktreePath,
             user: `${containerUid}:${containerGid}`,
             network: options?.network,

--- a/src/sandboxes/podman.test.ts
+++ b/src/sandboxes/podman.test.ts
@@ -132,6 +132,47 @@ describe("podman()", () => {
     await handle.close();
   });
 
+  it("accepts a devices option", () => {
+    const provider = podman({ devices: [{ hostPath: "/dev/kvm" }] });
+    expect(provider.tag).toBe("bind-mount");
+  });
+
+  it("passes --device flags to podman run when devices are specified", async () => {
+    const capturedRunArgs: string[] = [];
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      if (Array.isArray(_args) && _args[0] === "run") {
+        capturedRunArgs.push(..._args);
+      }
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({
+      devices: [
+        { hostPath: "/dev/kvm" },
+        { hostPath: "/dev/dri", permissions: "rw" },
+      ],
+    });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const deviceIdx = capturedRunArgs.indexOf("--device");
+    expect(deviceIdx).toBeGreaterThan(-1);
+    expect(capturedRunArgs[deviceIdx + 1]).toBe("/dev/kvm");
+    const secondIdx = capturedRunArgs.indexOf("--device", deviceIdx + 1);
+    expect(secondIdx).toBeGreaterThan(-1);
+    expect(capturedRunArgs[secondIdx + 1]).toBe("/dev/dri:rw");
+
+    await handle.close();
+  });
+
   it("accepts an env option", () => {
     const provider = podman({ env: { MY_VAR: "hello" } });
     expect(provider.tag).toBe("bind-mount");

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -22,6 +22,7 @@ import {
   type ExecResult,
   type InteractiveExecOptions,
 } from "../SandboxProvider.js";
+import type { DeviceConfig } from "../DeviceConfig.js";
 import type { MountConfig } from "../MountConfig.js";
 import type { SelinuxLabel } from "../mountUtils.js";
 import {
@@ -72,6 +73,17 @@ export interface PodmanOptions {
    * If `hostPath` does not exist, sandbox creation fails with a clear error.
    */
   readonly mounts?: readonly MountConfig[];
+  /**
+   * Host devices to attach to the sandbox container (e.g. `/dev/kvm`, `/dev/dri`).
+   *
+   * Each entry specifies a `hostPath` and optionally a `sandboxPath` (to remap
+   * inside the container) and `permissions` (`"r"`, `"w"`, `"m"`, or combinations).
+   * Passed as `--device` flags to `podman run`.
+   *
+   * Unlike mounts, device paths are NOT validated at construction time — the
+   * host path may point to a device that only exists at container start.
+   */
+  readonly devices?: readonly DeviceConfig[];
   /** Environment variables injected by this provider. Merged at launch time with env resolver and agent provider env. */
   readonly env?: Record<string, string>;
   /**
@@ -148,6 +160,12 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
         `${key}=${value}`,
       ]);
       const volumeArgs = volumeMounts.flatMap((v) => ["-v", v]);
+      const deviceArgs = (options?.devices ?? []).flatMap((device) => {
+        const parts = [device.hostPath];
+        if (device.sandboxPath) parts.push(device.sandboxPath);
+        if (device.permissions) parts.push(device.permissions);
+        return ["--device", parts.join(":")];
+      });
       const usernsArgs = userns
         ? [`--userns=keep-id:uid=${containerUid},gid=${containerGid}`]
         : [];
@@ -171,6 +189,7 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
             ...userArgs,
             ...usernsArgs,
             ...networkArgs,
+            ...deviceArgs,
             "-w",
             worktreePath,
             ...envArgs,


### PR DESCRIPTION
Closes #662 

Adds a devices option to both docker() and podman() sandbox providers, allowing users to attach host devices (e.g. /dev/kvm for KVM, /dev/dri for GPU) to sandbox containers via --device flags.

- New DeviceConfig interface (src/DeviceConfig.ts) with hostPath, optional sandboxPath (for remapping), and optional permissions ("r", "w", "m")
- DockerLifecycle.startContainer accepts devices in StartContainerOptions and emits one --device flag per entry, formatted as hostPath[:sandboxPath][:permissions]
- docker() and podman() providers forward devices to startContainer / podman run
- DeviceConfig re-exported from package index
- README updated with usage example
- 8 new test cases covering single device, multiple devices, sandboxPath, permissions, combined options, and omitted devices edge case
