### PR TITLE
fix: added daytona sdk minimal type declarations

### DIFF
--- a/src/daytona-sdk.d.ts
+++ b/src/daytona-sdk.d.ts
@@ -1,0 +1,72 @@
+/** Minimal type declarations for @daytona/sdk (optional peer dependency). */
+declare module "@daytona/sdk" {
+  export interface DaytonaConfig {
+    apiKey?: string;
+    apiUrl?: string;
+    target?: string;
+  }
+
+  export interface CreateSandboxFromImageParams {
+    [key: string]: unknown;
+  }
+
+  export interface CreateSandboxFromSnapshotParams {
+    [key: string]: unknown;
+  }
+
+  interface SessionCommandResponse {
+    cmdId?: string;
+  }
+
+  interface SessionCommandInfo {
+    exitCode?: number;
+  }
+
+  interface ExecuteCommandResponse {
+    result: string;
+    exitCode: number;
+  }
+
+  interface SandboxProcess {
+    createSession(sessionId: string): Promise<void>;
+    executeSessionCommand(
+      sessionId: string,
+      options: { command: string; async?: boolean },
+    ): Promise<SessionCommandResponse>;
+    getSessionCommandLogs(
+      sessionId: string,
+      cmdId: string,
+      onStdout?: (chunk: string) => void,
+      onStderr?: (chunk: string) => void,
+    ): Promise<void>;
+    getSessionCommand(
+      sessionId: string,
+      cmdId: string,
+    ): Promise<SessionCommandInfo>;
+    deleteSession(sessionId: string): Promise<void>;
+    executeCommand(
+      command: string,
+      cwd?: string,
+    ): Promise<ExecuteCommandResponse>;
+  }
+
+  interface SandboxFileSystem {
+    uploadFile(localPath: string, remotePath: string): Promise<void>;
+    downloadFile(remotePath: string, localPath: string): Promise<void>;
+  }
+
+  interface SandboxInstance {
+    process: SandboxProcess;
+    fs: SandboxFileSystem;
+    getWorkDir(): Promise<string | undefined>;
+    getUserHomeDir(): Promise<string | undefined>;
+  }
+
+  export class Daytona {
+    constructor(config?: DaytonaConfig);
+    create(
+      params?: CreateSandboxFromImageParams | CreateSandboxFromSnapshotParams,
+    ): Promise<SandboxInstance>;
+    delete(sandbox: SandboxInstance): Promise<void>;
+  }
+}


### PR DESCRIPTION
The latest release failed to build (https://github.com/mattpocock/sandcastle/actions/runs/26090710488) think its because of this bug https://github.com/npm/cli/issues/9249

This PR introduces daytona sdk minimal type declarations similar to the vercel sandbox sdk to make the build work without the optional peer dependency.