### PR TITLE
feat: add universal OpenAI-compatible provider support to opencode wi…

### DIFF
--- a/.changeset/opencode-crofai-support.md
+++ b/.changeset/opencode-crofai-support.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Add `apiBaseUrl` option to opencode provider for OpenAI-compatible API backends (e.g. crof.ai)

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -759,7 +759,9 @@ describe("opencode factory", () => {
   });
 
   it("buildPrintCommand shell-escapes the variant value", () => {
-    const provider = opencode("opencode/big-pickle", { variant: "it's tricky" });
+    const provider = opencode("opencode/big-pickle", {
+      variant: "it's tricky",
+    });
     const { command } = provider.buildPrintCommand(opts("test"));
     expect(command).toContain("--variant 'it'\\''s tricky'");
   });
@@ -807,6 +809,55 @@ describe("opencode factory", () => {
   it("defaults env to empty object when not provided", () => {
     const provider = opencode("opencode/big-pickle");
     expect(provider.env).toEqual({});
+  });
+
+  it("injects OPENCODE_CONFIG_CONTENT when apiBaseUrl is set (generic)", () => {
+    const provider = opencode("openai/gpt-4o-mini", {
+      apiBaseUrl: "https://custom-api.example.com/v1",
+    });
+    expect(provider.env).toHaveProperty("OPENCODE_CONFIG_CONTENT");
+    const config = JSON.parse(provider.env["OPENCODE_CONFIG_CONTENT"]!);
+    expect(config.provider.openai.options.baseURL).toBe(
+      "https://custom-api.example.com/v1",
+    );
+    expect(config.provider.openai.options.apiKey).toBeUndefined();
+  });
+
+  it("provider preset 'crofai' sets baseURL and apiKey mapping", () => {
+    const provider = opencode("openai/gpt-4o-mini", {
+      provider: "crofai",
+    });
+    expect(provider.env).toHaveProperty("OPENCODE_CONFIG_CONTENT");
+    const config = JSON.parse(provider.env["OPENCODE_CONFIG_CONTENT"]!);
+    expect(config.provider.openai.options.baseURL).toBe("https://crof.ai/v1");
+    expect(config.provider.openai.options.apiKey).toBe("{env:CROF_API_KEY}");
+  });
+
+  it("apiBaseUrl overrides provider preset baseURL", () => {
+    const provider = opencode("openai/gpt-4o-mini", {
+      provider: "crofai",
+      apiBaseUrl: "https://self-hosted.example.com/v1",
+    });
+    const config = JSON.parse(provider.env["OPENCODE_CONFIG_CONTENT"]!);
+    expect(config.provider.openai.options.baseURL).toBe(
+      "https://self-hosted.example.com/v1",
+    );
+    expect(config.provider.openai.options.apiKey).toBe("{env:CROF_API_KEY}");
+  });
+
+  it("merges provider config with user-provided env", () => {
+    const provider = opencode("openai/gpt-4o-mini", {
+      provider: "crofai",
+      env: { CROF_API_KEY: "my-key", EXTRA: "val" },
+    });
+    expect(provider.env["CROF_API_KEY"]).toBe("my-key");
+    expect(provider.env["EXTRA"]).toBe("val");
+    expect(provider.env).toHaveProperty("OPENCODE_CONFIG_CONTENT");
+  });
+
+  it("does not inject OPENCODE_CONFIG_CONTENT when neither apiBaseUrl nor provider is set", () => {
+    const provider = opencode("opencode/big-pickle");
+    expect(provider.env).not.toHaveProperty("OPENCODE_CONFIG_CONTENT");
   });
 });
 

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -21,7 +21,11 @@ const TOOL_ARG_FIELDS: Record<string, string> = {
 const extractErrorMessage = (obj: any): string | undefined => {
   const err = obj.error;
   if (typeof err === "string") return err;
-  if (typeof err === "object" && err !== null && typeof err.message === "string") {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    typeof err.message === "string"
+  ) {
     return err.message;
   }
   if (typeof obj.message === "string") return obj.message;
@@ -302,41 +306,85 @@ export const codex = (
 // OpenCode agent provider
 // ---------------------------------------------------------------------------
 
+const PROVIDER_PRESETS: Record<string, { baseURL: string; apiKey: string }> = {
+  crofai: {
+    baseURL: "https://crof.ai/v1",
+    apiKey: "{env:CROF_API_KEY}",
+  },
+};
+
 /** Options for the opencode agent provider. */
 export interface OpenCodeOptions {
   /** Provider-specific reasoning effort variant (e.g. "high", "max", "low", "minimal"). */
   readonly variant?: string;
   /** Environment variables injected by this agent provider. */
   readonly env?: Record<string, string>;
+  /**
+   * Custom API base URL for OpenAI-compatible providers.
+   * Overrides the baseURL from `provider` preset if both are set.
+   */
+  readonly apiBaseUrl?: string;
+  /**
+   * Well-known provider preset. Configures baseURL and apiKey mapping automatically.
+   * Supported: "crofai". Extensible for any OpenAI-compatible provider.
+   * Use `apiBaseUrl` for providers without a preset.
+   */
+  readonly provider?: string;
 }
 
 export const opencode = (
   model: string,
   options?: OpenCodeOptions,
-): AgentProvider => ({
-  name: "opencode",
-  env: options?.env ?? {},
-  captureSessions: false,
+): AgentProvider => {
+  const extraEnv: Record<string, string> = { ...options?.env };
+  const preset = options?.provider
+    ? PROVIDER_PRESETS[options.provider]
+    : undefined;
+  const resolvedBaseUrl = options?.apiBaseUrl ?? preset?.baseURL;
 
-  buildPrintCommand({ prompt }: AgentCommandOptions): PrintCommand {
-    const variantFlag = options?.variant
-      ? ` --variant ${shellEscape(options.variant)}`
-      : "";
-    return {
-      command: `opencode run --model ${shellEscape(model)}${variantFlag} ${shellEscape(prompt)}`,
+  if (resolvedBaseUrl) {
+    const options: Record<string, string> = {
+      baseURL: resolvedBaseUrl,
     };
-  },
 
-  buildInteractiveArgs({ prompt }: AgentCommandOptions): string[] {
-    const args = ["opencode", "--model", model];
-    if (prompt) args.push("-p", prompt);
-    return args;
-  },
+    if (preset?.apiKey) {
+      options.apiKey = preset.apiKey;
+    }
 
-  parseStreamLine(_line: string): ParsedStreamEvent[] {
-    return [];
-  },
-});
+    extraEnv["OPENCODE_CONFIG_CONTENT"] = JSON.stringify({
+      provider: {
+        openai: {
+          options,
+        },
+      },
+    });
+  }
+
+  return {
+    name: "opencode",
+    env: extraEnv,
+    captureSessions: false,
+
+    buildPrintCommand({ prompt }: AgentCommandOptions): PrintCommand {
+      const variantFlag = options?.variant
+        ? ` --variant ${shellEscape(options.variant)}`
+        : "";
+      return {
+        command: `opencode run --model ${shellEscape(model)}${variantFlag} ${shellEscape(prompt)}`,
+      };
+    },
+
+    buildInteractiveArgs({ prompt }: AgentCommandOptions): string[] {
+      const args = ["opencode", "--model", model];
+      if (prompt) args.push("-p", prompt);
+      return args;
+    },
+
+    parseStreamLine(_line: string): ParsedStreamEvent[] {
+      return [];
+    },
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Claude Code agent provider

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -225,8 +225,10 @@ OPENAI_KEY=`,
     defaultModel: "opencode/big-pickle",
     factoryImport: "opencode",
     dockerfileTemplate: OPENCODE_DOCKERFILE,
-    envExample: `# OpenCode API key
-OPENCODE_API_KEY=`,
+    envExample: `# OpenCode API key (required for opencode.ai provider)
+# OPENCODE_API_KEY=
+# CrofAI API key (required when using provider "crofai" preset)
+# CROF_API_KEY=`,
   },
 ];
 


### PR DESCRIPTION
…th crof.ai preset

Adds 'provider' and 'apiBaseUrl' options to opencode() factory:
- provider: 'crofai' preset configures baseURL and CROF_API_KEY mapping
- apiBaseUrl works with any OpenAI-compatible provider generically
- Both inject OPENCODE_CONFIG_CONTENT env var for opencode's provider config
- No model config files needed - opencode resolves models dynamically