### PR TITLE
Allow noSandbox() in run() and createSandbox()

### DIFF
--- a/.changeset/no-sandbox-in-run.md
+++ b/.changeset/no-sandbox-in-run.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Allow `noSandbox()` in `run()` and `createSandbox()`. Previously it was only accepted by `interactive()`. Use this when running Sandcastle from inside an already-isolated environment (containerized CI, VM, sandbox host) and you want the agent to operate directly on the host without a nested container.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -209,9 +209,8 @@ _Avoid_: "log event" (the log file contains more than just agent output), "displ
 - A **bind-mount sandbox provider** supports all three **branch strategies**: **head** (default), **merge-to-head**, and **branch**
 - An **isolated sandbox provider** supports **merge-to-head** (default) and **branch** only -- **head** is not valid because it cannot write directly to the **host** filesystem
 - An **isolated sandbox provider** handles syncing code in and extracting commits out -- optionally using **bundle/patch sync**. **Isolated sandbox providers are defined in the type system but not yet implemented**
-- A **no-sandbox provider** supports all three **branch strategies** (default: **head**). It is only accepted by `interactive()`, not `run()` -- enforced at the type level. The **agent provider** does not receive `dangerouslySkipPermissions: true`
-- `interactive()` accepts all three **sandbox provider** types; `run()` accepts only **bind-mount** and **isolated**
-- `createSandbox()` does not accept a **no-sandbox provider**
+- A **no-sandbox provider** supports all three **branch strategies** (default: **head**). It is accepted by `run()`, `createSandbox()`, and `interactive()` -- the caller opts in to host execution by importing `noSandbox()`. The **agent provider** does not receive `dangerouslySkipPermissions: true`
+- `run()`, `createSandbox()`, and `interactive()` all accept any **sandbox provider** type, including **no-sandbox**
 - **Sandbox providers** are imported from subpaths (e.g. `sandcastle/sandboxes/docker`) -- the main `sandcastle` entry point does not re-export any provider
 - **Host hooks** run on the **host**; **sandbox hooks** run inside the **sandbox**. Hooks are grouped under `host` and `sandbox` in the `hooks` option
 - Lifecycle ordering: `copyToWorktree` -> `host.onWorktreeReady` (sequential) -> sandbox created -> `host.onSandboxReady` + `sandbox.onSandboxReady` (parallel)
@@ -272,7 +271,7 @@ _Avoid_: "log event" (the log file contains more than just agent output), "displ
 
 > **Dev:** "What about using `noSandbox()` with `run()` for an AFK job?"
 
-> **Domain expert:** "That's not allowed -- `run()` doesn't accept a **no-sandbox provider**. This is enforced at the type level. AFK means unsupervised, so you need a real **sandbox** for isolation."
+> **Domain expert:** "Allowed -- `run()` and `createSandbox()` both accept `noSandbox()`. There's no isolation, so only opt in when Sandcastle itself is already running inside an isolated environment (containerized CI, VM, sandbox host) and a nested container is undesired. The `noSandbox()` import is the opt-in -- no extra flag."
 
 ### Prompt system
 

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ await run({
 
 ## Sandbox Providers
 
-Sandcastle uses a `SandboxProvider` to create isolated environments. The `sandbox` option on `run()` and `createSandbox()` accepts any provider. A no-sandbox option is also available for `interactive()` and `wt.interactive()`. Built-in providers:
+Sandcastle uses a `SandboxProvider` to create isolated environments. The `sandbox` option on `run()`, `interactive()`, and `createSandbox()` accepts any provider, including `noSandbox()` — opt in to running the agent directly on the host when container isolation is undesired. Built-in providers:
 
-| Provider   | Import path                                | Type       | Accepted by                                   |
-| ---------- | ------------------------------------------ | ---------- | --------------------------------------------- |
-| Docker     | `@ai-hero/sandcastle/sandboxes/docker`     | Bind-mount | `run()`, `createSandbox()`, `interactive()`   |
-| Podman     | `@ai-hero/sandcastle/sandboxes/podman`     | Bind-mount | `run()`, `createSandbox()`, `interactive()`   |
-| Vercel     | `@ai-hero/sandcastle/sandboxes/vercel`     | Isolated   | `run()`, `createSandbox()`, `interactive()`   |
-| No-sandbox | `@ai-hero/sandcastle/sandboxes/no-sandbox` | None       | `interactive()`, `wt.interactive()` (default) |
+| Provider   | Import path                                | Type       | Accepted by                                 |
+| ---------- | ------------------------------------------ | ---------- | ------------------------------------------- |
+| Docker     | `@ai-hero/sandcastle/sandboxes/docker`     | Bind-mount | `run()`, `createSandbox()`, `interactive()` |
+| Podman     | `@ai-hero/sandcastle/sandboxes/podman`     | Bind-mount | `run()`, `createSandbox()`, `interactive()` |
+| Vercel     | `@ai-hero/sandcastle/sandboxes/vercel`     | Isolated   | `run()`, `createSandbox()`, `interactive()` |
+| No-sandbox | `@ai-hero/sandcastle/sandboxes/no-sandbox` | None       | `run()`, `createSandbox()`, `interactive()` |
 
 Worktree methods (`wt.run()`, `wt.interactive()`, `wt.createSandbox()`) accept the same providers as their top-level counterparts. `wt.interactive()` defaults to `noSandbox()` when no sandbox is specified.
 
@@ -89,7 +89,8 @@ await run({
   prompt: "...",
 });
 
-// No-sandbox runs the agent directly on the host — interactive() only:
+// No-sandbox runs the agent directly on the host — accepted by run(),
+// createSandbox(), and interactive(). Skips container isolation entirely:
 await interactive({
   agent: claudeCode("claude-opus-4-7"),
   sandbox: noSandbox(),

--- a/docs/adr/0015-no-sandbox-in-run-and-create-sandbox.md
+++ b/docs/adr/0015-no-sandbox-in-run-and-create-sandbox.md
@@ -1,0 +1,25 @@
+# Allow `noSandbox()` in `run()` and `createSandbox()`
+
+## Context
+
+`noSandbox()` runs the agent directly on the **host** with no container. Previously the `SandboxProvider` union deliberately excluded `NoSandboxProvider`, so only `interactive()` accepted it — `run()` and `createSandbox()` rejected it at the type level. The intent was to prevent unsupervised (AFK) execution from escaping isolation, since `run()` is the AFK entry point.
+
+In practice, subscription-billed Claude users (and anyone running Sandcastle inside an already-isolated environment — containerized CI, VM, sandbox host) had no path to AFK orchestration. The workaround was to fork `noSandbox` and flip the type tag, which every such user re-invented. With the API-key-only sandbox path tracked in #191 marked wontfix, the type-level gate was forcing a workaround rather than preventing a mistake.
+
+## Decision
+
+Drop the type-level restriction. `SandboxProvider` now includes `NoSandboxProvider` alongside `BindMountSandboxProvider` and `IsolatedSandboxProvider`, so `run()`, `createSandbox()`, and `interactive()` all accept it. The opt-in is the `noSandbox()` import itself — no extra `allowAfk` flag.
+
+All three **branch strategies** remain supported with `noSandbox()`: **head** (agent works directly in `hostRepoDir`, no worktree), **merge-to-head**, and **branch** (worktree created on host, agent runs against it without a container).
+
+Rejected alternatives:
+
+- **Keep the type-level guard, add `noSandbox({ allowAfk: true })` as an explicit unlock.** The issue (#507) proposed this. Rejected because the `noSandbox()` import is already the opt-in — the user has to reach for a provider that the README and CONTEXT.md both describe as host-execution-only. A second flag on top adds ceremony without preventing the mistake it claims to prevent: anyone wiring `noSandbox()` into `run()` will pass the flag the type error tells them to pass.
+- **Reject `head` strategy with `noSandbox()` in `run()`, force a worktree.** Rejected because worktree-as-isolation-boundary is a partial protection at best — the agent already has full host access via `noSandbox()`. Forcing a worktree adds a copy step without changing the trust model. Callers who want a worktree pass `branchStrategy: { type: "merge-to-head" }` explicitly.
+
+## Consequences
+
+- Pre-1.0, shipped as a `patch` changeset.
+- `AnySandboxProvider` is deprecated as an alias for `SandboxProvider` — the distinction it encoded no longer exists.
+- Trust model is explicit: importing `noSandbox()` is the opt-in. Sandcastle does not add a runtime guard against AFK-on-host; the caller owns the risk.
+- The **agent provider** still does not receive `dangerouslySkipPermissions: true` with `noSandbox()` — that behaviour is unchanged from the `interactive()`-only path.

--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -15,6 +15,7 @@ import {
   type BranchStrategy,
 } from "./SandboxProvider.js";
 import { testIsolated } from "./sandboxes/test-isolated.js";
+import { noSandbox } from "./sandboxes/no-sandbox.js";
 
 vi.mock("./WorktreeManager.js", () => ({
   create: vi.fn(),
@@ -1007,5 +1008,91 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
       cwd: hostDir,
     });
     expect(stdout).toContain("sandbox commit");
+  });
+});
+
+describe("WorktreeDockerSandboxFactory — no-sandbox provider", () => {
+  const tempDirs: string[] = [];
+
+  const makeNoSandboxLayer = (
+    hostRepoDir: string,
+    branchStrategy: BranchStrategy = { type: "head" },
+  ) =>
+    Layer.provide(
+      WorktreeDockerSandboxFactory.layer,
+      Layer.mergeAll(
+        Layer.succeed(SandboxConfig, {
+          env: {},
+          hostRepoDir,
+          sandboxProvider: noSandbox(),
+          branchStrategy,
+        }),
+        NodeFileSystem.layer,
+        SilentDisplay.layer(Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([])),
+      ),
+    );
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((d) => rm(d, { recursive: true, force: true })),
+    );
+    tempDirs.length = 0;
+  });
+
+  it("head mode: does not create a worktree and runs in hostRepoDir", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
+    tempDirs.push(hostDir);
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hi", "initial");
+
+    let receivedInfo: { hostWorktreePath?: string } | undefined;
+    let execOut = "";
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const factory = yield* SandboxFactory;
+        yield* factory.withSandbox((info) => {
+          receivedInfo = info;
+          return Effect.gen(function* () {
+            const sandbox = yield* Sandbox;
+            const r = yield* sandbox.exec("cat hello.txt");
+            execOut = r.stdout.trim();
+          });
+        });
+      }).pipe(Effect.provide(makeNoSandboxLayer(hostDir))),
+    );
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockRemove).not.toHaveBeenCalled();
+    expect(receivedInfo?.hostWorktreePath).toBe(hostDir);
+    expect(execOut).toBe("hi");
+  });
+
+  it("worktree mode: creates worktree, runs in it, cleans up on success", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
+    tempDirs.push(hostDir);
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hi", "initial");
+
+    mockCreate.mockReturnValue(
+      Effect.succeed({
+        path: hostDir,
+        branch: "sandcastle/20240101-000000",
+      }),
+    );
+    mockRemove.mockReturnValue(Effect.void);
+    mockPruneStale.mockReturnValue(Effect.void);
+    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const factory = yield* SandboxFactory;
+        yield* factory.withSandbox(() => Effect.void);
+      }).pipe(
+        Effect.provide(makeNoSandboxLayer(hostDir, { type: "merge-to-head" })),
+      ),
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith(hostDir, { name: undefined });
+    expect(mockRemove).toHaveBeenCalledWith(hostDir);
   });
 });

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -298,7 +298,7 @@ export const resolveGitMounts = (
 /** Shared acquire result type for the worktree-mode acquireUseRelease. */
 interface AcquireResult {
   worktreeInfo: WorktreeManager.WorktreeInfo;
-  handle: BindMountSandboxHandle | IsolatedSandboxHandle;
+  handle: BindMountSandboxHandle | IsolatedSandboxHandle | NoSandboxHandle;
   sandboxLayer: Layer.Layer<Sandbox>;
   worktreePath: string;
 }
@@ -356,6 +356,127 @@ export const WorktreeDockerSandboxFactory = {
           E | SandboxError,
           Exclude<R, Sandbox>
         > => {
+          // No-sandbox providers: run directly on the host, no container or mounts.
+          if (sandboxProvider.tag === "none") {
+            let preservedPath: string | undefined;
+
+            // Head mode: use hostRepoDir directly, no worktree.
+            if (isHeadMode) {
+              return (
+                hooks?.host?.onWorktreeReady?.length
+                  ? runHostHooks(
+                      hooks.host.onWorktreeReady,
+                      hostRepoDir,
+                      signal,
+                    )
+                  : Effect.void
+              ).pipe(
+                Effect.andThen(
+                  Effect.acquireUseRelease(
+                    startSandbox({
+                      provider: sandboxProvider,
+                      hostRepoDir,
+                      env,
+                      worktreeOrRepoPath: hostRepoDir,
+                    }),
+                    ({ sandboxLayer, worktreePath, handle }) =>
+                      makeEffect({
+                        hostWorktreePath: hostRepoDir,
+                        sandboxRepoPath: worktreePath,
+                      }).pipe(Effect.provide(sandboxLayer)) as Effect.Effect<
+                        A,
+                        E | SandboxError,
+                        Exclude<R, Sandbox>
+                      >,
+                    ({ handle }) =>
+                      Effect.tryPromise({
+                        try: () => handle.close(),
+                        catch: () => undefined,
+                      }).pipe(Effect.orDie),
+                  ).pipe(
+                    Effect.map((value) => ({
+                      value,
+                      preservedWorktreePath: undefined,
+                    })),
+                  ),
+                ),
+              );
+            }
+
+            // Worktree mode (merge-to-head or explicit branch).
+            return Effect.acquireUseRelease(
+              pruneAndCreate().pipe(
+                Effect.flatMap((worktreeInfo) =>
+                  (copyPaths && copyPaths.length > 0
+                    ? display.spinner(
+                        "Copying to worktree",
+                        copyToWorktree(
+                          copyPaths,
+                          hostRepoDir,
+                          worktreeInfo.path,
+                          timeouts?.copyToWorktreeMs,
+                        ),
+                      )
+                    : Effect.succeed(undefined)
+                  ).pipe(Effect.map(() => worktreeInfo)),
+                ),
+                Effect.tap((worktreeInfo) =>
+                  hooks?.host?.onWorktreeReady?.length
+                    ? runHostHooks(
+                        hooks.host.onWorktreeReady,
+                        worktreeInfo.path,
+                        signal,
+                      )
+                    : Effect.void,
+                ),
+                Effect.flatMap((worktreeInfo) =>
+                  startSandbox({
+                    provider: sandboxProvider,
+                    hostRepoDir,
+                    env,
+                    worktreeOrRepoPath: worktreeInfo.path,
+                  }).pipe(
+                    Effect.map(({ handle, sandboxLayer, worktreePath }) => ({
+                      worktreeInfo,
+                      handle,
+                      sandboxLayer,
+                      worktreePath,
+                    })),
+                  ),
+                ),
+              ),
+              ({ worktreeInfo, sandboxLayer, worktreePath }) =>
+                makeEffect({
+                  hostWorktreePath: worktreeInfo.path,
+                  sandboxRepoPath: worktreePath,
+                }).pipe(Effect.provide(sandboxLayer)) as Effect.Effect<
+                  A,
+                  E | SandboxError,
+                  Exclude<R, Sandbox>
+                >,
+              ({ worktreeInfo, handle }, exit) =>
+                Effect.tryPromise({
+                  try: () => handle.close(),
+                  catch: () => undefined,
+                }).pipe(
+                  Effect.andThen(cleanupWorktree(worktreeInfo.path, exit)),
+                  Effect.tap((p) => {
+                    preservedPath = p;
+                  }),
+                  Effect.asVoid,
+                  Effect.orDie,
+                ),
+            ).pipe(
+              Effect.map((value) => ({
+                value,
+                preservedWorktreePath: preservedPath,
+              })),
+              Effect.mapError((e: E | SandboxError) =>
+                attachPreservedPath(preservedPath, e),
+              ),
+            );
+          }
+
           // Isolated providers: create worktree, sync via git bundle
           if (sandboxProvider.tag === "isolated") {
             let preservedPath: string | undefined;
@@ -504,7 +625,12 @@ export const WorktreeDockerSandboxFactory = {
                 (copyPaths && copyPaths.length > 0
                   ? display.spinner(
                       "Copying to worktree",
-                      copyToWorktree(copyPaths, hostRepoDir, worktreeInfo.path, timeouts?.copyToWorktreeMs),
+                      copyToWorktree(
+                        copyPaths,
+                        hostRepoDir,
+                        worktreeInfo.path,
+                        timeouts?.copyToWorktreeMs,
+                      ),
                     )
                   : Effect.succeed(undefined)
                 ).pipe(Effect.map(() => worktreeInfo)),

--- a/src/SandboxProvider.ts
+++ b/src/SandboxProvider.ts
@@ -289,22 +289,18 @@ export type BranchStrategy =
   | NoSandboxBranchStrategy;
 
 /**
- * A sandbox provider — the pluggable unit that `run()` and `createSandbox()` accept.
- * Tagged for internal dispatch: "bind-mount" or "isolated".
- * Does not include `NoSandboxProvider` — that is only valid for `interactive()`.
+ * A sandbox provider — the pluggable unit that `run()`, `interactive()`, and
+ * `createSandbox()` accept. Tagged for internal dispatch: "bind-mount",
+ * "isolated", or "none". When `NoSandboxProvider` is used, the agent runs
+ * directly on the host with no container isolation — opt in at your own risk.
  */
 export type SandboxProvider =
   | BindMountSandboxProvider
-  | IsolatedSandboxProvider;
-
-/**
- * Any sandbox provider, including no-sandbox.
- * This is the union accepted by `interactive()`.
- */
-export type AnySandboxProvider =
-  | BindMountSandboxProvider
   | IsolatedSandboxProvider
   | NoSandboxProvider;
+
+/** @deprecated Use `SandboxProvider` — it now includes `NoSandboxProvider`. */
+export type AnySandboxProvider = SandboxProvider;
 
 /**
  * Create a bind-mount sandbox provider from a config object.

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -43,6 +43,7 @@ import type {
   SandboxProvider,
   BindMountSandboxHandle,
   IsolatedSandboxHandle,
+  NoSandboxHandle,
 } from "./SandboxProvider.js";
 import { startSandbox } from "./startSandbox.js";
 import { syncOut } from "./syncOut.js";
@@ -188,6 +189,7 @@ interface SandboxHandleContext {
   readonly providerHandle:
     | BindMountSandboxHandle
     | IsolatedSandboxHandle
+    | NoSandboxHandle
     | undefined;
   readonly applyToHost: () => Effect.Effect<void, any>;
 }
@@ -528,7 +530,12 @@ export const createSandboxFromWorktree = async (
     options.sandbox.tag !== "isolated"
   ) {
     await Effect.runPromise(
-      copyToWorktree(options.copyToWorktree, hostRepoDir, worktreePath, options.timeouts?.copyToWorktreeMs),
+      copyToWorktree(
+        options.copyToWorktree,
+        hostRepoDir,
+        worktreePath,
+        options.timeouts?.copyToWorktreeMs,
+      ),
     );
   }
 
@@ -536,6 +543,7 @@ export const createSandboxFromWorktree = async (
   let providerHandle:
     | BindMountSandboxHandle
     | IsolatedSandboxHandle
+    | NoSandboxHandle
     | undefined;
   let sandboxLayer: Layer.Layer<SandboxTag>;
   let sandboxRepoDir: string;
@@ -564,6 +572,13 @@ export const createSandboxFromWorktree = async (
         env,
         copyPaths: options.copyToWorktree,
       });
+    } else if (provider.tag === "none") {
+      startEffect = startSandbox({
+        provider,
+        hostRepoDir,
+        env,
+        worktreeOrRepoPath: worktreePath,
+      });
     } else {
       startEffect = resolveGitMounts(join(hostRepoDir, ".git")).pipe(
         Effect.provide(NodeFileSystem.layer),
@@ -572,7 +587,11 @@ export const createSandboxFromWorktree = async (
         Effect.flatMap((gitMounts) =>
           Effect.tryPromise({
             try: () =>
-              patchGitMountsForWindows(gitMounts, worktreePath, SANDBOX_REPO_DIR),
+              patchGitMountsForWindows(
+                gitMounts,
+                worktreePath,
+                SANDBOX_REPO_DIR,
+              ),
             catch: (e) =>
               new Error(
                 `Failed to patch git mounts: ${e instanceof Error ? e.message : String(e)}`,
@@ -693,7 +712,12 @@ export const createSandbox = async (
     options.sandbox.tag !== "isolated"
   ) {
     await Effect.runPromise(
-      copyToWorktree(options.copyToWorktree, hostRepoDir, worktreePath, options.timeouts?.copyToWorktreeMs),
+      copyToWorktree(
+        options.copyToWorktree,
+        hostRepoDir,
+        worktreePath,
+        options.timeouts?.copyToWorktreeMs,
+      ),
     );
   }
 
@@ -708,6 +732,7 @@ export const createSandbox = async (
   let providerHandle:
     | BindMountSandboxHandle
     | IsolatedSandboxHandle
+    | NoSandboxHandle
     | undefined;
   let sandboxLayer: Layer.Layer<SandboxTag>;
   let sandboxRepoDir: string;
@@ -737,6 +762,13 @@ export const createSandbox = async (
         env,
         copyPaths: options.copyToWorktree,
       });
+    } else if (provider.tag === "none") {
+      startEffect = startSandbox({
+        provider,
+        hostRepoDir,
+        env,
+        worktreeOrRepoPath: worktreePath,
+      });
     } else {
       startEffect = resolveGitMounts(join(hostRepoDir, ".git")).pipe(
         Effect.provide(NodeFileSystem.layer),
@@ -745,7 +777,11 @@ export const createSandbox = async (
         Effect.flatMap((gitMounts) =>
           Effect.tryPromise({
             try: () =>
-              patchGitMountsForWindows(gitMounts, worktreePath, SANDBOX_REPO_DIR),
+              patchGitMountsForWindows(
+                gitMounts,
+                worktreePath,
+                SANDBOX_REPO_DIR,
+              ),
             catch: (e) =>
               new Error(
                 `Failed to patch git mounts: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -231,7 +231,12 @@ export const createWorktree = async (
       baseBranch,
     });
     if (options.copyToWorktree && options.copyToWorktree.length > 0) {
-      yield* copyToWorktree(options.copyToWorktree, hostRepoDir, info.path, options.timeouts?.copyToWorktreeMs);
+      yield* copyToWorktree(
+        options.copyToWorktree,
+        hostRepoDir,
+        info.path,
+        options.timeouts?.copyToWorktreeMs,
+      );
     }
     // Run host.onWorktreeReady hooks after copyToWorktree, before sandbox creation
     if (options.hooks?.host?.onWorktreeReady?.length) {
@@ -528,7 +533,10 @@ export const createWorktree = async (
       }
 
       // 4. Start sandbox
-      let handle: BindMountSandboxHandle | IsolatedSandboxHandle;
+      let handle:
+        | BindMountSandboxHandle
+        | IsolatedSandboxHandle
+        | NoSandboxHandle;
       let sandboxRepoDir: string;
 
       if (sandboxProvider.tag === "isolated") {
@@ -536,6 +544,15 @@ export const createWorktree = async (
           provider: sandboxProvider,
           hostRepoDir: worktreeInfo.path,
           env: effectiveEnv,
+        });
+        handle = startResult.handle;
+        sandboxRepoDir = startResult.worktreePath;
+      } else if (sandboxProvider.tag === "none") {
+        const startResult = yield* startSandbox({
+          provider: sandboxProvider,
+          hostRepoDir,
+          env: effectiveEnv,
+          worktreeOrRepoPath: worktreeInfo.path,
         });
         handle = startResult.handle;
         sandboxRepoDir = startResult.worktreePath;

--- a/src/sandboxes/no-sandbox.ts
+++ b/src/sandboxes/no-sandbox.ts
@@ -5,8 +5,9 @@
  *   import { noSandbox } from "sandcastle/sandboxes/no-sandbox";
  *   await interactive({ agent: claudeCode("claude-opus-4-7"), sandbox: noSandbox() });
  *
- * Only valid for `interactive()` — not accepted by `run()` or `createSandbox()`.
- * Does not pass `--dangerously-skip-permissions` to the agent — the user manages
+ * Accepted by `run()`, `interactive()`, and `createSandbox()`. Skips
+ * container isolation entirely — the agent executes on the host. Does not
+ * pass `--dangerously-skip-permissions` to the agent — the user manages
  * permissions themselves.
  */
 

--- a/src/startSandbox.ts
+++ b/src/startSandbox.ts
@@ -16,6 +16,8 @@ import type {
   BindMountSandboxHandle,
   IsolatedSandboxProvider,
   IsolatedSandboxHandle,
+  NoSandboxProvider,
+  NoSandboxHandle,
 } from "./SandboxProvider.js";
 import {
   type Sandbox,
@@ -46,12 +48,24 @@ export interface StartSandboxIsolatedOptions {
   copyPaths?: string[];
 }
 
+export interface StartSandboxNoSandboxOptions {
+  provider: NoSandboxProvider;
+  hostRepoDir: string;
+  env: Record<string, string>;
+  /** Host-side worktree path the agent will run in. Equal to hostRepoDir in head mode. */
+  worktreeOrRepoPath: string;
+  gitMounts?: undefined;
+  repoDir?: undefined;
+  copyPaths?: undefined;
+}
+
 export type StartSandboxOptions =
   | StartSandboxBindMountOptions
-  | StartSandboxIsolatedOptions;
+  | StartSandboxIsolatedOptions
+  | StartSandboxNoSandboxOptions;
 
 export interface StartSandboxResult {
-  handle: BindMountSandboxHandle | IsolatedSandboxHandle;
+  handle: BindMountSandboxHandle | IsolatedSandboxHandle | NoSandboxHandle;
   sandboxLayer: Layer.Layer<Sandbox>;
   worktreePath: string;
 }
@@ -83,8 +97,32 @@ export const startSandbox = (
   if (options.provider.tag === "bind-mount") {
     return startBindMountSandbox(options as StartSandboxBindMountOptions);
   }
+  if (options.provider.tag === "none") {
+    return startNoSandbox(options as StartSandboxNoSandboxOptions);
+  }
   return startIsolatedSandbox(options as StartSandboxIsolatedOptions);
 };
+
+const startNoSandbox = (
+  options: StartSandboxNoSandboxOptions,
+): Effect.Effect<StartSandboxResult, WorktreeError> =>
+  Effect.tryPromise({
+    try: () =>
+      options.provider.create({
+        worktreePath: options.worktreeOrRepoPath,
+        env: options.env,
+      }),
+    catch: (e) =>
+      new WorktreeError({
+        message: `Provider '${options.provider.name}' create failed: ${e instanceof Error ? e.message : String(e)}`,
+      }),
+  }).pipe(
+    Effect.map((handle) => ({
+      handle,
+      sandboxLayer: makeSandboxLayerFromHandle(handle),
+      worktreePath: handle.worktreePath,
+    })),
+  );
 
 const startBindMountSandbox = (
   options: StartSandboxBindMountOptions,


### PR DESCRIPTION
## Summary

- Drops the type-level restriction that prevented `noSandbox()` from being passed to `run()` and `createSandbox()` — it was already wired through `interactive()`, only the `SandboxProvider` union was holding it back.
- Adds a `"none"` dispatch branch to `SandboxFactory`, `startSandbox`, `createSandbox`, and `createWorktree` so the agent runs directly in the worktree (or `hostRepoDir` in head mode) with no container or mounts.
- All three branch strategies (head, merge-to-head, named branch) work; the worktree-mode path reuses the existing prune/create/copy/cleanup flow.

Useful when Sandcastle itself is already running inside an isolated environment (containerized CI, VM, sandbox host) and a nested container is undesired. You're opting in to the risk by importing `noSandbox` — no extra flag needed.

Closes #507

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (1110 tests)
- [x] New tests in `SandboxFactory.test.ts` cover head mode (no worktree created) and worktree mode (worktree created + cleaned up)
- [ ] Manual: `run({ sandbox: noSandbox(), agent: claudeCode(...), prompt: "..." })` executes the agent on the host

🤖 Generated with [Claude Code](https://claude.com/claude-code)