### PR TITLE
fix: handle pre-existing GID collision in generated Dockerfile templates

### DIFF
--- a/.changeset/fix-docker-gid-collision.md
+++ b/.changeset/fix-docker-gid-collision.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix Docker build failure when host GID collides with an existing Debian group (e.g., macOS `staff` / GID 20 conflicting with Debian `dialout`). The generated Dockerfile now reassigns any pre-existing group before aligning the `node` user's GID.

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -74,7 +74,11 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+RUN if getent group $AGENT_GID >/dev/null 2>&1; then \
+        groupmod -g 99999 $(getent group $AGENT_GID | cut -d: -f1); \
+    fi && \
+    groupmod -g $AGENT_GID node && \
+    usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 USER \${AGENT_UID}:\${AGENT_GID}
 
 # Install Claude Code CLI
@@ -109,7 +113,11 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+RUN if getent group $AGENT_GID >/dev/null 2>&1; then \
+        groupmod -g 99999 $(getent group $AGENT_GID | cut -d: -f1); \
+    fi && \
+    groupmod -g $AGENT_GID node && \
+    usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 
 # Install pi coding agent (run as root before USER agent)
 RUN npm install -g @mariozechner/pi-coding-agent
@@ -142,7 +150,11 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+RUN if getent group $AGENT_GID >/dev/null 2>&1; then \
+        groupmod -g 99999 $(getent group $AGENT_GID | cut -d: -f1); \
+    fi && \
+    groupmod -g $AGENT_GID node && \
+    usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 
 # Install Codex CLI (run as root before USER agent)
 RUN npm install -g @openai/codex
@@ -175,7 +187,11 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
 # Rename the base image's "node" user to "agent" and align UID/GID.
-RUN groupmod -g $AGENT_GID node && usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+RUN if getent group $AGENT_GID >/dev/null 2>&1; then \
+        groupmod -g 99999 $(getent group $AGENT_GID | cut -d: -f1); \
+    fi && \
+    groupmod -g $AGENT_GID node && \
+    usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 
 # Install OpenCode CLI (run as root before USER agent)
 RUN npm install -g opencode-ai@latest


### PR DESCRIPTION
## Summary

Fixes Docker build failure during `npx sandcastle init` when the host user's GID collides with an existing group in the Debian-based `node:22-bookworm` image.

**Example:** On macOS, the user's primary group (`staff`) has GID `20`. The Debian image already reserves GID `20` for the `dialout` group. The previous `RUN groupmod -g $AGENT_GID node` line crashed with `GID '20' already exists`.

## Change

The generated Dockerfile templates now guard against pre-existing GID collisions:

```dockerfile
RUN if getent group $AGENT_GID >/dev/null 2>&1; then \
        groupmod -g 99999 $(getent group $AGENT_GID | cut -d: -f1); \
    fi && \
    groupmod -g $AGENT_GID node && \
    usermod -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
```

If a group already occupies the target GID, it is reassigned to `99999` before the `node` group takes the desired GID. This preserves the UID/GID alignment behavior while avoiding fatal collisions.

Applied to all four Dockerfile templates in `src/InitService.ts`:
- Claude Code
- pi coding agent
- Codex
- OpenCode

## Fixes

Closes #680
