### PR TITLE
fix(createSandbox): report token usage on reused sandboxes

### DIFF
--- a/.changeset/warm-path-session-capture.md
+++ b/.changeset/warm-path-session-capture.md
@@ -1,0 +1,16 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix session capture (and token-usage reporting) on reused sandboxes.
+
+`createSandbox`'s reuse factory did not forward the bind-mount provider handle
+into the orchestrator, so the session-capture step — which copies the agent's
+session JSONL out to the host and parses token usage from it — was silently
+skipped on every `sandbox.run()`. Runs on reused sandboxes therefore reported
+no token usage, while the one-shot `run()` (whose factory does forward the
+handle) reported it correctly.
+
+The reuse factory now forwards the bind-mount handle, matching `run()`, so
+`iterations[].sessionFilePath` and token usage are populated for reused
+sandboxes too.

--- a/src/createSandbox.test.ts
+++ b/src/createSandbox.test.ts
@@ -1456,3 +1456,181 @@ describe("createSandbox", () => {
     }
   });
 });
+
+describe("createSandbox session capture (reuse factory)", () => {
+  // Regression coverage for the reuse factory forwarding `bindMountHandle`.
+  // The Orchestrator captures the session JSONL (and parses token usage from
+  // it) only when `bindMountHandle` is present in SandboxInfo. `sandbox.run()`
+  // builds its own factory; if it omits the handle, capture is silently
+  // skipped and `iterations[].sessionFilePath` / `.usage` come back empty.
+  const SESSION_ID = "reuse-capture-session-001";
+  const RAW_USAGE = {
+    input_tokens: 11,
+    cache_creation_input_tokens: 22,
+    cache_read_input_tokens: 33,
+    output_tokens: 44,
+  };
+  const EXPECTED_USAGE = {
+    inputTokens: 11,
+    cacheCreationInputTokens: 22,
+    cacheReadInputTokens: 33,
+    outputTokens: 44,
+  };
+
+  /** Claude stream that emits a session_id init line plus a usage-bearing
+   * assistant message, so the Orchestrator extracts a sessionId. */
+  const streamWithSession = (sessionId: string): string =>
+    [
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: sessionId,
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: { usage: RAW_USAGE, content: [{ type: "text", text: "ok" }] },
+      }),
+      JSON.stringify({ type: "result", result: "ok" }),
+    ].join("\n");
+
+  /** Synthetic session JSONL the handle "copies out" of the sandbox.
+   * `parseSessionUsage` reads the assistant.usage entry. */
+  const sessionJsonl = (cwd: string): string =>
+    [
+      JSON.stringify({ type: "system", cwd, session_id: SESSION_ID }),
+      JSON.stringify({ type: "assistant", message: { usage: RAW_USAGE } }),
+    ].join("\n");
+
+  it("captures the session and reports usage on a reused bind-mount sandbox", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "sandbox-capture-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "init.txt", "init", "initial commit");
+
+    const gitTmpDir = mkdtempSync(join(tmpdir(), "test-gitconfig-"));
+    const globalConfigPath = join(gitTmpDir, ".gitconfig");
+    writeFileSync(globalConfigPath, "");
+    const isolatedEnv = {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: globalConfigPath,
+    };
+
+    const provider = createBindMountSandboxProvider({
+      name: "capturing-bind-mount",
+      create: async (opts) => ({
+        worktreePath: opts.worktreePath,
+        exec: async (cmd, execOpts) => {
+          const cwd = execOpts?.cwd ?? opts.worktreePath;
+          if (cmd.startsWith("claude ")) {
+            const stream = streamWithSession(SESSION_ID);
+            if (execOpts?.onLine) {
+              for (const line of stream.split("\n")) execOpts.onLine(line);
+            }
+            return { stdout: stream, stderr: "", exitCode: 0 };
+          }
+          const result = await execAsync(cmd, { cwd, env: isolatedEnv });
+          if (execOpts?.onLine) {
+            for (const line of result.stdout.split("\n")) execOpts.onLine(line);
+          }
+          return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+        },
+        copyFileIn: async () => {},
+        // Ignore the requested sandbox path and hand back a synthetic session
+        // JSONL — this stands in for the file a real agent writes in-container.
+        copyFileOut: async (_sandboxPath, hostPath) => {
+          await writeFile(hostPath, sessionJsonl(opts.worktreePath));
+        },
+        close: async () => {},
+      }),
+    });
+
+    const sandbox = await createSandbox({
+      branch: "test-reuse-capture",
+      sandbox: provider,
+      cwd: hostDir,
+    });
+
+    // Redirect the host projects dir (defaultSessionPathsLayer reads HOME)
+    // to a temp dir so capture doesn't touch the real ~/.claude.
+    const origHome = process.env.HOME;
+    const tmpHome = await mkdtemp(join(tmpdir(), "capture-home-"));
+
+    try {
+      process.env.HOME = tmpHome;
+      const result = await sandbox.run({
+        agent: testProvider,
+        prompt: "do work",
+        maxIterations: 1,
+      });
+
+      const last = result.iterations.at(-1);
+      expect(last?.sessionId).toBe(SESSION_ID);
+      expect(last?.sessionFilePath).toBeDefined();
+      expect(last?.sessionFilePath).toContain(SESSION_ID);
+      expect(last?.usage).toEqual(EXPECTED_USAGE);
+    } finally {
+      process.env.HOME = origHome;
+      await sandbox.close();
+      await rm(hostDir, { recursive: true, force: true });
+      await rm(gitTmpDir, { recursive: true, force: true });
+      await rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it("does not capture for a non-bind-mount (isolated) provider", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "sandbox-iso-nocapture-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "init.txt", "init", "initial commit");
+
+    // Same session-bearing stream, but an isolated provider — the reuse
+    // factory must NOT forward its handle as a bindMountHandle, so capture is
+    // skipped even though a sessionId is extracted.
+    const base = testIsolated();
+    const provider = createIsolatedSandboxProvider({
+      name: "capturing-isolated",
+      create: async (opts) => {
+        const handle = await base.create(opts);
+        return {
+          ...handle,
+          exec: async (cmd: string, execOpts?: any) => {
+            if (cmd.startsWith("claude ")) {
+              const stream = streamWithSession(SESSION_ID);
+              if (execOpts?.onLine) {
+                for (const line of stream.split("\n")) execOpts.onLine(line);
+              }
+              return { stdout: stream, stderr: "", exitCode: 0 };
+            }
+            return handle.exec(cmd, execOpts);
+          },
+        };
+      },
+    });
+
+    const sandbox = await createSandbox({
+      branch: "test-iso-nocapture",
+      sandbox: provider,
+      cwd: hostDir,
+    });
+
+    const origHome = process.env.HOME;
+    const tmpHome = await mkdtemp(join(tmpdir(), "capture-home-"));
+
+    try {
+      process.env.HOME = tmpHome;
+      const result = await sandbox.run({
+        agent: testProvider,
+        prompt: "do work",
+        maxIterations: 1,
+      });
+
+      const last = result.iterations.at(-1);
+      expect(last?.sessionId).toBe(SESSION_ID);
+      expect(last?.sessionFilePath).toBeUndefined();
+      expect(last?.usage).toBeUndefined();
+    } finally {
+      process.env.HOME = origHome;
+      await sandbox.close();
+      await rm(hostDir, { recursive: true, force: true });
+      await rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -191,6 +191,13 @@ interface SandboxHandleContext {
     | IsolatedSandboxHandle
     | NoSandboxHandle
     | undefined;
+  /**
+   * The provider handle narrowed to a bind-mount handle, set only when the
+   * sandbox provider is bind-mount backed. Forwarded into the orchestrator so
+   * session capture — and therefore token-usage reporting — can run on reused
+   * sandboxes, mirroring what the one-shot `run()` factory already provides.
+   */
+  readonly bindMountHandle?: BindMountSandboxHandle;
   readonly applyToHost: () => Effect.Effect<void, any>;
 }
 
@@ -211,6 +218,7 @@ const buildSandboxHandle = (
     sandboxRepoDir,
     sandboxLayer,
     providerHandle,
+    bindMountHandle,
     applyToHost,
   } = ctx;
 
@@ -296,6 +304,7 @@ const buildSandboxHandle = (
           makeEffect({
             hostWorktreePath: worktreePath,
             sandboxRepoPath: sandboxRepoDir,
+            bindMountHandle,
             applyToHost,
           }).pipe(
             Effect.provide(sandboxLayer),
@@ -666,6 +675,10 @@ export const createSandboxFromWorktree = async (
       sandboxRepoDir,
       sandboxLayer,
       providerHandle,
+      bindMountHandle:
+        options.sandbox.tag === "bind-mount"
+          ? (providerHandle as BindMountSandboxHandle | undefined)
+          : undefined,
       applyToHost,
     },
     async () => {
@@ -904,6 +917,10 @@ export const createSandbox = async (
       sandboxRepoDir,
       sandboxLayer,
       providerHandle,
+      bindMountHandle:
+        options.sandbox.tag === "bind-mount"
+          ? (providerHandle as BindMountSandboxHandle | undefined)
+          : undefined,
       applyToHost,
     },
     async () => {


### PR DESCRIPTION
## The bug

When you reuse a sandbox across multiple runs:

```ts
const sandbox = await createSandbox({ branch, sandbox: docker(...) })
const result = await sandbox.run({ agent, prompt })
result.iterations[0].sessionFilePath // ❌ always undefined
// → no session file captured, so no token usage is reported
```

The one-shot `run()` reports token usage fine. Only the reused
`createSandbox` + `sandbox.run()` path comes back empty.

## Why

After each run, the orchestrator copies the agent's session file out of the
sandbox to the host and reads token usage from it. That step only happens when
it has a handle to the sandbox's filesystem (`bindMountHandle`).

`run()` passes that handle through. `createSandbox` builds its own internal
factory to reuse the container across runs — and that factory was passing
everything *except* the handle. So the copy-out step was silently skipped every
time, and with no session file there was nothing to read usage from.

## The fix

Forward the bind-mount handle through the reuse factory, the same way `run()`
already does. The handle is narrowed to the bind-mount provider case (so an
isolated/no-sandbox handle is never mistaken for a bind-mount one). With the
handle present, the existing capture code runs and `sessionFilePath` / token
usage are populated on reused sandboxes too.

## Changes

- `src/createSandbox.ts` — carry the bind-mount handle into the handle context
  and forward it into the orchestrator's per-run context, narrowed to
  bind-mount providers.
- `src/createSandbox.test.ts` — two regression tests (see below).
- `.changeset/` — patch bump.

## Tests

Added two tests at the `createSandbox` level:
- **reused bind-mount sandbox captures the session + reports usage** —
  `sessionFilePath` and `usage` are populated. Verified to **fail on the
  pre-fix factory** (`expected undefined to be defined`).
- **a non-bind-mount (isolated) provider does not capture** — a `sessionId` is
  still extracted, but the handle isn't forwarded, so capture is skipped. This
  pins the narrowing.
