### PR TITLE
Add Codex app-server agent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,6 +811,37 @@ agent: codex("gpt-5.4", { effort: "high" });
 | `effort` | `"low"` \| `"medium"` \| `"high"` \| `"xhigh"` | —       | Codex reasoning effort level via `model_reasoning_effort` |
 | `env`    | `Record<string, string>`                       | `{}`    | Environment variables injected by this agent provider     |
 
+### `CodexAppServerOptions`
+
+The `codexAppServer()` factory uses `codex app-server --listen stdio://` instead of
+`codex exec`. This is useful when you want Sandcastle to use Codex's ChatGPT auth
+from `~/.codex/auth.json` inside the sandbox instead of passing an OpenAI API key.
+
+```typescript
+agent: codexAppServer("gpt-5.5", { effort: "low" });
+```
+
+| Option   | Type                                           | Default | Description                                           |
+| -------- | ---------------------------------------------- | ------- | ----------------------------------------------------- |
+| `effort` | `"low"` \| `"medium"` \| `"high"` \| `"xhigh"` | —       | Codex app-server effort value                         |
+| `env`    | `Record<string, string>`                       | `{}`    | Environment variables injected by this agent provider |
+
+When using ChatGPT auth, mount `~/.codex/auth.json` into the sandbox and set
+`CODEX_HOME` to the mounted directory, for example:
+
+```typescript
+docker({
+  mounts: [
+    {
+      hostPath: `${process.env.HOME}/.codex/auth.json`,
+      sandboxPath: "~/.codex/auth.json",
+      readonly: true,
+    },
+  ],
+  env: { CODEX_HOME: "/home/agent/.codex" },
+});
+```
+
 ### Provider `env`
 
 Both **agent providers** and **sandbox providers** accept an optional `env: Record<string, string>` in their options. These environment variables are merged with the `.sandcastle/.env` resolver output at launch time:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "./sandboxes/no-sandbox": {
       "import": "./dist/sandboxes/no-sandbox.js",
       "types": "./dist/sandboxes/no-sandbox.d.ts"
+    },
+    "./codex-app-server-runner": {
+      "import": "./dist/codexAppServerRunner.js",
+      "types": "./dist/codexAppServerRunner.d.ts"
     }
   },
   "bin": {
@@ -42,7 +46,7 @@
     "typecheck": "tsgo --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky",
+    "prepare": "npm run build && husky",
     "release": "changeset publish",
     "sandcastle": "npm run build && tsx .sandcastle/run.ts",
     "test-podman": "npm run build && tsx --env-file=.sandcastle/.env .sandcastle/test-podman.ts",

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { claudeCode, codex, opencode, pi } from "./AgentProvider.js";
+import {
+  claudeCode,
+  codex,
+  codexAppServer,
+  opencode,
+  pi,
+} from "./AgentProvider.js";
 import type { AgentCommandOptions } from "./AgentProvider.js";
 
 /** Shorthand: build options with dangerouslySkipPermissions: true (mirrors existing sandbox callers). */
@@ -688,6 +694,83 @@ describe("codex factory", () => {
 });
 
 // ---------------------------------------------------------------------------
+// codexAppServer factory
+// ---------------------------------------------------------------------------
+
+describe("codexAppServer factory", () => {
+  it("returns a provider with name 'codex-app-server'", () => {
+    const provider = codexAppServer("gpt-5.5");
+    expect(provider.name).toBe("codex-app-server");
+  });
+
+  it("buildPrintCommand imports the packaged runner and passes the model", () => {
+    const provider = codexAppServer("gpt-5.5");
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).toContain("@ai-hero/sandcastle/codex-app-server-runner");
+    expect(command).toContain("--model 'gpt-5.5'");
+  });
+
+  it("buildPrintCommand delivers prompt via stdin, not argv", () => {
+    const provider = codexAppServer("gpt-5.5");
+    const { command, stdin } = provider.buildPrintCommand(opts("it's a test"));
+    expect(command).not.toContain("it's a test");
+    expect(stdin).toBe("it's a test");
+  });
+
+  it("buildPrintCommand includes effort when specified", () => {
+    const provider = codexAppServer("gpt-5.5", { effort: "low" });
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).toContain("--effort 'low'");
+  });
+
+  it("buildPrintCommand omits effort when not specified", () => {
+    const provider = codexAppServer("gpt-5.5");
+    const { command } = provider.buildPrintCommand(opts("do something"));
+    expect(command).not.toContain("--effort");
+  });
+
+  it("parseStreamLine extracts text from app-server deltas", () => {
+    const provider = codexAppServer("gpt-5.5");
+    const line = JSON.stringify({
+      type: "item.delta",
+      item: { type: "agent_message_delta", text: "Hello" },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "text", text: "Hello" },
+    ]);
+  });
+
+  it("parseStreamLine extracts result from app-server completed messages", () => {
+    const provider = codexAppServer("gpt-5.5");
+    const line = JSON.stringify({
+      type: "item.completed",
+      item: { type: "agent_message", text: "Done" },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "result", result: "Done" },
+    ]);
+  });
+
+  it("parseStreamLine extracts tool calls from app-server command execution", () => {
+    const provider = codexAppServer("gpt-5.5");
+    const line = JSON.stringify({
+      type: "item.started",
+      item: { type: "command_execution", command: "npm test" },
+    });
+    expect(provider.parseStreamLine(line)).toEqual([
+      { type: "tool_call", name: "Bash", args: "npm test" },
+    ]);
+  });
+
+  it("accepts an env option and exposes it on the provider", () => {
+    const provider = codexAppServer("gpt-5.5", {
+      env: { CODEX_HOME: "/home/agent/.codex" },
+    });
+    expect(provider.env).toEqual({ CODEX_HOME: "/home/agent/.codex" });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // opencode factory
 // ---------------------------------------------------------------------------
 
@@ -759,7 +842,9 @@ describe("opencode factory", () => {
   });
 
   it("buildPrintCommand shell-escapes the variant value", () => {
-    const provider = opencode("opencode/big-pickle", { variant: "it's tricky" });
+    const provider = opencode("opencode/big-pickle", {
+      variant: "it's tricky",
+    });
     const { command } = provider.buildPrintCommand(opts("test"));
     expect(command).toContain("--variant 'it'\\''s tricky'");
   });

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -21,7 +21,11 @@ const TOOL_ARG_FIELDS: Record<string, string> = {
 const extractErrorMessage = (obj: any): string | undefined => {
   const err = obj.error;
   if (typeof err === "string") return err;
-  if (typeof err === "object" && err !== null && typeof err.message === "string") {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    typeof err.message === "string"
+  ) {
     return err.message;
   }
   if (typeof obj.message === "string") return obj.message;
@@ -295,6 +299,88 @@ export const codex = (
 
   parseStreamLine(line: string): ParsedStreamEvent[] {
     return parseCodexStreamLine(line);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Codex app-server agent provider
+// ---------------------------------------------------------------------------
+
+const parseCodexAppServerStreamLine = (line: string): ParsedStreamEvent[] => {
+  if (!line.startsWith("{")) return [];
+  try {
+    const obj = JSON.parse(line);
+
+    if (
+      obj.type === "item.completed" &&
+      obj.item?.type === "agent_message" &&
+      typeof obj.item.text === "string"
+    ) {
+      return [{ type: "result", result: obj.item.text }];
+    }
+
+    if (
+      obj.type === "item.delta" &&
+      obj.item?.type === "agent_message_delta" &&
+      typeof obj.item.text === "string"
+    ) {
+      return [{ type: "text", text: obj.item.text }];
+    }
+
+    if (
+      obj.type === "item.started" &&
+      obj.item?.type === "command_execution" &&
+      typeof obj.item.command === "string"
+    ) {
+      return [{ type: "tool_call", name: "Bash", args: obj.item.command }];
+    }
+
+    if (obj.type === "error") {
+      const msg = extractErrorMessage(obj);
+      return msg ? [{ type: "result", result: msg }] : [];
+    }
+  } catch {
+    // Not valid JSON — skip
+  }
+  return [];
+};
+
+/** Options for the codex app-server agent provider. */
+export interface CodexAppServerOptions {
+  readonly effort?: "low" | "medium" | "high" | "xhigh";
+  /** Environment variables injected by this agent provider. */
+  readonly env?: Record<string, string>;
+}
+
+export const codexAppServer = (
+  model: string,
+  options?: CodexAppServerOptions,
+): AgentProvider => ({
+  name: "codex-app-server",
+  env: options?.env ?? {},
+  captureSessions: false,
+
+  buildPrintCommand({ prompt }: AgentCommandOptions): PrintCommand {
+    const importRunner =
+      "import('@ai-hero/sandcastle/codex-app-server-runner').then(({ runCli }) => runCli()).catch((error) => { console.error(error instanceof Error ? error.stack ?? error.message : String(error)); process.exit(1); })";
+    const effortArg = options?.effort
+      ? ` --effort ${shellEscape(options.effort)}`
+      : "";
+
+    return {
+      command: `node --input-type=module -e ${shellEscape(importRunner)} -- --model ${shellEscape(model)}${effortArg}`,
+      stdin: prompt,
+    };
+  },
+
+  buildInteractiveArgs({ prompt }: AgentCommandOptions): string[] {
+    const args = ["codex", "--model", model];
+    if (prompt) args.push(prompt);
+    return args;
+  },
+
+  parseStreamLine(line: string): ParsedStreamEvent[] {
+    return parseCodexAppServerStreamLine(line);
   },
 });
 

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -220,6 +220,18 @@ ANTHROPIC_API_KEY=`,
 OPENAI_KEY=`,
   },
   {
+    name: "codex-app-server",
+    label: "Codex app-server",
+    defaultModel: "gpt-5.5",
+    factoryImport: "codexAppServer",
+    dockerfileTemplate: CODEX_DOCKERFILE,
+    envExample: `# Optional OpenAI API key fallback.
+# To use Codex ChatGPT auth, mount ~/.codex/auth.json into the sandbox
+# and set CODEX_HOME to that mounted directory.
+OPENAI_KEY=
+OPENAI_API_KEY=`,
+  },
+  {
     name: "opencode",
     label: "OpenCode",
     defaultModel: "opencode/big-pickle",

--- a/src/codexAppServerRunner.ts
+++ b/src/codexAppServerRunner.ts
@@ -1,0 +1,393 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+
+interface ParsedArgs {
+  readonly model?: string;
+  readonly effort?: string;
+}
+
+interface PendingRequest {
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (error: Error) => void;
+}
+
+export async function runCli(argv = process.argv.slice(1)): Promise<void> {
+  const args = parseArgs(argv);
+  const prompt = await readStdin();
+
+  if (!args.model) {
+    throw new Error("Missing required --model argument.");
+  }
+
+  if (process.env.OPENAI_KEY && !process.env.OPENAI_API_KEY) {
+    process.env.OPENAI_API_KEY = process.env.OPENAI_KEY;
+  }
+
+  const appServer = spawn("codex", ["app-server", "--listen", "stdio://"], {
+    env: {
+      ...process.env,
+      CODEX_HOME: process.env.CODEX_HOME ?? "/home/agent/.codex",
+      NO_COLOR: "1",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let nextRequestId = 1;
+  let threadId: string | null = null;
+  let activeTurnId: string | null = null;
+  let exited = false;
+  const pendingRequests = new Map<number, PendingRequest>();
+
+  appServer.stderr.pipe(process.stderr);
+
+  const stdoutLines = createInterface({ input: appServer.stdout });
+  stdoutLines.on("line", (line) => {
+    void handleAppServerLine(line);
+  });
+
+  appServer.on("exit", (code, signal) => {
+    if (exited) {
+      return;
+    }
+
+    const reason = signal ? `signal ${signal}` : `exit code ${code ?? 0}`;
+    emitError(`codex app-server exited before the turn completed (${reason}).`);
+    process.exit(code ?? 1);
+  });
+
+  try {
+    await request("initialize", {
+      clientInfo: {
+        name: "sandcastle-codex-app-server",
+        title: "Sandcastle Codex App Server",
+        version: "0.1.0",
+      },
+      capabilities: {
+        experimentalApi: true,
+        requestAttestation: false,
+      },
+    });
+
+    notify("initialized");
+
+    const threadStart = await request("thread/start", {
+      model: args.model,
+      cwd: process.cwd(),
+      approvalPolicy: "never",
+      approvalsReviewer: "user",
+      sandbox: "danger-full-access",
+      serviceName: "sandcastle",
+      ephemeral: true,
+      threadSource: "subagent",
+    });
+
+    threadId = getNestedString(threadStart, ["thread", "id"]);
+
+    if (!threadId) {
+      throw new Error("codex app-server did not return a thread id.");
+    }
+
+    const turnStart = await request("turn/start", {
+      threadId,
+      input: [{ type: "text", text: prompt, text_elements: [] }],
+      cwd: process.cwd(),
+      approvalPolicy: "never",
+      approvalsReviewer: "user",
+      sandboxPolicy: { type: "dangerFullAccess" },
+      model: args.model,
+      effort: args.effort ?? null,
+    });
+
+    activeTurnId = getNestedString(turnStart, ["turn", "id"]);
+  } catch (error) {
+    emitError(error instanceof Error ? error.message : String(error));
+    await shutdown(1);
+  }
+
+  function request(method: string, params: unknown): Promise<unknown> {
+    const id = nextRequestId++;
+    appServer.stdin.write(`${JSON.stringify({ id, method, params })}\n`);
+
+    return new Promise((resolve, reject) => {
+      pendingRequests.set(id, { resolve, reject });
+    });
+  }
+
+  function notify(method: string, params?: unknown): void {
+    const message = params === undefined ? { method } : { method, params };
+    appServer.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  async function handleAppServerLine(line: string): Promise<void> {
+    let message: any;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    if (message.id !== undefined && pendingRequests.has(message.id)) {
+      const pending = pendingRequests.get(message.id)!;
+      pendingRequests.delete(message.id);
+
+      if (message.error) {
+        pending.reject(
+          new Error(message.error.message ?? JSON.stringify(message.error)),
+        );
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+
+    if (message.id !== undefined && message.method) {
+      handleServerRequest(message);
+      return;
+    }
+
+    if (!message.method) {
+      return;
+    }
+
+    switch (message.method) {
+      case "item/started":
+        handleItemStarted(message.params);
+        break;
+      case "item/agentMessage/delta":
+        handleAgentMessageDelta(message.params);
+        break;
+      case "item/completed":
+        handleItemCompleted(message.params);
+        break;
+      case "item/commandExecution/outputDelta":
+      case "command/exec/outputDelta":
+      case "process/outputDelta":
+      case "item/plan/delta":
+      case "item/reasoning/summaryTextDelta":
+      case "item/reasoning/textDelta":
+        emit({ type: "heartbeat" });
+        break;
+      case "error":
+        emitError(
+          message.params?.error?.message ?? JSON.stringify(message.params),
+        );
+        break;
+      case "turn/completed":
+        await handleTurnCompleted(message.params);
+        break;
+    }
+  }
+
+  function handleServerRequest(message: any): void {
+    switch (message.method) {
+      case "item/commandExecution/requestApproval":
+        respond(message.id, { decision: "accept" });
+        break;
+      case "item/fileChange/requestApproval":
+        respond(message.id, { decision: "accept" });
+        break;
+      case "item/permissions/requestApproval":
+        respond(message.id, {
+          permissions: message.params?.permissions ?? {},
+          scope: "session",
+        });
+        break;
+      case "mcpServer/elicitation/request":
+        respond(message.id, { action: "cancel", content: null, _meta: null });
+        break;
+      case "item/tool/requestUserInput":
+        respond(message.id, { answers: {} });
+        break;
+      case "item/tool/call":
+        respond(message.id, { contentItems: [], success: false });
+        break;
+      case "account/chatgptAuthTokens/refresh":
+        respondWithCurrentAuthTokens(message.id);
+        break;
+      default:
+        rejectRequest(
+          message.id,
+          `Unsupported app-server request: ${message.method}`,
+        );
+        break;
+    }
+  }
+
+  function respondWithCurrentAuthTokens(id: number): void {
+    try {
+      const authPath = join(
+        process.env.CODEX_HOME ?? "/home/agent/.codex",
+        "auth.json",
+      );
+      const auth = JSON.parse(readFileSync(authPath, "utf8"));
+      const accessToken = auth.tokens?.access_token;
+      const chatgptAccountId = auth.tokens?.account_id;
+
+      if (
+        typeof accessToken !== "string" ||
+        typeof chatgptAccountId !== "string"
+      ) {
+        throw new Error("auth.json does not contain ChatGPT tokens.");
+      }
+
+      respond(id, {
+        accessToken,
+        chatgptAccountId,
+        chatgptPlanType: null,
+      });
+    } catch (error) {
+      rejectRequest(
+        id,
+        error instanceof Error
+          ? error.message
+          : "Unable to read ChatGPT auth tokens.",
+      );
+    }
+  }
+
+  function respond(id: number, result: unknown): void {
+    appServer.stdin.write(`${JSON.stringify({ id, result })}\n`);
+  }
+
+  function rejectRequest(id: number, message: string): void {
+    appServer.stdin.write(
+      `${JSON.stringify({ id, error: { code: -32000, message } })}\n`,
+    );
+  }
+
+  function handleItemStarted(params: any): void {
+    if (params?.item?.type !== "commandExecution") {
+      return;
+    }
+
+    emit({
+      type: "item.started",
+      item: {
+        type: "command_execution",
+        command: params.item.command,
+      },
+    });
+  }
+
+  function handleAgentMessageDelta(params: any): void {
+    if (typeof params?.delta !== "string" || params.delta.length === 0) {
+      return;
+    }
+
+    emit({
+      type: "item.delta",
+      item: {
+        type: "agent_message_delta",
+        text: params.delta,
+      },
+    });
+  }
+
+  function handleItemCompleted(params: any): void {
+    if (params?.item?.type !== "agentMessage") {
+      return;
+    }
+
+    emit({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: params.item.text,
+      },
+    });
+  }
+
+  async function handleTurnCompleted(params: any): Promise<void> {
+    if (params.threadId !== threadId) {
+      return;
+    }
+
+    const turn = params.turn;
+    if (activeTurnId && turn?.id !== activeTurnId) {
+      return;
+    }
+
+    if (turn?.status === "failed") {
+      emitError(turn.error?.message ?? "Codex turn failed.");
+      await shutdown(1);
+      return;
+    }
+
+    await shutdown(0);
+  }
+
+  function emit(event: unknown): void {
+    process.stdout.write(`${JSON.stringify(event)}\n`);
+  }
+
+  function emitError(message: string): void {
+    emit({ type: "error", message });
+  }
+
+  async function shutdown(code: number): Promise<void> {
+    if (exited) {
+      return;
+    }
+
+    exited = true;
+    stdoutLines.close();
+    appServer.stdin.end();
+    appServer.kill("SIGTERM");
+
+    try {
+      await Promise.race([
+        once(appServer, "exit"),
+        new Promise((resolve) => setTimeout(resolve, 1000)),
+      ]);
+    } catch {
+      // Best-effort shutdown.
+    }
+
+    process.exit(code);
+  }
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  const parsed: { model?: string; effort?: string } = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--model") {
+      parsed.model = argv[++i];
+      continue;
+    }
+    if (arg === "--effort") {
+      parsed.effort = argv[++i];
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return parsed;
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function getNestedString(
+  value: unknown,
+  path: readonly string[],
+): string | null {
+  let cursor: unknown = value;
+  for (const key of path) {
+    if (typeof cursor !== "object" || cursor === null || !(key in cursor)) {
+      return null;
+    }
+    cursor = (cursor as Record<string, unknown>)[key];
+  }
+
+  return typeof cursor === "string" ? cursor : null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,12 +51,19 @@ export type {
   OutputStringDefinition,
 } from "./Output.js";
 export { CwdError } from "./resolveCwd.js";
-export { claudeCode, codex, opencode, pi } from "./AgentProvider.js";
+export {
+  claudeCode,
+  codex,
+  codexAppServer,
+  opencode,
+  pi,
+} from "./AgentProvider.js";
 export type {
   AgentProvider,
   AgentCommandOptions,
   PrintCommand,
   ClaudeCodeOptions,
+  CodexAppServerOptions,
   CodexOptions,
   OpenCodeOptions,
   PiOptions,


### PR DESCRIPTION
## Summary

Adds a first-class `codexAppServer()` agent provider that runs `codex app-server --listen stdio://` through a packaged runner instead of requiring projects to carry their own app-server bridge script.

## Details

- adds `codexAppServer(model, { effort, env })` alongside the existing `codex()` provider
- packages a `codex-app-server-runner` subpath used by the provider command
- supports Codex ChatGPT auth refresh from mounted `CODEX_HOME/auth.json`
- exposes the provider through the public index and init agent registry
- documents sandbox auth mounting for `~/.codex/auth.json`
- updates `prepare` to build `dist` so GitHub fork installs include runnable artifacts

## Verification

- `npm run typecheck`
- `npm test -- AgentProvider.test.ts InitService.test.ts`
- `npm run build`
- `npx prettier --check README.md package.json src/AgentProvider.ts src/AgentProvider.test.ts src/InitService.ts src/index.ts src/codexAppServerRunner.ts`
- `npm pack --dry-run`

Full `npm test` was also attempted, but this local Mac environment has unrelated failures: Podman machine is not running, and several existing path assertions compare `/var/...` to `/private/var/...`.
