### PR TITLE
docs: fix sandcastle init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Sandcastle is provider-agnostic — it ships with built-in providers for Docker,
 npm install --save-dev @ai-hero/sandcastle
 ```
 
-2. Run `sandcastle init`. This scaffolds a `.sandcastle` directory with all the files needed.
+2. Run `npx @ai-hero/sandcastle init`. This scaffolds a `.sandcastle` directory with all the files needed.
 
 ```bash
-npx sandcastle init
+npx @ai-hero/sandcastle init
 ```
 
 3. Edit `.sandcastle/.env` and fill in your default values for `ANTHROPIC_API_KEY`. If you want to use your Claude subscription instead of an API key, see [#191](https://github.com/mattpocock/sandcastle/issues/191).


### PR DESCRIPTION
## Summary

When trying to set up Sandcastle for the first time, I ran into an issue: running `npx sandcastle init` executed the unscoped `sandcastle` package from npm instead of this project’s package.

The unscoped package exists here and appears to be unrelated: https://www.npmjs.com/package/sandcastle

To avoid that ambiguity, I would suggest updating the README quick start to use the scoped package name explicitly.

## Changes

- Change the README quick-start command to use `npx @ai-hero/sandcastle init`

## Notes

`npx sandcastle init` can still work after `@ai-hero/sandcastle` has been installed locally, because `npx` can resolve the local binary. This change makes the README less surprising if the command is run before install or from another directory.

I also noticed that `docs/content/docs/index.mdx` appears to be out of date: it references `npm install -g sandcastle` and `sandcastle run`. I intentionally left that untouched to keep this PR focused on the README quick start.

## Verification

- Pre-commit hook ran Prettier on the edited README
```