### PR TITLE
fix(init): bundle planner template Zod dependency

### DIFF
--- a/.changeset/bundled-zod-planner-templates.md
+++ b/.changeset/bundled-zod-planner-templates.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Bundle Zod through Sandcastle's public API and update planner templates to use `sandcastle.z`, so generated `.sandcastle/main.ts` files do not require users to install `zod` separately before running.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ai-hero/sandcastle",
-  "version": "0.6.0",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ai-hero/sandcastle",
-      "version": "0.6.0",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
@@ -15,7 +15,8 @@
         "@effect/platform-node": "^0.105.0",
         "@effect/printer": "^0.48.0",
         "@effect/printer-ansi": "^0.48.0",
-        "effect": "^3.20.0"
+        "effect": "^3.20.0",
+        "zod": "^4.4.3"
       },
       "bin": {
         "sandcastle": "dist/main.js"
@@ -30,8 +31,7 @@
         "lint-staged": "^15.5.1",
         "prettier": "^3.5.3",
         "tsx": "^4.21.0",
-        "vitest": "^3.2.0",
-        "zod": "^4.4.3"
+        "vitest": "^3.2.0"
       },
       "peerDependencies": {
         "@daytona/sdk": "^0.164.0",
@@ -8093,7 +8093,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "prettier": "^3.5.3",
     "tsx": "^4.21.0",
     "vitest": "^3.2.0",
-    "@daytona/sdk": "^0.164.0",
-    "zod": "^4.4.3"
+    "@daytona/sdk": "^0.164.0"
   },
   "dependencies": {
     "@clack/prompts": "^1.1.0",
@@ -82,7 +81,8 @@
     "@effect/platform-node": "^0.105.0",
     "@effect/printer": "^0.48.0",
     "@effect/printer-ansi": "^0.48.0",
-    "effect": "^3.20.0"
+    "effect": "^3.20.0",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "@vercel/sandbox": ">=1.0.0",

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -767,17 +767,17 @@ describe("InitService scaffold", () => {
       expect(joined).not.toContain("CODING_STANDARDS.md");
     });
 
-    it("planner template includes a step to install a schema validator", () => {
+    it("planner template does not require a separate schema validator install", () => {
       const lines = next("parallel-planner", "main.mts");
       const joined = lines.join("\n");
-      expect(joined).toContain("npm install zod");
-      expect(joined).toContain("standardschema.dev");
+      expect(joined).not.toContain("npm install zod");
+      expect(joined).not.toContain("standardschema.dev");
     });
 
-    it("parallel-planner-with-review template includes the schema validator step", () => {
+    it("parallel-planner-with-review template does not require a separate schema validator install", () => {
       const lines = next("parallel-planner-with-review", "main.mts");
       const joined = lines.join("\n");
-      expect(joined).toContain("npm install zod");
+      expect(joined).not.toContain("npm install zod");
     });
 
     it("non-planner template does not mention installing zod", () => {
@@ -1818,7 +1818,7 @@ describe("InitService scaffold", () => {
         join(dir, ".sandcastle", "main.mts"),
         "utf-8",
       );
-      expect(main).toContain("id: z.string()");
+      expect(main).toContain("id: sandcastle.z.string()");
       expect(main).toContain("TASK_ID: issue.id");
       expect(main).not.toContain("number: number");
       expect(main).not.toContain("ISSUE_NUMBER");
@@ -1838,8 +1838,8 @@ describe("InitService scaffold", () => {
       expect(main).toContain("Output.object");
       expect(main).toContain('tag: "plan"');
       expect(main).toContain("plan.output.issues");
-      expect(main).toContain('from "zod"');
-      expect(main).toContain("z.object");
+      expect(main).not.toContain('from "zod"');
+      expect(main).toContain("sandcastle.z.object");
       expect(main).not.toContain("extractPlanIssues");
     });
 
@@ -1989,7 +1989,7 @@ describe("InitService scaffold", () => {
         join(dir, ".sandcastle", "main.mts"),
         "utf-8",
       );
-      expect(main).toContain("id: z.string()");
+      expect(main).toContain("id: sandcastle.z.string()");
       expect(main).toContain("TASK_ID: issue.id");
       expect(main).not.toContain("number: number");
       expect(main).not.toContain("ISSUE_NUMBER");
@@ -2009,8 +2009,8 @@ describe("InitService scaffold", () => {
       expect(main).toContain("Output.object");
       expect(main).toContain('tag: "plan"');
       expect(main).toContain("plan.output.issues");
-      expect(main).toContain('from "zod"');
-      expect(main).toContain("z.object");
+      expect(main).not.toContain('from "zod"');
+      expect(main).toContain("sandcastle.z.object");
       expect(main).not.toContain("extractPlanIssues");
     });
 

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -516,7 +516,6 @@ export function getNextStepsLines(
     ];
   } else {
     const hasReviewer = template.includes("review");
-    const usesPlanSchema = template.includes("planner");
     let step = 1;
     const lines: string[] = [
       "Next steps:",
@@ -525,11 +524,6 @@ export function getNextStepsLines(
       `${step++}. Add "sandcastle": "npx tsx .sandcastle/${mainFilename}" to your package.json scripts`,
       `${step++}. Templates use \`copyToWorktree: ["node_modules"]\` to copy your host node_modules into the sandbox for fast startup — the \`npm install\` in the onSandboxReady hook is a safety net for platform-specific binaries. Adjust both if you use a different package manager`,
     ];
-    if (usesPlanSchema) {
-      lines.push(
-        `${step++}. Install a schema validator for the planner's \`<plan>\` output — the template uses Zod (\`npm install zod\`), but Valibot, ArkType, or any Standard Schema library works (https://standardschema.dev)`,
-      );
-    }
     lines.push(
       `${step++}. Read and customize the prompt files in .sandcastle/ — they shape what the agent does`,
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export type {
   OutputObjectDefinition,
   OutputStringDefinition,
 } from "./Output.js";
+export { z } from "zod";
 export { CwdError } from "./resolveCwd.js";
 export {
   claudeCode,

--- a/src/templates/parallel-planner-with-review/main.mts
+++ b/src/templates/parallel-planner-with-review/main.mts
@@ -23,15 +23,18 @@
 
 import * as sandcastle from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
-import { z } from "zod";
 
 // The planner emits its plan as JSON inside <plan> tags; Output.object extracts
-// and validates it against this schema. We use Zod here, but any Standard
-// Schema validator works just as well — Valibot, ArkType, etc. See
+// and validates it against this schema. The template uses Sandcastle's bundled
+// Zod export, but any Standard Schema validator works just as well. See
 // https://standardschema.dev.
-const planSchema = z.object({
-  issues: z.array(
-    z.object({ id: z.string(), title: z.string(), branch: z.string() }),
+const planSchema = sandcastle.z.object({
+  issues: sandcastle.z.array(
+    sandcastle.z.object({
+      id: sandcastle.z.string(),
+      title: sandcastle.z.string(),
+      branch: sandcastle.z.string(),
+    }),
   ),
 });
 

--- a/src/templates/parallel-planner/main.mts
+++ b/src/templates/parallel-planner/main.mts
@@ -18,15 +18,18 @@
 
 import * as sandcastle from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
-import { z } from "zod";
 
 // The planner emits its plan as JSON inside <plan> tags; Output.object extracts
-// and validates it against this schema. We use Zod here, but any Standard
-// Schema validator works just as well — Valibot, ArkType, etc. See
+// and validates it against this schema. The template uses Sandcastle's bundled
+// Zod export, but any Standard Schema validator works just as well. See
 // https://standardschema.dev.
-const planSchema = z.object({
-  issues: z.array(
-    z.object({ id: z.string(), title: z.string(), branch: z.string() }),
+const planSchema = sandcastle.z.object({
+  issues: sandcastle.z.array(
+    sandcastle.z.object({
+      id: sandcastle.z.string(),
+      title: sandcastle.z.string(),
+      branch: sandcastle.z.string(),
+    }),
   ),
 });
 


### PR DESCRIPTION
## Summary
- re-export Zod from `@ai-hero/sandcastle`
- move `zod` to runtime dependencies so the export is available to installed users
- update planner templates to use `sandcastle.z` instead of a bare `zod` import
- remove the next-step instruction that told users to install Zod separately

Closes #746.

## Verification
- `npx vitest run src/InitService.test.ts` (188 passed)
- `npx tsgo --project tsconfig.build.json`
- `npx prettier --check package.json package-lock.json src/index.ts src/InitService.ts src/InitService.test.ts src/templates/parallel-planner/main.mts src/templates/parallel-planner-with-review/main.mts .changeset/bundled-zod-planner-templates.md`
- `node --input-type=module -e "import('./dist/index.js').then((m) => { if (typeof m.z?.object !== 'function') throw new Error('missing z export'); console.log('z export ok'); })"`
- `git diff --check`

Note: `npm run build` reaches `tsgo`, then the existing Windows shell cannot run the package `postbuild` script because it uses POSIX `rm`/`cp`. The raw `tsgo` build command above passed.