### PR TITLE
fix(init): offer planner template zod install

### DIFF
--- a/.changeset/planner-template-zod-init.md
+++ b/.changeset/planner-template-zod-init.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Prompt during init to install Zod for planner templates, with package manager detection and a scripted `--install-template-dependencies` flag.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ai-hero/sandcastle",
-  "version": "0.6.0",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ai-hero/sandcastle",
-      "version": "0.6.0",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -83,6 +83,11 @@ describe("sandcastle CLI", () => {
     expect(stdout).toContain("--model");
   });
 
+  it("init --help exposes --install-template-dependencies flag", async () => {
+    const { stdout } = await runCli("init --help", process.cwd());
+    expect(stdout).toContain("--install-template-dependencies");
+  });
+
   it("init --help exposes --sandbox flag", async () => {
     const { stdout } = await runCli("init --help", process.cwd());
     expect(stdout).toContain("--sandbox");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,11 +3,13 @@ import { FileSystem } from "@effect/platform";
 import { Effect } from "effect";
 import * as clack from "@clack/prompts";
 import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { styleText } from "node:util";
 
 import { Display } from "./Display.js";
+import type { DisplayService } from "./Display.js";
 import { buildImage, removeImage } from "./DockerLifecycle.js";
 import {
   buildImage as podmanBuildImage,
@@ -46,6 +48,135 @@ const resolveImageName = (
   cliFlag: import("effect").Option.Option<string>,
   cwd: string,
 ): string => (cliFlag._tag === "Some" ? cliFlag.value : defaultImageName(cwd));
+
+type OptionalTextFlag = import("effect").Option.Option<string>;
+
+type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+const parseStrictBoolean = (
+  flagLabel: string,
+  raw: string,
+): Effect.Effect<boolean, InitError, never> => {
+  const value = raw.trim().toLowerCase();
+  if (["true", "1", "yes"].includes(value)) return Effect.succeed(true);
+  if (["false", "0", "no"].includes(value)) return Effect.succeed(false);
+  return Effect.fail(
+    new InitError({
+      message: `Invalid value for --${flagLabel}: "${raw}". Expected true or false.`,
+    }),
+  );
+};
+
+const readPackageJson = (cwd: string): Record<string, unknown> | undefined => {
+  const packageJsonPath = join(cwd, "package.json");
+  if (!existsSync(packageJsonPath)) return undefined;
+  try {
+    return JSON.parse(readFileSync(packageJsonPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return undefined;
+  }
+};
+
+export const detectPackageManager = (cwd: string): PackageManager => {
+  const packageManager = readPackageJson(cwd)?.packageManager;
+  if (typeof packageManager === "string") {
+    const name = packageManager.split("@")[0];
+    if (name === "pnpm" || name === "yarn" || name === "bun") return name;
+    if (name === "npm") return "npm";
+  }
+
+  if (existsSync(join(cwd, "pnpm-lock.yaml"))) return "pnpm";
+  if (existsSync(join(cwd, "bun.lock")) || existsSync(join(cwd, "bun.lockb"))) {
+    return "bun";
+  }
+  if (existsSync(join(cwd, "yarn.lock"))) return "yarn";
+  return "npm";
+};
+
+export const zodInstallCommand = (packageManager: PackageManager): string => {
+  switch (packageManager) {
+    case "pnpm":
+      return "pnpm add zod";
+    case "yarn":
+      return "yarn add zod";
+    case "bun":
+      return "bun add zod";
+    case "npm":
+      return "npm install zod";
+  }
+};
+
+const packageHasDependency = (cwd: string, dependency: string): boolean => {
+  const pkg = readPackageJson(cwd);
+  if (!pkg) return false;
+  return [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+  ].some((field) => {
+    const deps = pkg[field];
+    return (
+      deps !== null &&
+      typeof deps === "object" &&
+      !Array.isArray(deps) &&
+      Object.prototype.hasOwnProperty.call(deps, dependency)
+    );
+  });
+};
+
+const templateUsesZod = (template: string): boolean =>
+  template === "parallel-planner" ||
+  template === "parallel-planner-with-review";
+
+const maybeInstallZodForTemplate = (
+  cwd: string,
+  template: string,
+  installFlag: OptionalTextFlag,
+  d: DisplayService,
+): Effect.Effect<void, InitError, never> =>
+  Effect.gen(function* () {
+    if (!templateUsesZod(template) || packageHasDependency(cwd, "zod")) return;
+
+    const packageManager = detectPackageManager(cwd);
+    const command = zodInstallCommand(packageManager);
+    const shouldInstall =
+      installFlag._tag === "Some"
+        ? yield* parseStrictBoolean(
+            "install-template-dependencies",
+            installFlag.value,
+          )
+        : yield* Effect.promise(() =>
+            clack.confirm({
+              message: `Install Zod for the planner template now? (${command})`,
+              initialValue: true,
+            }),
+          );
+
+    if (clack.isCancel(shouldInstall)) {
+      yield* Effect.fail(
+        new InitError({ message: "Template dependency install cancelled." }),
+      );
+    }
+
+    if (shouldInstall !== true) return;
+
+    yield* d.spinner(
+      `Installing planner template dependency with ${packageManager}...`,
+      Effect.try({
+        try: () => execSync(command, { cwd, stdio: "pipe" }),
+        catch: (error) =>
+          new InitError({
+            message: `Failed to install Zod with \`${command}\`: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          }),
+      }),
+    );
+  });
 
 // --- UID build-args ---
 
@@ -106,6 +237,15 @@ const sandboxOption = Options.text("sandbox").pipe(
   Options.optional,
 );
 
+const installTemplateDependenciesOption = Options.text(
+  "install-template-dependencies",
+).pipe(
+  Options.withDescription(
+    "true or false: install dependencies required by the selected template during init",
+  ),
+  Options.optional,
+);
+
 const initCommand = Command.make(
   "init",
   {
@@ -114,6 +254,7 @@ const initCommand = Command.make(
     agent: agentOption,
     model: initModelOption,
     sandbox: sandboxOption,
+    installTemplateDependencies: installTemplateDependenciesOption,
   },
   ({
     imageName: imageNameFlag,
@@ -121,6 +262,7 @@ const initCommand = Command.make(
     agent: agentFlag,
     model: modelFlag,
     sandbox: sandboxFlag,
+    installTemplateDependencies,
   }) =>
     Effect.gen(function* () {
       const d = yield* Display;
@@ -308,6 +450,13 @@ const initCommand = Command.make(
               }),
           ),
         ),
+      );
+
+      yield* maybeInstallZodForTemplate(
+        cwd,
+        selectedTemplate,
+        installTemplateDependencies,
+        d,
       );
 
       // Prompt user before building image. The custom issue tracker scaffolds

--- a/src/cliTemplateDependencies.test.ts
+++ b/src/cliTemplateDependencies.test.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { detectPackageManager, zodInstallCommand } from "./cli.js";
+
+const makeDir = () => mkdtemp(join(tmpdir(), "cli-template-deps-"));
+
+describe("template dependency package manager detection", () => {
+  it("uses packageManager when present", async () => {
+    const dir = await makeDir();
+    await writeFile(
+      join(dir, "package.json"),
+      JSON.stringify({ packageManager: "pnpm@10.0.0" }),
+    );
+
+    expect(detectPackageManager(dir)).toBe("pnpm");
+  });
+
+  it("detects bun, yarn, pnpm, and npm install commands", () => {
+    expect(zodInstallCommand("bun")).toBe("bun add zod");
+    expect(zodInstallCommand("yarn")).toBe("yarn add zod");
+    expect(zodInstallCommand("pnpm")).toBe("pnpm add zod");
+    expect(zodInstallCommand("npm")).toBe("npm install zod");
+  });
+
+  it("falls back to lockfiles and then npm", async () => {
+    const pnpmDir = await makeDir();
+    await writeFile(join(pnpmDir, "pnpm-lock.yaml"), "");
+    expect(detectPackageManager(pnpmDir)).toBe("pnpm");
+
+    const bunDir = await makeDir();
+    await writeFile(join(bunDir, "bun.lock"), "");
+    expect(detectPackageManager(bunDir)).toBe("bun");
+
+    const yarnDir = await makeDir();
+    await writeFile(join(yarnDir, "yarn.lock"), "");
+    expect(detectPackageManager(yarnDir)).toBe("yarn");
+
+    const npmDir = await makeDir();
+    expect(detectPackageManager(npmDir)).toBe("npm");
+  });
+});


### PR DESCRIPTION
Closes #746.

This follows the maintainer direction from the issue thread after #748:

- detect the package manager from `packageManager` / lockfiles (`npm`, `pnpm`, `yarn`, `bun`, defaulting to `npm`)
- during `sandcastle init`, only prompt to install Zod when the selected template uses the planner schema
- add `--install-template-dependencies true|false` so scripted/programmatic init can opt in or out without an extra prompt
- skip the install prompt entirely when `zod` is already present in package dependencies

Verification:

- `npm run typecheck`
- `npm test -- cliTemplateDependencies.test.ts InitService.test.ts cli.test.ts` (208 passed)
- `npx prettier --check src/cli.ts src/cli.test.ts src/cliTemplateDependencies.test.ts .changeset/planner-template-zod-init.md`
- `git diff --check`
- `npx tsgo --project tsconfig.build.json`

Note: `npm run build` reaches the compile step but fails on Windows during the existing `postbuild` command because it uses Unix `rm`/`cp`; the direct `tsgo` compile command above passes.