### PR TITLE
feat: add Linear issue tracker

### DIFF
--- a/.changeset/linear-tracker.md
+++ b/.changeset/linear-tracker.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+feat: add Linear as a built-in issue tracker option

--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ try {
 
 ### Templates
 
-`sandcastle init` prompts you to choose a sandbox provider (Docker or Podman), an issue tracker (GitHub Issues, Beads, or Custom), and a template, which scaffolds a ready-to-use prompt and `main.mts` suited to a specific workflow. If your project's `package.json` has `"type": "module"`, the file will be named `main.ts` instead. Choosing **Custom** scaffolds the project in a deliberately broken-until-configured state plus a `.sandcastle/SETUP_ISSUE_TRACKER.md` prompt you feed to your coding agent, which wires up your own tracker by editing the scaffolded files in place. Five templates are available:
+`sandcastle init` prompts you to choose a sandbox provider (Docker or Podman), an issue tracker (GitHub Issues, Beads, Linear, or Custom), and a template, which scaffolds a ready-to-use prompt and `main.mts` suited to a specific workflow. If your project's `package.json` has `"type": "module"`, the file will be named `main.ts` instead. Choosing **Custom** scaffolds the project in a deliberately broken-until-configured state plus a `.sandcastle/SETUP_ISSUE_TRACKER.md` prompt you feed to your coding agent, which wires up your own tracker by editing the scaffolded files in place. Five templates are available:
 
 | Template                       | Description                                                               |
 | ------------------------------ | ------------------------------------------------------------------------- |

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -1343,10 +1343,11 @@ describe("InitService scaffold", () => {
   // --- Issue tracker ---
 
   describe("Issue tracker registry", () => {
-    it("listIssueTrackers returns github-issues and beads", () => {
+    it("listIssueTrackers returns github-issues, beads, and linear", () => {
       const managers = listIssueTrackers();
       expect(managers.some((m) => m.name === "github-issues")).toBe(true);
       expect(managers.some((m) => m.name === "beads")).toBe(true);
+      expect(managers.some((m) => m.name === "linear")).toBe(true);
     });
 
     it("getIssueTracker returns github-issues entry with expected templateArgs", () => {
@@ -1389,6 +1390,25 @@ describe("InitService scaffold", () => {
       expect(manager!.templateArgs.ISSUE_TRACKER_TOOLS).toContain(
         "dpkg-architecture -qDEB_HOST_MULTIARCH",
       );
+    });
+
+    it("getIssueTracker returns linear entry with expected templateArgs", () => {
+      const manager = getIssueTracker("linear");
+      expect(manager).toBeDefined();
+      expect(manager!.label).toBe("Linear");
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain(
+        "api.linear.app/graphql",
+      );
+      expect(manager!.templateArgs.LIST_TASKS_COMMAND).toContain("jq");
+      expect(manager!.templateArgs.VIEW_TASK_COMMAND).toContain(
+        "api.linear.app/graphql",
+      );
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain(
+        "workflowStates",
+      );
+      expect(manager!.templateArgs.CLOSE_TASK_COMMAND).toContain("issueUpdate");
+      expect(manager!.templateArgs.ISSUE_TRACKER_TOOLS).toBe("");
+      expect(manager!.envExample).toContain("LINEAR_API_KEY=");
     });
 
     it("getIssueTracker returns custom entry with broken-until-configured templateArgs", () => {
@@ -1514,6 +1534,39 @@ describe("InitService scaffold", () => {
         "utf-8",
       );
       expect(prompt).not.toContain("--label Sandcastle");
+    });
+
+    it("simple-loop with linear produces prompt with linear commands", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        templateName: "simple-loop",
+        issueTracker: getIssueTracker("linear"),
+      });
+
+      const prompt = await readFile(
+        join(dir, ".sandcastle", "prompt.md"),
+        "utf-8",
+      );
+      expect(prompt).toContain("api.linear.app/graphql");
+      expect(prompt).toContain("jq");
+      expect(prompt).not.toContain("gh issue list");
+      expect(prompt).not.toContain("gh issue close");
+      expect(prompt).not.toContain("{{LIST_TASKS_COMMAND}}");
+      expect(prompt).not.toContain("{{CLOSE_TASK_COMMAND}}");
+    });
+
+    it("generates .env.example with LINEAR_API_KEY when issue tracker is linear", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        issueTracker: getIssueTracker("linear"),
+      });
+
+      const envExample = await readFile(
+        join(dir, ".sandcastle", ".env.example"),
+        "utf-8",
+      );
+      expect(envExample).toContain("LINEAR_API_KEY=");
+      expect(envExample).not.toContain("GH_TOKEN=");
     });
 
     it("simple-loop with github-issues retains --label Sandcastle when createLabel is true", async () => {
@@ -2151,6 +2204,21 @@ describe("InitService scaffold", () => {
       expect(dockerfile).not.toContain("{{ISSUE_TRACKER_TOOLS}}");
       expect(dockerfile).not.toContain("x86_64-linux-gnu");
       expect(dockerfile).toContain("dpkg-architecture -qDEB_HOST_MULTIARCH");
+    });
+
+    it("scaffold with linear produces Dockerfile with no extra tools (curl/jq already in base image)", async () => {
+      const dir = await makeDir();
+      await runScaffold(dir, {
+        issueTracker: getIssueTracker("linear"),
+      });
+
+      const dockerfile = await readFile(
+        join(dir, ".sandcastle", "Dockerfile"),
+        "utf-8",
+      );
+      expect(dockerfile).not.toContain("GitHub CLI");
+      expect(dockerfile).not.toContain("beads");
+      expect(dockerfile).not.toContain("{{ISSUE_TRACKER_TOOLS}}");
     });
 
     it("scaffold with beads + podman produces Containerfile with beads install", async () => {

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -419,6 +419,31 @@ GH_TOKEN=`,
     envExample: "",
   },
   {
+    name: "linear",
+    label: "Linear",
+    templateArgs: {
+      LIST_TASKS_COMMAND: `curl -s -X POST https://api.linear.app/graphql \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: $LINEAR_API_KEY" \\
+  -d '{"query": "query { issues(filter: { state: { name: { nin: [\\"Done\\", \\"Canceled\\"] } } }) { nodes { id title description } } }"}' | jq '[.data.issues.nodes[] | {id, title, description}]'`,
+      VIEW_TASK_COMMAND: `curl -s -X POST https://api.linear.app/graphql \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: $LINEAR_API_KEY" \\
+  -d '{"query": "query { issue(id: \\"<ID>\\") { id title description } }"}' | jq '{title: .data.issue.title, description: .data.issue.description}'`,
+      CLOSE_TASK_COMMAND: `STATE_ID=$(curl -s -X POST https://api.linear.app/graphql \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: $LINEAR_API_KEY" \\
+  -d '{"query":"{workflowStates(filter:{type:{eq:\\"completed\\"}}){nodes{id}}}"}' | jq -r '.data.workflowStates.nodes[0].id') \\
+&& curl -s -X POST https://api.linear.app/graphql \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: $LINEAR_API_KEY" \\
+  -d "$(jq -n --arg id '<ID>' --arg stateId "$STATE_ID" '{query: ("mutation { issueUpdate(id: " + ($id | tojson) + ", input: { stateId: " + ($stateId | tojson) + " }) { success } }")}')"`,
+      ISSUE_TRACKER_TOOLS: "",
+    },
+    envExample: `# Linear API key
+LINEAR_API_KEY=`,
+  },
+  {
     name: "custom",
     label: "Custom",
     templateArgs: {


### PR DESCRIPTION
Adds Linear as a first-class issue tracker option in `sandcastle init`.

Linear has no official CLI, so the integration uses `curl` + `jq` against Linear's GraphQL API (same scaffold pattern as GitHub Issues and Beads).

### Changes
- `linear` entry in `ISSUE_TRACKER_REGISTRY` with templated GraphQL commands
- `LIST_TASKS_COMMAND`: lists open issues as JSON
- `VIEW_TASK_COMMAND`: views a single issue by ID
- `CLOSE_TASK_COMMAND`: dynamically resolves workspace Done state and closes via mutation
- Auth via `LINEAR_API_KEY` env var
- No Dockerfile changes needed (`curl` and `jq` already in base images)
- 5 new tests (192/192 passing), README updated, patch changeset

### Out of scope
- MCP server integration (explored, deferred to follow-up)