### PR TITLE
Reduce test seams from 8 to 4 (#757)

### DIFF
--- a/.changeset/reduce-test-seams.md
+++ b/.changeset/reduce-test-seams.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Replace the `SessionStore`-based public API with pure JSONL transfer helpers. The previous `hostSessionStore`, `sandboxSessionStore`, `codexHostSessionStore`, `codexSandboxSessionStore` exports and the `SessionStore` type were the implementation seam used internally to read/write agent session files. They are now removed in favour of pure-string helpers — `transferClaudeSession(jsonl, fromCwd, toCwd)` and `transferCodexSession(jsonl, fromCwd, toCwd)` — that rewrite a session JSONL without touching the filesystem. Path helpers (`claudeHostSessionPath`, `claudeSandboxSessionPath`, `encodeProjectPath`) and the host-side scan utilities (`findClaudeSessionOnHost`, `findCodexSessionOnHost`, `HostSessionLookup`) are exposed instead, so callers building a custom `AgentSessionStorage` do their own file I/O at the call site. The built-in `claudeCode()` and `codex()` providers are unchanged for end users — only direct consumers of the removed store factories need to migrate.

--- a/docs/agents/adding-an-agent-provider.md
+++ b/docs/agents/adding-an-agent-provider.md
@@ -69,12 +69,7 @@ interface AgentProvider {
   name: string;
   env: Record<string, string>;
   captureSessions: boolean;
-  sessionStorage: {
-    hostStore(cwd: string): SessionStore;
-    sandboxStore(cwd: string, handle: BindMountSandboxHandle): SessionStore;
-    transfer(from: SessionStore, to: SessionStore, id: string): Promise<void>;
-    findByIdOnHost(id: string): Promise<HostSessionLookup>;
-  };
+  sessionStorage?: AgentSessionStorage;
   buildPrintCommand(options: AgentCommandOptions): PrintCommand;
   buildInteractiveArgs?(options: AgentCommandOptions): string[];
   parseStreamLine(line: string): ParsedStreamEvent[];
@@ -87,29 +82,43 @@ Field by field:
 - `name` — short identifier (e.g. `"claude-code"`, `"codex"`). Used in logs and config.
 - `env` — environment variables injected into the **sandbox** when this agent runs. Auth keys live here. Merged with the env resolver and **sandbox provider** env at launch.
 - `captureSessions` — user-facing kill-switch. When `true` (default), Sandcastle records the agent's session log per **iteration** and is able to resume it. Expose this on the provider's `Options` interface so users can opt out.
-- `sessionStorage` — provider-owned factories that describe where and how the agent's session record is persisted ([ADR 0012](../adr/0012-agent-provider-owned-session-storage.md)). The provider supplies `hostStore` (reads/writes session content on the **host**), `sandboxStore` (the same, inside the **sandbox** via the bind-mount handle), `transfer` (copies a session between two stores, applying any format-specific content rewriting — e.g. Claude Code rewrites the `cwd` field in each JSONL entry from source-cwd to target-cwd), and `findByIdOnHost` (locates a session on the **host** by its unique id, independent of cwd encoding — used by the no-sandbox resume precheck, where the agent runs on the **host** and writes the session in place under a cwd-derived directory Sandcastle cannot reliably reconstruct). Resumable providers must be filesystem-backed; stores wrap the provider's directory + filename convention.
+- `sessionStorage` — provider-owned object that describes where and how the agent's session record is persisted ([ADR 0012](../adr/0012-agent-provider-owned-session-storage.md)). See [`AgentSessionStorage`](#agentsessionstorage) below. Omit for providers that do not support resume.
 - `buildPrintCommand({ prompt, dangerouslySkipPermissions, resumeSession })` — returns the shell command to run the agent non-interactively. Return `{ command, stdin }` when piping the prompt via stdin (preferred for large prompts). When `resumeSession` is set, append the agent's native resume CLI flag.
 - `buildInteractiveArgs(options)` — optional. Returns the argv array for `interactive()`. Omit if the agent has no TUI.
 - `parseStreamLine(line)` — given one line of stdout, return zero or more `ParsedStreamEvent`s. Event types: `text`, `result`, `tool_call`, `session_id`, `usage`. Return `[]` for lines you can't or don't need to parse. **Emitting `session_id` is required** — without it, Sandcastle cannot capture the session for resume. Emit `usage` if the stream carries token counts (e.g. Codex's `turn.completed`); it feeds the usage display without needing session capture.
 - `parseSessionUsage(content)` — optional. Given the session log content, return token usage for the most recent iteration. Currently only Claude Code implements this.
 
-### `SessionStore`
+### `AgentSessionStorage`
 
-Defined in [`src/SessionStore.ts`](../../src/SessionStore.ts).
+Defined in [`src/AgentProvider.ts`](../../src/AgentProvider.ts).
 
 ```ts
-interface SessionStore {
-  readonly cwd: string;
-  exists(id: string): Promise<boolean>;
-  sessionFilePath(id: string): string | undefined;
-  readSession(id: string): Promise<string>;
-  writeSession(id: string, content: string): Promise<void>;
+interface AgentSessionStorage {
+  captureToHost(args: {
+    hostCwd: string;
+    sandboxCwd: string;
+    sessionId: string;
+    handle: BindMountSandboxHandle;
+  }): Promise<void>;
+  resumeIntoSandbox(args: {
+    hostCwd: string;
+    sandboxCwd: string;
+    sessionId: string;
+    handle: BindMountSandboxHandle;
+  }): Promise<void>;
+  readHostSession(cwd: string, sessionId: string): Promise<string | undefined>;
+  existsOnHost(cwd: string, sessionId: string): Promise<boolean>;
+  hostSessionFilePath(cwd: string, sessionId: string): string | undefined;
+  findByIdOnHost(sessionId: string): Promise<HostSessionLookup>;
 }
 ```
 
-- `exists(id)` — pre-flight check used by `run()` and `createWorktree()` to validate `resumeSession` before launching.
-- `sessionFilePath(id)` — the on-disk path of the session, surfaced to callers via `OrchestrateResult.sessionFilePath`. Return `undefined` only when a file-backed store cannot synchronously expose a located path yet.
-- `readSession(id)` / `writeSession(id, content)` — read/write the session content as an opaque string. For JSONL agents, this is the file contents.
+- `captureToHost` — transfer a session JSONL from the **sandbox** into the **host** store, applying any format-specific content rewriting (e.g. Claude Code rewrites the `cwd` field in each JSONL entry from sandbox-cwd to host-cwd). The session JSONL transfer helpers `transferClaudeSession` / `transferCodexSession` in [`src/SessionStore.ts`](../../src/SessionStore.ts) are pure string functions you can call from here.
+- `resumeIntoSandbox` — the reverse: transfer a session JSONL from the host store into the sandbox before resuming.
+- `readHostSession` — read a captured session JSONL from the host. Returns `undefined` when no session with that id exists. Used to parse per-iteration token usage.
+- `existsOnHost` — pre-flight check used by `run()` and `createWorktree()` to validate `resumeSession` before launching.
+- `hostSessionFilePath` — the on-disk path of the session, surfaced to callers via `OrchestrateResult.sessionFilePath`. Synchronous: file-backed stores that can derive the path from `(cwd, sessionId)` return it directly; otherwise return the path cached by `captureToHost`. Future SQLite-backed stores would return `undefined`.
+- `findByIdOnHost` — locate a session on the **host** by its unique id, independent of cwd encoding. Used by the no-sandbox resume precheck, where the agent runs on the **host** and writes the session in place under a cwd-derived directory Sandcastle cannot reliably reconstruct.
 
 ## Resume support (required)
 
@@ -118,7 +127,7 @@ Every new **agent provider** must wire resume end-to-end. The four pieces:
 1. **`parseStreamLine` emits `session_id` events.** Identify the event in your agent's stream that carries the session ID and emit `{ type: "session_id", sessionId }`. Test this with a representative captured stream line.
 2. **`buildPrintCommand` honours `resumeSession`.** When the option is set, append the agent's native resume CLI flag to the command. Verify the flag composes with `--print` / `--json` / `--model` and any other flags you pass.
 3. **`captureSessions: true` by default.** Set this in the factory; expose `captureSessions?: boolean` on the provider's `Options` interface for users who want to opt out.
-4. **`sessionStorage` sub-object populated.** Supply factories that read/write the agent's session record on **host** and inside the **sandbox**, plus a `transfer` op that copies between them. If the agent's format embeds the working directory (Claude Code's JSONL has a `cwd` field per entry), apply the rewrite inside `transfer`.
+4. **`sessionStorage` sub-object populated.** Implement `captureToHost` (sandbox → host) and `resumeIntoSandbox` (host → sandbox) for the agent's on-disk layout, plus the read/lookup ops described above. If the agent's format embeds the working directory (Claude Code's JSONL has a `cwd` field per entry), apply the rewrite inside `captureToHost` / `resumeIntoSandbox` — `transferClaudeSession` / `transferCodexSession` in `SessionStore.ts` are reusable pure-string helpers.
 
 Before writing code, **verify session-ID round-trip stability empirically**: run the agent, capture the session ID it emits, then invoke the agent with the resume flag pointing at that ID. If the agent treats the ID as opaque and continues the conversation, you're good. If it mints a new ID and ignores the requested one, or if the ID emitted to the stream is different from the one persisted to disk, the agent's CLI cannot support resume as-is.
 
@@ -154,10 +163,10 @@ For a new agent provider `foo`:
 - [ ] Verify session-ID round-trip stability empirically (see [Resume support](#resume-support-required)).
 - [ ] Factory `foo()` in [`src/AgentProvider.ts`](../../src/AgentProvider.ts), with options interface `FooOptions` (including `captureSessions?: boolean`).
 - [ ] Stream-parsing helper `parseFooStreamLine` that emits `session_id` events alongside `text` / `result` / `tool_call`.
-- [ ] `sessionStorage` sub-object on the factory's return value, with `hostStore`, `sandboxStore`, `transfer`, and `findByIdOnHost` factories specific to `foo`'s on-disk (or SQLite, etc.) layout.
+- [ ] `sessionStorage` sub-object on the factory's return value, implementing `captureToHost`, `resumeIntoSandbox`, `readHostSession`, `existsOnHost`, `hostSessionFilePath`, and `findByIdOnHost` for `foo`'s on-disk layout.
 - [ ] `buildPrintCommand` honours `resumeSession` by appending `foo`'s native resume CLI flag.
 - [ ] Tests in `src/AgentProvider.test.ts` covering `buildPrintCommand` (both fresh and resume forms), `buildInteractiveArgs`, and stream parsing — including session-ID extraction and error events on stdout if applicable.
-- [ ] Tests covering `sessionStorage` round-trip: write, read, transfer host↔sandbox, content preserved (and rewritten correctly if `foo`'s format requires it).
+- [ ] Tests covering `sessionStorage` round-trip: capture host↔sandbox, content preserved (and rewritten correctly if `foo`'s format requires it).
 - [ ] Public export from [`src/index.ts`](../../src/index.ts): the `foo` factory and the `FooOptions` type.
 - [ ] `AGENT_REGISTRY` entry in [`src/InitService.ts`](../../src/InitService.ts).
 - [ ] `FOO_DOCKERFILE` constant in `src/InitService.ts`.

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, posix } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   claudeCode,
@@ -8,6 +11,7 @@ import {
   pi,
 } from "./AgentProvider.js";
 import type { AgentCommandOptions } from "./AgentProvider.js";
+import type { BindMountSandboxHandle } from "./SandboxProvider.js";
 
 /** Shorthand: build options with dangerouslySkipPermissions: true (mirrors existing sandbox callers). */
 const opts = (prompt: string): AgentCommandOptions => ({
@@ -1846,5 +1850,110 @@ describe("captureSessions flag", () => {
 
   it("cursor has captureSessions false", () => {
     expect(cursor("cursor-model").captureSessions).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sessionStorage — captureToHost populates hostSessionFilePath
+// ---------------------------------------------------------------------------
+
+describe("sessionStorage", () => {
+  /** Bind-mount handle backed by the host filesystem (sandbox path == host path). */
+  const fsBindMountHandle = (): BindMountSandboxHandle => ({
+    worktreePath: "/workspace",
+    exec: async (command) => {
+      const { exec } = await import("node:child_process");
+      return new Promise((resolve) => {
+        exec(command, (err, stdout, stderr) => {
+          resolve({
+            stdout: stdout.toString(),
+            stderr: stderr.toString(),
+            exitCode: err && typeof err.code === "number" ? err.code : 0,
+          });
+        });
+      });
+    },
+    copyFileIn: async (hostPath, sandboxPath) => {
+      const { copyFile } = await import("node:fs/promises");
+      await copyFile(hostPath, sandboxPath);
+    },
+    copyFileOut: async (sandboxPath, hostPath) => {
+      const { copyFile } = await import("node:fs/promises");
+      await copyFile(sandboxPath, hostPath);
+    },
+    close: async () => {},
+  });
+
+  it("claudeCode hostSessionFilePath is derivable without capture", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sandcastle-claude-hostpath-"));
+    try {
+      const provider = claudeCode("claude-opus-4-7", {
+        sessionStorage: { hostProjectsDir: dir },
+      });
+      // Path is purely a function of (cwd, id) — available before any capture.
+      const path = provider.sessionStorage!.hostSessionFilePath(
+        "/some/cwd",
+        "abc-123",
+      );
+      expect(path).toContain("-some-cwd");
+      expect(path).toContain("abc-123.jsonl");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("codex hostSessionFilePath returns the captured rollout file after captureToHost", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-codex-hostpath-"));
+    const sandboxDir = await mkdtemp(join(tmpdir(), "sandcastle-codex-sbx-"));
+    try {
+      const id = "9ba1c695-2222-4444-8888-e7e847bf34dd";
+      // Stage a sandbox-side rollout file mirroring Codex's YYYY/MM/DD layout.
+      const relativePath = posix.join(
+        "2026",
+        "05",
+        "26",
+        `rollout-2026-05-26T08-00-00-${id}.jsonl`,
+      );
+      const sandboxRollout = join(sandboxDir, relativePath);
+      await mkdir(join(sandboxRollout, ".."), { recursive: true });
+      await writeFile(
+        sandboxRollout,
+        JSON.stringify({
+          type: "session_meta",
+          payload: { id, cwd: "/sandbox/repo" },
+        }),
+      );
+
+      const provider = codex("gpt-5.4-mini", {
+        sessionStorage: {
+          hostSessionsDir: hostDir,
+          sandboxSessionsDir: sandboxDir,
+        },
+      });
+
+      // Before capture, the path is unknown.
+      expect(
+        provider.sessionStorage!.hostSessionFilePath("/host/repo", id),
+      ).toBeUndefined();
+
+      await provider.sessionStorage!.captureToHost({
+        hostCwd: "/host/repo",
+        sandboxCwd: "/sandbox/repo",
+        sessionId: id,
+        handle: fsBindMountHandle(),
+      });
+
+      // After capture, the path resolves to the rewritten rollout under hostDir.
+      const captured = provider.sessionStorage!.hostSessionFilePath(
+        "/host/repo",
+        id,
+      );
+      expect(captured).toBe(join(hostDir, relativePath));
+      const content = await readFile(captured!, "utf-8");
+      expect(JSON.parse(content).payload.cwd).toBe("/host/repo");
+    } finally {
+      await rm(hostDir, { recursive: true, force: true });
+      await rm(sandboxDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -4,7 +4,6 @@ import { tmpdir } from "node:os";
 import {
   claudeHostSessionPath,
   claudeSandboxSessionPath,
-  encodeProjectPath,
   findClaudeSessionOnHost,
   findCodexSessionOnHost,
   locateCodexHostSession,
@@ -348,8 +347,7 @@ const makeClaudeSessionStorage = (
         hostProjectsDir,
       );
       const jsonl = await readFile(hostPath, "utf-8");
-      const rewritten =
-        jsonl === "" ? "" : transferClaudeSession(jsonl, hostCwd, sandboxCwd);
+      const rewritten = transferClaudeSession(jsonl, hostCwd, sandboxCwd);
       const sandboxPath = claudeSandboxSessionPath(
         sandboxCwd,
         sessionId,
@@ -369,8 +367,13 @@ const makeCodexSessionStorage = (
     options?.sessionStorage?.sandboxSessionsDir ??
     posix.join("/home/agent", ".codex", "sessions");
 
+  // Codex sessions live at YYYY/MM/DD/rollout-*-<id>.jsonl — the path is not
+  // derivable from (cwd, id) alone, so we cache the path written by
+  // captureToHost for hostSessionFilePath to surface on the IterationResult.
+  const capturedPaths = new Map<string, string>();
+
   return {
-    hostSessionFilePath: () => undefined,
+    hostSessionFilePath: (_cwd, id) => capturedPaths.get(id),
     existsOnHost: async (_cwd, id) => {
       const found = await findCodexSessionOnHost(id, hostSessionsDir);
       return found.path !== undefined;
@@ -393,6 +396,7 @@ const makeCodexSessionStorage = (
       const target = join(root, located.relativePath);
       await mkdir(dirname(target), { recursive: true });
       await writeFile(target, rewritten);
+      capturedPaths.set(sessionId, target);
     },
     resumeIntoSandbox: async ({ hostCwd, sandboxCwd, sessionId, handle }) => {
       const located = await locateCodexHostSession(sessionId, hostSessionsDir);

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -1,17 +1,28 @@
+import { mkdir, readFile, rm, writeFile, access } from "node:fs/promises";
+import { dirname, join, posix } from "node:path";
+import { tmpdir } from "node:os";
 import {
-  codexHostSessionStore,
-  codexSandboxSessionStore,
+  claudeHostSessionPath,
+  claudeSandboxSessionPath,
+  encodeProjectPath,
   findClaudeSessionOnHost,
   findCodexSessionOnHost,
-  hostSessionStore,
-  sandboxSessionStore,
+  locateCodexHostSession,
+  locateCodexSandboxSession,
   transferClaudeSession,
   transferCodexSession,
   type HostSessionLookup,
-  type LocatableSessionStore,
-  type SessionStore,
 } from "./SessionStore.js";
 import type { BindMountSandboxHandle } from "./SandboxProvider.js";
+
+const fileExists = async (path: string): Promise<boolean> => {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 export type ParsedStreamEvent =
   | { type: "text"; text: string }
@@ -206,9 +217,26 @@ export interface IterationUsage {
 }
 
 export interface AgentSessionStorage {
-  hostStore(cwd: string): SessionStore;
-  sandboxStore(cwd: string, handle: BindMountSandboxHandle): SessionStore;
-  transfer(from: SessionStore, to: SessionStore, id: string): Promise<void>;
+  /** Transfer a session JSONL from the sandbox into the host store. */
+  captureToHost(args: {
+    hostCwd: string;
+    sandboxCwd: string;
+    sessionId: string;
+    handle: BindMountSandboxHandle;
+  }): Promise<void>;
+  /** Transfer a session JSONL from the host store into the sandbox. */
+  resumeIntoSandbox(args: {
+    hostCwd: string;
+    sandboxCwd: string;
+    sessionId: string;
+    handle: BindMountSandboxHandle;
+  }): Promise<void>;
+  /** Read a captured session JSONL from the host store. Returns undefined when absent. */
+  readHostSession(cwd: string, sessionId: string): Promise<string | undefined>;
+  /** Whether a session with the given id exists in the host store keyed on cwd. */
+  existsOnHost(cwd: string, sessionId: string): Promise<boolean>;
+  /** Absolute host path where a session would be stored (for not-found error messages). */
+  hostSessionFilePath(cwd: string, sessionId: string): string | undefined;
   /**
    * Locate a session on the host by its unique id, independent of cwd encoding.
    * Used by the no-sandbox resume precheck, where the agent runs on the host and
@@ -216,7 +244,7 @@ export interface AgentSessionStorage {
    * reliably reconstruct. Returns the located path (or `undefined`) plus the
    * directory that was searched (for not-found errors).
    */
-  findByIdOnHost(id: string): Promise<HostSessionLookup>;
+  findByIdOnHost(sessionId: string): Promise<HostSessionLookup>;
 }
 
 export interface AgentProvider {
@@ -235,6 +263,147 @@ export interface AgentProvider {
 }
 
 export const DEFAULT_MODEL = "claude-opus-4-7";
+
+// ---------------------------------------------------------------------------
+// Session storage helpers — file I/O lives here so callers (Orchestrator,
+// resumePrecheck) work against the high-level AgentSessionStorage interface
+// and tests can exercise transferClaudeSession / transferCodexSession as
+// pure string functions.
+// ---------------------------------------------------------------------------
+
+const readSandboxFile = async (
+  handle: Pick<BindMountSandboxHandle, "copyFileOut">,
+  sandboxPath: string,
+  tag: string,
+): Promise<string> => {
+  const tmpPath = join(
+    tmpdir(),
+    `sandcastle-${tag}-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`,
+  );
+  await handle.copyFileOut(sandboxPath, tmpPath);
+  try {
+    return await readFile(tmpPath, "utf-8");
+  } finally {
+    await rm(tmpPath, { force: true }).catch(() => {});
+  }
+};
+
+const writeSandboxFile = async (
+  handle: Pick<BindMountSandboxHandle, "copyFileIn" | "exec">,
+  sandboxPath: string,
+  content: string,
+  tag: string,
+): Promise<void> => {
+  const tmpPath = join(
+    tmpdir(),
+    `sandcastle-${tag}-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`,
+  );
+  await writeFile(tmpPath, content);
+  try {
+    await handle.exec(`mkdir -p ${JSON.stringify(posix.dirname(sandboxPath))}`);
+    await handle.copyFileIn(tmpPath, sandboxPath);
+  } finally {
+    await rm(tmpPath, { force: true }).catch(() => {});
+  }
+};
+
+const makeClaudeSessionStorage = (
+  options?: ClaudeCodeOptions,
+): AgentSessionStorage => {
+  const hostProjectsDir = options?.sessionStorage?.hostProjectsDir;
+  const sandboxProjectsDir =
+    options?.sessionStorage?.sandboxProjectsDir ??
+    "/home/agent/.claude/projects";
+
+  return {
+    hostSessionFilePath: (cwd, id) =>
+      claudeHostSessionPath(cwd, id, hostProjectsDir),
+    existsOnHost: (cwd, id) =>
+      fileExists(claudeHostSessionPath(cwd, id, hostProjectsDir)),
+    readHostSession: async (cwd, id) => {
+      const path = claudeHostSessionPath(cwd, id, hostProjectsDir);
+      if (!(await fileExists(path))) return undefined;
+      return readFile(path, "utf-8");
+    },
+    captureToHost: async ({ hostCwd, sandboxCwd, sessionId, handle }) => {
+      const sandboxPath = claudeSandboxSessionPath(
+        sandboxCwd,
+        sessionId,
+        sandboxProjectsDir,
+      );
+      const jsonl = await readSandboxFile(handle, sandboxPath, "claude-cap");
+      const rewritten = transferClaudeSession(jsonl, sandboxCwd, hostCwd);
+      const hostPath = claudeHostSessionPath(
+        hostCwd,
+        sessionId,
+        hostProjectsDir,
+      );
+      await mkdir(dirname(hostPath), { recursive: true });
+      await writeFile(hostPath, rewritten);
+    },
+    resumeIntoSandbox: async ({ hostCwd, sandboxCwd, sessionId, handle }) => {
+      const hostPath = claudeHostSessionPath(
+        hostCwd,
+        sessionId,
+        hostProjectsDir,
+      );
+      const jsonl = await readFile(hostPath, "utf-8");
+      const rewritten =
+        jsonl === "" ? "" : transferClaudeSession(jsonl, hostCwd, sandboxCwd);
+      const sandboxPath = claudeSandboxSessionPath(
+        sandboxCwd,
+        sessionId,
+        sandboxProjectsDir,
+      );
+      await writeSandboxFile(handle, sandboxPath, rewritten, "claude-res");
+    },
+    findByIdOnHost: (id) => findClaudeSessionOnHost(id, hostProjectsDir),
+  };
+};
+
+const makeCodexSessionStorage = (
+  options?: CodexOptions,
+): AgentSessionStorage => {
+  const hostSessionsDir = options?.sessionStorage?.hostSessionsDir;
+  const sandboxSessionsDir =
+    options?.sessionStorage?.sandboxSessionsDir ??
+    posix.join("/home/agent", ".codex", "sessions");
+
+  return {
+    hostSessionFilePath: () => undefined,
+    existsOnHost: async (_cwd, id) => {
+      const found = await findCodexSessionOnHost(id, hostSessionsDir);
+      return found.path !== undefined;
+    },
+    readHostSession: async (_cwd, id) => {
+      const found = await findCodexSessionOnHost(id, hostSessionsDir);
+      if (!found.path) return undefined;
+      return readFile(found.path, "utf-8");
+    },
+    captureToHost: async ({ hostCwd, sandboxCwd, sessionId, handle }) => {
+      const located = await locateCodexSandboxSession(
+        sessionId,
+        handle,
+        sandboxSessionsDir,
+      );
+      const jsonl = await readSandboxFile(handle, located.path, "codex-cap");
+      const rewritten = transferCodexSession(jsonl, sandboxCwd, hostCwd);
+      const root =
+        hostSessionsDir ?? join(process.env.HOME ?? "~", ".codex", "sessions");
+      const target = join(root, located.relativePath);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, rewritten);
+    },
+    resumeIntoSandbox: async ({ hostCwd, sandboxCwd, sessionId, handle }) => {
+      const located = await locateCodexHostSession(sessionId, hostSessionsDir);
+      const jsonl = await readFile(located.path, "utf-8");
+      const rewritten = transferCodexSession(jsonl, hostCwd, sandboxCwd);
+      const target = posix.join(sandboxSessionsDir, located.relativePath);
+      await writeSandboxFile(handle, target, rewritten, "codex-res");
+    },
+    findByIdOnHost: (id) => findCodexSessionOnHost(id, hostSessionsDir),
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Pi agent provider
@@ -432,26 +601,7 @@ export const codex = (
   name: "codex",
   env: options?.env ?? {},
   captureSessions: options?.captureSessions ?? true,
-  sessionStorage: {
-    hostStore: (cwd) =>
-      codexHostSessionStore(cwd, options?.sessionStorage?.hostSessionsDir),
-    sandboxStore: (cwd, handle) =>
-      codexSandboxSessionStore(
-        cwd,
-        handle,
-        options?.sessionStorage?.sandboxSessionsDir,
-      ),
-    // Both stores above are LocatableSessionStore by construction; the
-    // AgentSessionStorage seam types them as the narrower SessionStore.
-    transfer: (from, to, id) =>
-      transferCodexSession(
-        from as LocatableSessionStore,
-        to as LocatableSessionStore,
-        id,
-      ),
-    findByIdOnHost: (id) =>
-      findCodexSessionOnHost(id, options?.sessionStorage?.hostSessionsDir),
-  },
+  sessionStorage: makeCodexSessionStorage(options),
 
   buildPrintCommand({
     prompt,
@@ -826,20 +976,7 @@ export const claudeCode = (
   name: "claude-code",
   env: options?.env ?? {},
   captureSessions: options?.captureSessions ?? true,
-  sessionStorage: {
-    hostStore: (cwd) =>
-      hostSessionStore(cwd, options?.sessionStorage?.hostProjectsDir),
-    sandboxStore: (cwd, handle) =>
-      sandboxSessionStore(
-        cwd,
-        handle,
-        options?.sessionStorage?.sandboxProjectsDir ??
-          "/home/agent/.claude/projects",
-      ),
-    transfer: transferClaudeSession,
-    findByIdOnHost: (id) =>
-      findClaudeSessionOnHost(id, options?.sessionStorage?.hostProjectsDir),
-  },
+  sessionStorage: makeClaudeSessionStorage(options),
 
   buildPrintCommand({
     prompt,

--- a/src/AgentStreamEmitter.ts
+++ b/src/AgentStreamEmitter.ts
@@ -31,25 +31,27 @@ export class AgentStreamEmitter extends Context.Tag("AgentStreamEmitter")<
   AgentStreamEmitterService
 >() {}
 
-export const noopAgentStreamEmitterLayer: Layer.Layer<AgentStreamEmitter> =
-  Layer.succeed(AgentStreamEmitter, { emit: () => Effect.void });
-
 /**
- * Build a layer that forwards each event to the provided callback.
+ * Build a layer for the AgentStreamEmitter service.
+ *
+ * Called with no argument, returns a no-op layer that discards events.
+ * Called with a callback, returns a layer that forwards each event to it.
  * The callback is invoked synchronously inside an `Effect.sync`; any error
  * thrown by the callback is caught and discarded so observability failures
  * cannot kill the run.
  */
-export const callbackAgentStreamEmitterLayer = (
-  onEvent: (event: AgentStreamEvent) => void,
+export const agentStreamEmitterLayer = (
+  onEvent?: (event: AgentStreamEvent) => void,
 ): Layer.Layer<AgentStreamEmitter> =>
   Layer.succeed(AgentStreamEmitter, {
-    emit: (event) =>
-      Effect.sync(() => {
-        try {
-          onEvent(event);
-        } catch {
-          // Swallow callback errors — a broken forwarder must not kill the run.
-        }
-      }),
+    emit: onEvent
+      ? (event) =>
+          Effect.sync(() => {
+            try {
+              onEvent(event);
+            } catch {
+              // Swallow callback errors — a broken forwarder must not kill the run.
+            }
+          })
+      : () => Effect.void,
   });

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -34,9 +34,9 @@ import {
   agentStreamEmitterLayer,
   type AgentStreamEvent,
 } from "./AgentStreamEmitter.js";
+import type { BindMountSandboxHandle } from "./SandboxProvider.js";
 
 const noopAgentStreamEmitterLayer = agentStreamEmitterLayer();
-import type { BindMountSandboxHandle } from "./SandboxProvider.js";
 
 const execAsync = promisify(exec);
 

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -15,7 +15,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { Display, type DisplayEntry, SilentDisplay } from "./Display.js";
-import { makeLocalSandboxLayer } from "./testSandbox.js";
+import { makeLocalSandbox } from "./testSandbox.js";
 import { orchestrate } from "./Orchestrator.js";
 import { substitutePromptArgs } from "./PromptArgumentSubstitution.js";
 import {
@@ -25,7 +25,7 @@ import {
   pi as piFactory,
   DEFAULT_MODEL,
 } from "./AgentProvider.js";
-import { Sandbox } from "./SandboxFactory.js";
+import type { SandboxService } from "./SandboxFactory.js";
 import type { DockerError, SandboxError } from "./errors.js";
 import { AgentError, AgentIdleTimeoutError } from "./errors.js";
 import { SandboxFactory } from "./SandboxFactory.js";
@@ -104,10 +104,10 @@ const toStreamJson = (output: string, sessionId?: string): string => {
  */
 const makeTestSandboxFactory = (
   hostRepoDir: string,
-  buildLayer: (sandboxDir: string) => Layer.Layer<Sandbox>,
+  buildSandbox: (sandboxDir: string) => SandboxService,
 ): { factoryLayer: Layer.Layer<SandboxFactory>; sandboxRepoDir: string } => {
   const sandboxBaseDir = join(tmpdir(), `orch-factory-${randomUUID()}`);
-  const sandboxRepoDir = sandboxBaseDir; // The worktree IS the sandbox
+  const sandboxRepoDir = sandboxBaseDir;
 
   let branchCounter = 0;
 
@@ -115,14 +115,14 @@ const makeTestSandboxFactory = (
     withSandbox: <A, E, R>(
       makeEffect: (
         info: import("./SandboxFactory.js").SandboxInfo,
-      ) => Effect.Effect<A, E, R | Sandbox>,
+        sandbox: SandboxService,
+      ) => Effect.Effect<A, E, R>,
     ): Effect.Effect<
       import("./SandboxFactory.js").WithSandboxResult<A>,
       E | DockerError,
-      Exclude<R, Sandbox>
+      R
     > =>
       Effect.acquireUseRelease(
-        // Acquire: create fresh worktree from host repo
         Effect.promise(async () => {
           await rm(sandboxBaseDir, { recursive: true, force: true });
           const branchName = `sandcastle/test-${++branchCounter}`;
@@ -132,18 +132,15 @@ const makeTestSandboxFactory = (
           );
           return branchName;
         }),
-        // Use: provide sandbox layer and run effect
         (_branchName) =>
-          makeEffect({
-            hostWorktreePath: sandboxBaseDir,
-            sandboxRepoPath: sandboxBaseDir,
-            applyToHost: () => Effect.void,
-          }).pipe(Effect.provide(buildLayer(sandboxBaseDir))) as Effect.Effect<
-            A,
-            E | DockerError,
-            Exclude<R, Sandbox>
-          >,
-        // Release: remove the worktree (branch cleanup is handled by withSandboxLifecycle)
+          makeEffect(
+            {
+              hostWorktreePath: sandboxBaseDir,
+              sandboxRepoPath: sandboxBaseDir,
+              applyToHost: () => Effect.void,
+            },
+            buildSandbox(sandboxBaseDir),
+          ) as Effect.Effect<A, E | DockerError, R>,
         (_branchName) =>
           Effect.promise(async () => {
             try {
@@ -169,12 +166,11 @@ const makeTestSandboxFactory = (
 const makeMockAgentLayer = (
   sandboxDir: string,
   mockAgentBehavior: (sandboxRepoDir: string) => Promise<string>,
-): Layer.Layer<Sandbox> => {
-  const fsLayer = makeLocalSandboxLayer(sandboxDir);
+): SandboxService => {
+  const real = makeLocalSandbox(sandboxDir);
 
-  return Layer.succeed(Sandbox, {
+  return {
     exec: (command, options) => {
-      // Intercept claude invocations
       if (command.startsWith("claude ")) {
         if (options?.onLine) {
           const onLine = options.onLine;
@@ -182,7 +178,6 @@ const makeMockAgentLayer = (
             const cwd = options?.cwd ?? sandboxDir;
             const output = yield* Effect.promise(() => mockAgentBehavior(cwd));
             const streamOutput = toStreamJson(output);
-            // Emit each line to the callback
             for (const line of streamOutput.split("\n")) {
               onLine(line);
             }
@@ -195,20 +190,11 @@ const makeMockAgentLayer = (
           return { stdout: output, stderr: "", exitCode: 0 };
         });
       }
-      // Pass through to real filesystem sandbox
-      return Effect.flatMap(Sandbox, (real) =>
-        real.exec(command, options),
-      ).pipe(Effect.provide(fsLayer));
+      return real.exec(command, options);
     },
-    copyIn: (hostPath, sandboxPath) =>
-      Effect.flatMap(Sandbox, (real) =>
-        real.copyIn(hostPath, sandboxPath),
-      ).pipe(Effect.provide(fsLayer)),
-    copyFileOut: (sandboxPath, hostPath) =>
-      Effect.flatMap(Sandbox, (real) =>
-        real.copyFileOut(sandboxPath, hostPath),
-      ).pipe(Effect.provide(fsLayer)),
-  });
+    copyIn: real.copyIn,
+    copyFileOut: real.copyFileOut,
+  };
 };
 
 describe("Orchestrator", () => {
@@ -741,11 +727,12 @@ describe("OrchestrateResult", () => {
       withSandbox: <A, E, R>(
         makeEffect: (
           info: import("./SandboxFactory.js").SandboxInfo,
-        ) => Effect.Effect<A, E, R | Sandbox>,
+          sandbox: SandboxService,
+        ) => Effect.Effect<A, E, R>,
       ): Effect.Effect<
         import("./SandboxFactory.js").WithSandboxResult<A>,
         E | DockerError,
-        Exclude<R, Sandbox>
+        R
       > =>
         Effect.acquireUseRelease(
           Effect.promise(async () => {
@@ -758,39 +745,38 @@ describe("OrchestrateResult", () => {
             return branchName;
           }),
           (_branchName) =>
-            makeEffect({
-              hostWorktreePath: sandboxBaseDir,
-              sandboxRepoPath: sandboxBaseDir,
-              applyToHost: () => Effect.void,
-            }).pipe(
-              Effect.provide(
-                makeMockAgentLayer(sandboxBaseDir, async (repoDir) => {
-                  // Make a commit
-                  await writeFile(
-                    join(repoDir, "committed.txt"),
-                    "committed content",
-                  );
-                  await execAsync("git add -A", { cwd: repoDir });
-                  await execAsync('git config user.email "agent@test.com"', {
-                    cwd: repoDir,
-                  });
-                  await execAsync('git config user.name "Agent"', {
-                    cwd: repoDir,
-                  });
-                  await execAsync('git commit -m "agent commit"', {
-                    cwd: repoDir,
-                  });
+            makeEffect(
+              {
+                hostWorktreePath: sandboxBaseDir,
+                sandboxRepoPath: sandboxBaseDir,
+                applyToHost: () => Effect.void,
+              },
+              makeMockAgentLayer(sandboxBaseDir, async (repoDir) => {
+                // Make a commit
+                await writeFile(
+                  join(repoDir, "committed.txt"),
+                  "committed content",
+                );
+                await execAsync("git add -A", { cwd: repoDir });
+                await execAsync('git config user.email "agent@test.com"', {
+                  cwd: repoDir,
+                });
+                await execAsync('git config user.name "Agent"', {
+                  cwd: repoDir,
+                });
+                await execAsync('git commit -m "agent commit"', {
+                  cwd: repoDir,
+                });
 
-                  // Leave uncommitted changes
-                  await writeFile(
-                    join(repoDir, "uncommitted.txt"),
-                    "uncommitted content",
-                  );
+                // Leave uncommitted changes
+                await writeFile(
+                  join(repoDir, "uncommitted.txt"),
+                  "uncommitted content",
+                );
 
-                  return "Done.";
-                }),
-              ),
-            ) as Effect.Effect<A, E | DockerError, Exclude<R, Sandbox>>,
+                return "Done.";
+              }),
+            ) as Effect.Effect<A, E | DockerError, R>,
           (_branchName) =>
             Effect.promise(async () => {
               try {
@@ -1055,8 +1041,8 @@ describe("Orchestrator tool call display integration", () => {
     );
 
     const mockLayer = makeTestSandboxFactory(hostDir, (dir) => {
-      const fsLayer = makeLocalSandboxLayer(dir);
-      return Layer.succeed(Sandbox, {
+      const real = makeLocalSandbox(dir);
+      return {
         exec: (command, options) => {
           if (command.startsWith("claude ") && options?.onLine) {
             const onLine = options.onLine;
@@ -1097,19 +1083,12 @@ describe("Orchestrator tool call display integration", () => {
               exitCode: 0,
             });
           }
-          return Effect.flatMap(Sandbox, (real) =>
-            real.exec(command, options),
-          ).pipe(Effect.provide(fsLayer));
+          return real.exec(command, options);
         },
-        copyIn: (hostPath, sandboxPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyIn(hostPath, sandboxPath),
-          ).pipe(Effect.provide(fsLayer)),
+        copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
         copyFileOut: (sandboxPath, hostPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyFileOut(sandboxPath, hostPath),
-          ).pipe(Effect.provide(fsLayer)),
-      });
+          real.copyFileOut(sandboxPath, hostPath),
+      };
     });
 
     await Effect.runPromise(
@@ -1165,8 +1144,8 @@ describe("Orchestrator agent stream emitter", () => {
     });
 
     const mockLayer = makeTestSandboxFactory(hostDir, (dir) => {
-      const fsLayer = makeLocalSandboxLayer(dir);
-      return Layer.succeed(Sandbox, {
+      const real = makeLocalSandbox(dir);
+      return {
         exec: (command, options) => {
           if (command.startsWith("claude ") && options?.onLine) {
             const onLine = options.onLine;
@@ -1196,19 +1175,12 @@ describe("Orchestrator agent stream emitter", () => {
               exitCode: 0,
             });
           }
-          return Effect.flatMap(Sandbox, (real) =>
-            real.exec(command, options),
-          ).pipe(Effect.provide(fsLayer));
+          return real.exec(command, options);
         },
-        copyIn: (hostPath, sandboxPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyIn(hostPath, sandboxPath),
-          ).pipe(Effect.provide(fsLayer)),
+        copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
         copyFileOut: (sandboxPath, hostPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyFileOut(sandboxPath, hostPath),
-          ).pipe(Effect.provide(fsLayer)),
-      });
+          real.copyFileOut(sandboxPath, hostPath),
+      };
     });
 
     await Effect.runPromise(
@@ -1255,8 +1227,8 @@ describe("Orchestrator agent stream emitter", () => {
     });
 
     const mockLayer = makeTestSandboxFactory(hostDir, (dir) => {
-      const fsLayer = makeLocalSandboxLayer(dir);
-      return Layer.succeed(Sandbox, {
+      const real = makeLocalSandbox(dir);
+      return {
         exec: (command, options) => {
           if (command.startsWith("claude ") && options?.onLine) {
             const onLine = options.onLine;
@@ -1279,19 +1251,12 @@ describe("Orchestrator agent stream emitter", () => {
               exitCode: 0,
             });
           }
-          return Effect.flatMap(Sandbox, (real) =>
-            real.exec(command, options),
-          ).pipe(Effect.provide(fsLayer));
+          return real.exec(command, options);
         },
-        copyIn: (hostPath, sandboxPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyIn(hostPath, sandboxPath),
-          ).pipe(Effect.provide(fsLayer)),
+        copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
         copyFileOut: (sandboxPath, hostPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyFileOut(sandboxPath, hostPath),
-          ).pipe(Effect.provide(fsLayer)),
-      });
+          real.copyFileOut(sandboxPath, hostPath),
+      };
     });
 
     const result = await Effect.runPromise(
@@ -1322,8 +1287,8 @@ describe("Orchestrator error handling", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               return Effect.succeed({
@@ -1332,19 +1297,12 @@ describe("Orchestrator error handling", () => {
                 exitCode: 1,
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -1373,8 +1331,8 @@ describe("Orchestrator error handling", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               const onLine = options.onLine;
@@ -1390,19 +1348,12 @@ describe("Orchestrator error handling", () => {
                 exitCode: 0,
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -1434,8 +1385,8 @@ describe("Orchestrator error handling", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               const onLine = options.onLine;
@@ -1470,19 +1421,12 @@ describe("Orchestrator error handling", () => {
                 exitCode: 1,
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -1535,8 +1479,8 @@ describe("Orchestrator error handling", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command === "git rev-parse --abbrev-ref HEAD") {
               return Effect.succeed({
@@ -1545,19 +1489,12 @@ describe("Orchestrator error handling", () => {
                 exitCode: 128,
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -1586,8 +1523,8 @@ describe("Orchestrator error handling", () => {
       "Setting up environment...\nLoading model...\nError: API key is invalid\nPlease check your credentials";
 
     const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
-      const fsLayer = makeLocalSandboxLayer(dir);
-      return Layer.succeed(Sandbox, {
+      const real = makeLocalSandbox(dir);
+      return {
         exec: (command, options) => {
           if (command.startsWith("opencode ")) {
             return Effect.succeed({
@@ -1596,19 +1533,12 @@ describe("Orchestrator error handling", () => {
               exitCode: 1,
             });
           }
-          return Effect.flatMap(Sandbox, (real) =>
-            real.exec(command, options),
-          ).pipe(Effect.provide(fsLayer));
+          return real.exec(command, options);
         },
-        copyIn: (hostPath, sandboxPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyIn(hostPath, sandboxPath),
-          ).pipe(Effect.provide(fsLayer)),
+        copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
         copyFileOut: (sandboxPath, hostPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyFileOut(sandboxPath, hostPath),
-          ).pipe(Effect.provide(fsLayer)),
-      });
+          real.copyFileOut(sandboxPath, hostPath),
+      };
     });
 
     const exit = await Effect.runPromiseExit(
@@ -1644,8 +1574,8 @@ describe("Orchestrator error handling", () => {
     });
 
     const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
-      const fsLayer = makeLocalSandboxLayer(dir);
-      return Layer.succeed(Sandbox, {
+      const real = makeLocalSandbox(dir);
+      return {
         exec: (command, options) => {
           if (command.startsWith("claude ") && options?.onLine) {
             options.onLine(errorLine);
@@ -1655,19 +1585,12 @@ describe("Orchestrator error handling", () => {
               exitCode: 1,
             });
           }
-          return Effect.flatMap(Sandbox, (real) =>
-            real.exec(command, options),
-          ).pipe(Effect.provide(fsLayer));
+          return real.exec(command, options);
         },
-        copyIn: (hostPath, sandboxPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyIn(hostPath, sandboxPath),
-          ).pipe(Effect.provide(fsLayer)),
+        copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
         copyFileOut: (sandboxPath, hostPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyFileOut(sandboxPath, hostPath),
-          ).pipe(Effect.provide(fsLayer)),
-      });
+          real.copyFileOut(sandboxPath, hostPath),
+      };
     });
 
     const exit = await Effect.runPromiseExit(
@@ -1701,8 +1624,8 @@ describe("Orchestrator error handling", () => {
     const opencodeProvider = opencodeFactory("test-model");
 
     const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
-      const fsLayer = makeLocalSandboxLayer(dir);
-      return Layer.succeed(Sandbox, {
+      const real = makeLocalSandbox(dir);
+      return {
         exec: (command, options) => {
           if (command.startsWith("opencode ")) {
             return Effect.succeed({
@@ -1711,19 +1634,12 @@ describe("Orchestrator error handling", () => {
               exitCode: 1,
             });
           }
-          return Effect.flatMap(Sandbox, (real) =>
-            real.exec(command, options),
-          ).pipe(Effect.provide(fsLayer));
+          return real.exec(command, options);
         },
-        copyIn: (hostPath, sandboxPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyIn(hostPath, sandboxPath),
-          ).pipe(Effect.provide(fsLayer)),
+        copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
         copyFileOut: (sandboxPath, hostPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyFileOut(sandboxPath, hostPath),
-          ).pipe(Effect.provide(fsLayer)),
-      });
+          real.copyFileOut(sandboxPath, hostPath),
+      };
     });
 
     const exit = await Effect.runPromiseExit(
@@ -1760,8 +1676,8 @@ describe("Orchestrator streaming", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               const onLine = options.onLine;
@@ -1777,19 +1693,12 @@ describe("Orchestrator streaming", () => {
                 exitCode: 0,
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -1850,8 +1759,8 @@ describe("Orchestrator streaming", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               const onLine = options.onLine;
@@ -1867,19 +1776,12 @@ describe("Orchestrator streaming", () => {
                 exitCode: 0,
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -1907,8 +1809,8 @@ describe("Orchestrator streaming", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               const onLine = options.onLine;
@@ -1924,19 +1826,12 @@ describe("Orchestrator streaming", () => {
                 exitCode: 0,
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -1967,8 +1862,8 @@ describe("Orchestrator prompt preprocessing", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               const onLine = options.onLine;
@@ -1985,19 +1880,12 @@ describe("Orchestrator prompt preprocessing", () => {
                 exitCode: 0,
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -2036,8 +1924,8 @@ describe("Orchestrator prompt preprocessing", () => {
     const { factoryLayer: fl2, sandboxRepoDir: sr2 } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               const onLine = options.onLine;
@@ -2053,19 +1941,12 @@ describe("Orchestrator prompt preprocessing", () => {
                 exitCode: 0,
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -2090,8 +1971,8 @@ describe("Orchestrator prompt preprocessing", () => {
     let capturedStdin = "";
 
     const { factoryLayer } = makeTestSandboxFactory(hostDir, (dir) => {
-      const fsLayer = makeLocalSandboxLayer(dir);
-      return Layer.succeed(Sandbox, {
+      const real = makeLocalSandbox(dir);
+      return {
         exec: (command, options) => {
           if (command.startsWith("claude ") && options?.onLine) {
             const onLine = options.onLine;
@@ -2107,19 +1988,12 @@ describe("Orchestrator prompt preprocessing", () => {
               exitCode: 0,
             });
           }
-          return Effect.flatMap(Sandbox, (real) =>
-            real.exec(command, options),
-          ).pipe(Effect.provide(fsLayer));
+          return real.exec(command, options);
         },
-        copyIn: (hostPath, sandboxPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyIn(hostPath, sandboxPath),
-          ).pipe(Effect.provide(fsLayer)),
+        copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
         copyFileOut: (sandboxPath, hostPath) =>
-          Effect.flatMap(Sandbox, (real) =>
-            real.copyFileOut(sandboxPath, hostPath),
-          ).pipe(Effect.provide(fsLayer)),
-      });
+          real.copyFileOut(sandboxPath, hostPath),
+      };
     });
 
     const literalPrompt =
@@ -2421,8 +2295,8 @@ describe("Orchestrator Display integration", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               const onLine = options.onLine;
@@ -2447,19 +2321,12 @@ describe("Orchestrator Display integration", () => {
                 return { stdout: "", stderr: "", exitCode: 0 };
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -2495,8 +2362,8 @@ describe("Orchestrator Display integration", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               const onLine = options.onLine;
@@ -2514,19 +2381,12 @@ describe("Orchestrator Display integration", () => {
                 return { stdout: "", stderr: "", exitCode: 0 };
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -2559,8 +2419,8 @@ describe("Orchestrator Display integration", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               const onLine = options.onLine;
@@ -2573,19 +2433,12 @@ describe("Orchestrator Display integration", () => {
                 return { stdout: "", stderr: "", exitCode: 0 };
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -2640,8 +2493,8 @@ describe("Orchestrator Display integration", () => {
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
       (dir) => {
-        const fsLayer = makeLocalSandboxLayer(dir);
-        return Layer.succeed(Sandbox, {
+        const real = makeLocalSandbox(dir);
+        return {
           exec: (command, options) => {
             if (command.startsWith("claude ") && options?.onLine) {
               const onLine = options.onLine;
@@ -2667,19 +2520,12 @@ describe("Orchestrator Display integration", () => {
                 return { stdout: "", stderr: "", exitCode: 0 };
               });
             }
-            return Effect.flatMap(Sandbox, (real) =>
-              real.exec(command, options),
-            ).pipe(Effect.provide(fsLayer));
+            return real.exec(command, options);
           },
-          copyIn: (hostPath, sandboxPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyIn(hostPath, sandboxPath),
-            ).pipe(Effect.provide(fsLayer)),
+          copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
           copyFileOut: (sandboxPath, hostPath) =>
-            Effect.flatMap(Sandbox, (real) =>
-              real.copyFileOut(sandboxPath, hostPath),
-            ).pipe(Effect.provide(fsLayer)),
-        });
+            real.copyFileOut(sandboxPath, hostPath),
+        };
       },
     );
 
@@ -2759,10 +2605,10 @@ const toPiStreamJson = (output: string): string => {
 const makeMockPiAgentLayer = (
   sandboxDir: string,
   mockAgentBehavior: (sandboxRepoDir: string) => Promise<string>,
-): Layer.Layer<Sandbox> => {
-  const fsLayer = makeLocalSandboxLayer(sandboxDir);
+): SandboxService => {
+  const real = makeLocalSandbox(sandboxDir);
 
-  return Layer.succeed(Sandbox, {
+  return {
     exec: (command, options) => {
       if (command.startsWith("pi ")) {
         if (options?.onLine) {
@@ -2783,19 +2629,12 @@ const makeMockPiAgentLayer = (
           return { stdout: output, stderr: "", exitCode: 0 };
         });
       }
-      return Effect.flatMap(Sandbox, (real) =>
-        real.exec(command, options),
-      ).pipe(Effect.provide(fsLayer));
+      return real.exec(command, options);
     },
-    copyIn: (hostPath, sandboxPath) =>
-      Effect.flatMap(Sandbox, (real) =>
-        real.copyIn(hostPath, sandboxPath),
-      ).pipe(Effect.provide(fsLayer)),
+    copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
     copyFileOut: (sandboxPath, hostPath) =>
-      Effect.flatMap(Sandbox, (real) =>
-        real.copyFileOut(sandboxPath, hostPath),
-      ).pipe(Effect.provide(fsLayer)),
-  });
+      real.copyFileOut(sandboxPath, hostPath),
+  };
 };
 
 describe("Orchestrator with pi provider", () => {
@@ -2910,8 +2749,8 @@ describe("Orchestrator with pi provider", () => {
       noopAgentStreamEmitterLayer,
     );
 
-    const fsLayer = makeLocalSandboxLayer(hostDir);
-    const mockLayer = Layer.succeed(Sandbox, {
+    const real = makeLocalSandbox(hostDir);
+    const mockSandbox: SandboxService = {
       exec: (command, options) => {
         if (command.startsWith("pi ") && options?.onLine) {
           const onLine = options.onLine;
@@ -2922,23 +2761,16 @@ describe("Orchestrator with pi provider", () => {
             return { stdout: streamLines.join("\n"), stderr: "", exitCode: 0 };
           });
         }
-        return Effect.flatMap(Sandbox, (real) =>
-          real.exec(command, options),
-        ).pipe(Effect.provide(fsLayer));
+        return real.exec(command, options);
       },
-      copyIn: (hostPath, sandboxPath) =>
-        Effect.flatMap(Sandbox, (real) =>
-          real.copyIn(hostPath, sandboxPath),
-        ).pipe(Effect.provide(fsLayer)),
+      copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
       copyFileOut: (sandboxPath, hostPath) =>
-        Effect.flatMap(Sandbox, (real) =>
-          real.copyFileOut(sandboxPath, hostPath),
-        ).pipe(Effect.provide(fsLayer)),
-    });
+        real.copyFileOut(sandboxPath, hostPath),
+    };
 
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
-      () => mockLayer,
+      () => mockSandbox,
     );
 
     await Effect.runPromise(
@@ -2997,8 +2829,8 @@ describe("Orchestrator with pi provider", () => {
       noopAgentStreamEmitterLayer,
     );
 
-    const fsLayer = makeLocalSandboxLayer(hostDir);
-    const mockLayer = Layer.succeed(Sandbox, {
+    const real = makeLocalSandbox(hostDir);
+    const mockSandbox: SandboxService = {
       exec: (command, options) => {
         if (command.startsWith("pi ") && options?.onLine) {
           const onLine = options.onLine;
@@ -3009,23 +2841,16 @@ describe("Orchestrator with pi provider", () => {
             return { stdout: streamLines.join("\n"), stderr: "", exitCode: 0 };
           });
         }
-        return Effect.flatMap(Sandbox, (real) =>
-          real.exec(command, options),
-        ).pipe(Effect.provide(fsLayer));
+        return real.exec(command, options);
       },
-      copyIn: (hostPath, sandboxPath) =>
-        Effect.flatMap(Sandbox, (real) =>
-          real.copyIn(hostPath, sandboxPath),
-        ).pipe(Effect.provide(fsLayer)),
+      copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
       copyFileOut: (sandboxPath, hostPath) =>
-        Effect.flatMap(Sandbox, (real) =>
-          real.copyFileOut(sandboxPath, hostPath),
-        ).pipe(Effect.provide(fsLayer)),
-    });
+        real.copyFileOut(sandboxPath, hostPath),
+    };
 
     const { factoryLayer, sandboxRepoDir } = makeTestSandboxFactory(
       hostDir,
-      () => mockLayer,
+      () => mockSandbox,
     );
 
     await Effect.runPromise(
@@ -3095,10 +2920,10 @@ const makeMockCodexAgentLayer = (
     cached_input_tokens: number;
     output_tokens: number;
   },
-): Layer.Layer<Sandbox> => {
-  const fsLayer = makeLocalSandboxLayer(sandboxDir);
+): SandboxService => {
+  const real = makeLocalSandbox(sandboxDir);
 
-  return Layer.succeed(Sandbox, {
+  return {
     exec: (command, options) => {
       if (command.startsWith("codex ")) {
         if (options?.onLine) {
@@ -3119,19 +2944,12 @@ const makeMockCodexAgentLayer = (
           return { stdout: output, stderr: "", exitCode: 0 };
         });
       }
-      return Effect.flatMap(Sandbox, (real) =>
-        real.exec(command, options),
-      ).pipe(Effect.provide(fsLayer));
+      return real.exec(command, options);
     },
-    copyIn: (hostPath, sandboxPath) =>
-      Effect.flatMap(Sandbox, (real) =>
-        real.copyIn(hostPath, sandboxPath),
-      ).pipe(Effect.provide(fsLayer)),
+    copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
     copyFileOut: (sandboxPath, hostPath) =>
-      Effect.flatMap(Sandbox, (real) =>
-        real.copyFileOut(sandboxPath, hostPath),
-      ).pipe(Effect.provide(fsLayer)),
-  });
+      real.copyFileOut(sandboxPath, hostPath),
+  };
 };
 
 describe("Orchestrator with codex provider", () => {
@@ -3249,11 +3067,12 @@ describe("Session capture integration", () => {
       withSandbox: <A, E, R>(
         makeEffect: (
           info: import("./SandboxFactory.js").SandboxInfo,
-        ) => Effect.Effect<A, E, R | Sandbox>,
+          sandbox: SandboxService,
+        ) => Effect.Effect<A, E, R>,
       ): Effect.Effect<
         import("./SandboxFactory.js").WithSandboxResult<A>,
         E | DockerError,
-        Exclude<R, Sandbox>
+        R
       > =>
         Effect.acquireUseRelease(
           Effect.promise(async () => {
@@ -3281,9 +3100,9 @@ describe("Session capture integration", () => {
               close: async () => {},
             };
 
-            // Build a sandbox layer that intercepts claude commands
-            const fsLayer = makeLocalSandboxLayer(sandboxBaseDir);
-            const sandboxLayer = Layer.succeed(Sandbox, {
+            // Build a sandbox service that intercepts claude commands
+            const real = makeLocalSandbox(sandboxBaseDir);
+            const sandbox: SandboxService = {
               exec: (command, options) => {
                 if (command.startsWith("claude ") && options?.onLine) {
                   const onLine = options.onLine;
@@ -3299,30 +3118,23 @@ describe("Session capture integration", () => {
                     return { stdout: streamOutput, stderr: "", exitCode: 0 };
                   });
                 }
-                return Effect.flatMap(Sandbox, (real) =>
-                  real.exec(command, options),
-                ).pipe(Effect.provide(fsLayer));
+                return real.exec(command, options);
               },
               copyIn: (hostPath, sandboxPath) =>
-                Effect.flatMap(Sandbox, (real) =>
-                  real.copyIn(hostPath, sandboxPath),
-                ).pipe(Effect.provide(fsLayer)),
+                real.copyIn(hostPath, sandboxPath),
               copyFileOut: (sandboxPath, hostPath) =>
-                Effect.flatMap(Sandbox, (real) =>
-                  real.copyFileOut(sandboxPath, hostPath),
-                ).pipe(Effect.provide(fsLayer)),
-            });
+                real.copyFileOut(sandboxPath, hostPath),
+            };
 
-            return makeEffect({
-              hostWorktreePath: sandboxBaseDir,
-              sandboxRepoPath: sandboxBaseDir,
-              applyToHost: () => Effect.void,
-              bindMountHandle: handle,
-            }).pipe(Effect.provide(sandboxLayer)) as Effect.Effect<
-              A,
-              E | DockerError,
-              Exclude<R, Sandbox>
-            >;
+            return makeEffect(
+              {
+                hostWorktreePath: sandboxBaseDir,
+                sandboxRepoPath: sandboxBaseDir,
+                applyToHost: () => Effect.void,
+                bindMountHandle: handle,
+              },
+              sandbox,
+            ) as Effect.Effect<A, E | DockerError, R>;
           },
           (_branchName) =>
             Effect.promise(async () => {

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -31,10 +31,11 @@ import { AgentError, AgentIdleTimeoutError } from "./errors.js";
 import { SandboxFactory } from "./SandboxFactory.js";
 import { encodeProjectPath } from "./SessionStore.js";
 import {
-  callbackAgentStreamEmitterLayer,
-  noopAgentStreamEmitterLayer,
+  agentStreamEmitterLayer,
   type AgentStreamEvent,
 } from "./AgentStreamEmitter.js";
+
+const noopAgentStreamEmitterLayer = agentStreamEmitterLayer();
 import type { BindMountSandboxHandle } from "./SandboxProvider.js";
 
 const execAsync = promisify(exec);
@@ -1159,7 +1160,7 @@ describe("Orchestrator agent stream emitter", () => {
     const displayLayer = SilentDisplay.layer(ref);
 
     const events: AgentStreamEvent[] = [];
-    const emitterLayer = callbackAgentStreamEmitterLayer((e) => {
+    const emitterLayer = agentStreamEmitterLayer((e) => {
       events.push(e);
     });
 
@@ -1249,7 +1250,7 @@ describe("Orchestrator agent stream emitter", () => {
     const ref = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]);
     const displayLayer = SilentDisplay.layer(ref);
 
-    const emitterLayer = callbackAgentStreamEmitterLayer(() => {
+    const emitterLayer = agentStreamEmitterLayer(() => {
       throw new Error("callback intentionally broken");
     });
 

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -3235,7 +3235,7 @@ describe("Session capture integration", () => {
   /**
    * Create a test factory that provides a bindMountHandle with copyFileIn/copyFileOut
    * backed by the filesystem. This allows session capture to work through the
-   * sandboxSessionStore → transferClaudeSession → hostSessionStore path.
+   * sessionStorage.captureToHost / resumeIntoSandbox path.
    */
   const makeSessionCaptureFactory = (
     hostRepoDir: string,

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -263,7 +263,10 @@ export const orchestrate = (
       yield* display.status(label(`Iteration ${i}/${iterations}`), "info");
 
       const sandboxResult = yield* factory.withSandbox(
-        ({ hostWorktreePath, sandboxRepoPath, applyToHost, bindMountHandle }) =>
+        (
+          { hostWorktreePath, sandboxRepoPath, applyToHost, bindMountHandle },
+          sandbox,
+        ) =>
           withSandboxLifecycle(
             {
               hostRepoDir,
@@ -275,6 +278,7 @@ export const orchestrate = (
               signal: options.signal,
               timeouts: options.timeouts,
             },
+            sandbox,
             (ctx) =>
               Effect.gen(function* () {
                 // Resume session: transfer JSONL from host to sandbox before iteration 1

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -286,18 +286,14 @@ export const orchestrate = (
                   provider.sessionStorage
                 ) {
                   yield* display.status(label("Resuming session"), "info");
-                  const sbStore = provider.sessionStorage.sandboxStore(
-                    ctx.sandboxRepoDir,
-                    bindMountHandle,
-                  );
-                  const hStore = provider.sessionStorage.hostStore(hostRepoDir);
                   yield* Effect.tryPromise({
                     try: () =>
-                      provider.sessionStorage!.transfer(
-                        hStore,
-                        sbStore,
-                        iterationResumeSession,
-                      ),
+                      provider.sessionStorage!.resumeIntoSandbox({
+                        hostCwd: hostRepoDir,
+                        sandboxCwd: ctx.sandboxRepoDir,
+                        sessionId: iterationResumeSession,
+                        handle: bindMountHandle,
+                      }),
                     catch: (e) =>
                       new SessionCaptureError({
                         message: `Session resume failed: ${e instanceof Error ? e.message : String(e)}`,
@@ -389,31 +385,30 @@ export const orchestrate = (
                   bindMountHandle
                 ) {
                   yield* display.status(label("Capturing session"), "info");
-                  const sbStore = provider.sessionStorage.sandboxStore(
-                    ctx.sandboxRepoDir,
-                    bindMountHandle,
-                  );
-                  const hStore = provider.sessionStorage.hostStore(hostRepoDir);
                   yield* Effect.tryPromise({
                     try: () =>
-                      provider.sessionStorage!.transfer(
-                        sbStore,
-                        hStore,
+                      provider.sessionStorage!.captureToHost({
+                        hostCwd: hostRepoDir,
+                        sandboxCwd: ctx.sandboxRepoDir,
                         sessionId,
-                      ),
+                        handle: bindMountHandle,
+                      }),
                     catch: (e) =>
                       new SessionCaptureError({
                         message: `Session capture failed: ${e instanceof Error ? e.message : String(e)}`,
                         sessionId,
                       }),
                   });
-                  sessionFilePath = hStore.sessionFilePath(sessionId);
+                  sessionFilePath = provider.sessionStorage.hostSessionFilePath(
+                    hostRepoDir,
+                    sessionId,
+                  );
 
                   // Parse token usage from the captured session JSONL
                   if (provider.parseSessionUsage) {
                     const content = yield* Effect.promise(() =>
-                      hStore
-                        .readSession(sessionId)
+                      provider
+                        .sessionStorage!.readHostSession(hostRepoDir, sessionId)
                         .catch(() => undefined as string | undefined),
                     );
                     if (content) {

--- a/src/PromptPreprocessor.test.ts
+++ b/src/PromptPreprocessor.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { type DisplayEntry, SilentDisplay } from "./Display.js";
+import { Display, type DisplayEntry, SilentDisplay } from "./Display.js";
 import { preprocessPrompt } from "./PromptPreprocessor.js";
 import { substitutePromptArgs } from "./PromptArgumentSubstitution.js";
 import type { SandboxService } from "./SandboxFactory.js";
@@ -24,13 +24,11 @@ describe("PromptPreprocessor", () => {
   const run = async (
     prompt: string,
     sandbox: SandboxService,
-    displayLayer: Layer.Layer<import("./Display.js").Display, never, never>,
+    displayLayer: Layer.Layer<Display>,
     cwd: string,
   ) => {
     const marked = await Effect.runPromise(
-      substitutePromptArgs(prompt, {}).pipe(
-        Effect.provide(displayLayer),
-      ) as Effect.Effect<string, unknown, never>,
+      substitutePromptArgs(prompt, {}).pipe(Effect.provide(displayLayer)),
     );
     return Effect.runPromise(
       preprocessPrompt(marked, sandbox, cwd).pipe(Effect.provide(displayLayer)),
@@ -63,7 +61,7 @@ describe("PromptPreprocessor", () => {
     const marked = await Effect.runPromise(
       substitutePromptArgs("Output: !`exit 1`", {}).pipe(
         Effect.provide(displayLayer),
-      ) as Effect.Effect<string, unknown, never>,
+      ),
     );
     const result = await Effect.runPromise(
       preprocessPrompt(marked, sandbox, sandboxDir).pipe(
@@ -72,9 +70,9 @@ describe("PromptPreprocessor", () => {
       ),
     );
     expect(result).toBeInstanceOf(PromptError);
-    expect((result as PromptError)._tag).toBe("PromptError");
-    expect((result as PromptError).message).toContain("exit 1");
-    expect((result as PromptError).message).toContain("exited with code 1");
+    expect(result._tag).toBe("PromptError");
+    expect(result.message).toContain("exit 1");
+    expect(result.message).toContain("exited with code 1");
   });
 
   it("runs commands with the provided cwd", async () => {
@@ -116,11 +114,7 @@ describe("PromptPreprocessor", () => {
       substitutePromptArgs(
         "First: !`echo hello`\nSecond: !`echo world`",
         {},
-      ).pipe(Effect.provide(displayLayer)) as Effect.Effect<
-        string,
-        unknown,
-        never
-      >,
+      ).pipe(Effect.provide(displayLayer)),
     );
     const result = await Effect.runPromise(
       preprocessPrompt(marked, spySandbox, sandboxDir).pipe(
@@ -162,7 +156,7 @@ describe("PromptPreprocessor", () => {
     const substituted = await Effect.runPromise(
       substitutePromptArgs(rawTemplate, { NAME: "world" }).pipe(
         Effect.provide(displayLayer),
-      ) as Effect.Effect<string, unknown, never>,
+      ),
     );
     const result = await Effect.runPromise(
       preprocessPrompt(substituted, sandbox, sandboxDir).pipe(
@@ -178,11 +172,7 @@ describe("PromptPreprocessor", () => {
     const substituted = await Effect.runPromise(
       substitutePromptArgs(rawTemplate, {
         TITLE: "fixes !`rm -rf /` (do not run)",
-      }).pipe(Effect.provide(displayLayer)) as Effect.Effect<
-        string,
-        unknown,
-        never
-      >,
+      }).pipe(Effect.provide(displayLayer)),
     );
     const result = await Effect.runPromise(
       preprocessPrompt(substituted, sandbox, sandboxDir).pipe(
@@ -198,11 +188,7 @@ describe("PromptPreprocessor", () => {
     const substituted = await Effect.runPromise(
       substitutePromptArgs(rawTemplate, {
         DATA: "!\x01`rm -rf /`",
-      }).pipe(Effect.provide(displayLayer)) as Effect.Effect<
-        string,
-        unknown,
-        never
-      >,
+      }).pipe(Effect.provide(displayLayer)),
     );
     const result = await Effect.runPromise(
       preprocessPrompt(substituted, sandbox, sandboxDir).pipe(

--- a/src/PromptPreprocessor.test.ts
+++ b/src/PromptPreprocessor.test.ts
@@ -6,93 +6,92 @@ import { describe, expect, it } from "vitest";
 import { type DisplayEntry, SilentDisplay } from "./Display.js";
 import { preprocessPrompt } from "./PromptPreprocessor.js";
 import { substitutePromptArgs } from "./PromptArgumentSubstitution.js";
-import { Sandbox } from "./SandboxFactory.js";
-import { makeLocalSandboxLayer } from "./testSandbox.js";
+import type { SandboxService } from "./SandboxFactory.js";
+import { makeLocalSandbox } from "./testSandbox.js";
 import { PromptError } from "./errors.js";
 
 describe("PromptPreprocessor", () => {
   const setup = async () => {
     const sandboxDir = await mkdtemp(join(tmpdir(), "preprocess-test-"));
     const displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]);
-    const layer = Layer.merge(
-      makeLocalSandboxLayer(sandboxDir),
-      SilentDisplay.layer(displayRef),
-    );
-    return { sandboxDir, layer, displayRef };
+    const displayLayer = SilentDisplay.layer(displayRef);
+    const sandbox = makeLocalSandbox(sandboxDir);
+    return { sandboxDir, sandbox, displayLayer, displayRef };
   };
 
   // Mirrors production: raw template goes through substitutePromptArgs first
   // (which marks template-authored shell blocks), then through preprocessPrompt.
   const run = async (
     prompt: string,
-    layer: Awaited<ReturnType<typeof setup>>["layer"],
+    sandbox: SandboxService,
+    displayLayer: Layer.Layer<import("./Display.js").Display, never, never>,
     cwd: string,
   ) => {
     const marked = await Effect.runPromise(
-      substitutePromptArgs(prompt, {}).pipe(Effect.provide(layer)),
+      substitutePromptArgs(prompt, {}).pipe(
+        Effect.provide(displayLayer),
+      ) as Effect.Effect<string, unknown, never>,
     );
     return Effect.runPromise(
-      Sandbox.pipe(
-        Effect.flatMap((s) => preprocessPrompt(marked, s, cwd)),
-        Effect.provide(layer),
-      ),
+      preprocessPrompt(marked, sandbox, cwd).pipe(Effect.provide(displayLayer)),
     );
   };
 
   it("passes through prompts with no !`command` expressions unchanged", async () => {
-    const { sandboxDir, layer } = await setup();
+    const { sandboxDir, sandbox, displayLayer } = await setup();
     const prompt = "This is a plain prompt with no commands.\n\nJust text.";
-    const result = await run(prompt, layer, sandboxDir);
+    const result = await run(prompt, sandbox, displayLayer, sandboxDir);
     expect(result).toBe(prompt);
   });
 
   it("replaces a single !`command` with its stdout", async () => {
-    const { sandboxDir, layer } = await setup();
+    const { sandboxDir, sandbox, displayLayer } = await setup();
     const prompt = "Here is the date: !`echo 2026-03-24`";
-    const result = await run(prompt, layer, sandboxDir);
+    const result = await run(prompt, sandbox, displayLayer, sandboxDir);
     expect(result).toBe("Here is the date: 2026-03-24");
   });
 
   it("replaces multiple !`command` expressions", async () => {
-    const { sandboxDir, layer } = await setup();
+    const { sandboxDir, sandbox, displayLayer } = await setup();
     const prompt = "First: !`echo hello`\nSecond: !`echo world`";
-    const result = await run(prompt, layer, sandboxDir);
+    const result = await run(prompt, sandbox, displayLayer, sandboxDir);
     expect(result).toBe("First: hello\nSecond: world");
   });
 
   it("fails with PromptError on non-zero exit code", async () => {
-    const { sandboxDir, layer } = await setup();
+    const { sandboxDir, sandbox, displayLayer } = await setup();
     const marked = await Effect.runPromise(
-      substitutePromptArgs("Output: !`exit 1`", {}).pipe(Effect.provide(layer)),
+      substitutePromptArgs("Output: !`exit 1`", {}).pipe(
+        Effect.provide(displayLayer),
+      ) as Effect.Effect<string, unknown, never>,
     );
     const result = await Effect.runPromise(
-      Sandbox.pipe(
-        Effect.flatMap((s) => preprocessPrompt(marked, s, sandboxDir)),
+      preprocessPrompt(marked, sandbox, sandboxDir).pipe(
         Effect.flip,
-        Effect.provide(layer),
+        Effect.provide(displayLayer),
       ),
     );
     expect(result).toBeInstanceOf(PromptError);
-    expect(result._tag).toBe("PromptError");
-    expect(result.message).toContain("exit 1");
-    expect(result.message).toContain("exited with code 1");
+    expect((result as PromptError)._tag).toBe("PromptError");
+    expect((result as PromptError).message).toContain("exit 1");
+    expect((result as PromptError).message).toContain("exited with code 1");
   });
 
   it("runs commands with the provided cwd", async () => {
-    const { sandboxDir, layer } = await setup();
+    const { sandboxDir, sandbox, displayLayer } = await setup();
     const prompt = "Dir: !`pwd`";
-    const result = await run(prompt, layer, sandboxDir);
+    const result = await run(prompt, sandbox, displayLayer, sandboxDir);
     expect(result).toBe(`Dir: ${sandboxDir}`);
   });
 
   it("runs multiple shell expressions in parallel", async () => {
-    const { sandboxDir, layer } = await setup();
+    const { sandboxDir } = await setup();
 
     // Track start/end events to verify parallel execution
     const events: string[] = [];
 
-    const spySandboxLayer = Layer.succeed(Sandbox, {
-      exec: (command, options) =>
+    const spySandbox: SandboxService = {
+      exec: (command, _options) =>
         Effect.gen(function* () {
           events.push(`start:${command}`);
           yield* Effect.yieldNow();
@@ -107,28 +106,29 @@ describe("PromptPreprocessor", () => {
         }),
       copyIn: () => Effect.succeed(undefined as never),
       copyFileOut: () => Effect.succeed(undefined as never),
-    });
+    };
 
-    const spyLayer = Layer.merge(
-      spySandboxLayer,
-      SilentDisplay.layer(Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([])),
+    const displayLayer = SilentDisplay.layer(
+      Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]),
     );
 
     const marked = await Effect.runPromise(
       substitutePromptArgs(
         "First: !`echo hello`\nSecond: !`echo world`",
         {},
-      ).pipe(Effect.provide(spyLayer)),
+      ).pipe(Effect.provide(displayLayer)) as Effect.Effect<
+        string,
+        unknown,
+        never
+      >,
     );
     const result = await Effect.runPromise(
-      Sandbox.pipe(
-        Effect.flatMap((s) => preprocessPrompt(marked, s, sandboxDir)),
-        Effect.provide(spyLayer),
+      preprocessPrompt(marked, spySandbox, sandboxDir).pipe(
+        Effect.provide(displayLayer),
       ),
     );
 
     expect(result).toBe("First: hello\nSecond: world");
-    // With parallel execution, both commands should start before either ends
     expect(events).toEqual([
       "start:echo hello",
       "start:echo world",
@@ -138,84 +138,84 @@ describe("PromptPreprocessor", () => {
   });
 
   it("logs per-command token counts after shell expressions resolve", async () => {
-    const { sandboxDir, layer, displayRef } = await setup();
+    const { sandboxDir, sandbox, displayLayer, displayRef } = await setup();
     const prompt = "First: !`echo hello`\nSecond: !`echo world`";
-    await run(prompt, layer, sandboxDir);
+    await run(prompt, sandbox, displayLayer, sandboxDir);
     const entries = await Effect.runPromise(Ref.get(displayRef));
     const taskLogEntry = entries.find((e) => e._tag === "taskLog");
     expect(taskLogEntry).toBeDefined();
     if (taskLogEntry!._tag !== "taskLog") throw new Error("unreachable");
-    // Each command appears exactly once — with its token count
     const helloTokens = Math.ceil("hello".length / 4);
     const worldTokens = Math.ceil("world".length / 4);
     expect(taskLogEntry!.messages[0]).toBe(
-      `echo hello \u2192 ~${helloTokens} tokens`,
+      `echo hello → ~${helloTokens} tokens`,
     );
     expect(taskLogEntry!.messages[1]).toBe(
-      `echo world \u2192 ~${worldTokens} tokens`,
+      `echo world → ~${worldTokens} tokens`,
     );
-    // No upfront command names, no total line — exactly 2 messages
     expect(taskLogEntry!.messages).toHaveLength(2);
   });
 
   it("executes template shell blocks with {{KEY}} substituted into the command", async () => {
-    const { sandboxDir, layer } = await setup();
+    const { sandboxDir, sandbox, displayLayer } = await setup();
     const rawTemplate = "Greeting: !`echo hello {{NAME}}`";
     const substituted = await Effect.runPromise(
       substitutePromptArgs(rawTemplate, { NAME: "world" }).pipe(
-        Effect.provide(layer),
-      ),
+        Effect.provide(displayLayer),
+      ) as Effect.Effect<string, unknown, never>,
     );
     const result = await Effect.runPromise(
-      Sandbox.pipe(
-        Effect.flatMap((s) => preprocessPrompt(substituted, s, sandboxDir)),
-        Effect.provide(layer),
+      preprocessPrompt(substituted, sandbox, sandboxDir).pipe(
+        Effect.provide(displayLayer),
       ),
     );
     expect(result).toBe("Greeting: hello world");
   });
 
   it("does not execute shell blocks that arrive via prompt argument substitution", async () => {
-    const { sandboxDir, layer } = await setup();
+    const { sandboxDir, sandbox, displayLayer } = await setup();
     const rawTemplate = "Title: {{TITLE}}";
     const substituted = await Effect.runPromise(
       substitutePromptArgs(rawTemplate, {
         TITLE: "fixes !`rm -rf /` (do not run)",
-      }).pipe(Effect.provide(layer)),
+      }).pipe(Effect.provide(displayLayer)) as Effect.Effect<
+        string,
+        unknown,
+        never
+      >,
     );
     const result = await Effect.runPromise(
-      Sandbox.pipe(
-        Effect.flatMap((s) => preprocessPrompt(substituted, s, sandboxDir)),
-        Effect.provide(layer),
+      preprocessPrompt(substituted, sandbox, sandboxDir).pipe(
+        Effect.provide(displayLayer),
       ),
     );
-    // The injected !`...` pattern must survive as literal text, not be executed.
     expect(result).toContain("!`rm -rf /`");
   });
 
   it("strips marker characters smuggled through arg values so they cannot forge a shell block", async () => {
-    const { sandboxDir, layer } = await setup();
+    const { sandboxDir, sandbox, displayLayer } = await setup();
     const rawTemplate = "Payload: {{DATA}}";
-    // An attacker who knows about the marker tries to smuggle a pre-marked
-    // shell block through an arg value. The marker must be stripped.
     const substituted = await Effect.runPromise(
       substitutePromptArgs(rawTemplate, {
         DATA: "!\x01`rm -rf /`",
-      }).pipe(Effect.provide(layer)),
+      }).pipe(Effect.provide(displayLayer)) as Effect.Effect<
+        string,
+        unknown,
+        never
+      >,
     );
     const result = await Effect.runPromise(
-      Sandbox.pipe(
-        Effect.flatMap((s) => preprocessPrompt(substituted, s, sandboxDir)),
-        Effect.provide(layer),
+      preprocessPrompt(substituted, sandbox, sandboxDir).pipe(
+        Effect.provide(displayLayer),
       ),
     );
     expect(result).toBe("Payload: !`rm -rf /`");
   });
 
   it("does not show taskLog when prompt has no commands", async () => {
-    const { sandboxDir, layer, displayRef } = await setup();
+    const { sandboxDir, sandbox, displayLayer, displayRef } = await setup();
     const prompt = "Just a plain prompt with no commands.";
-    await run(prompt, layer, sandboxDir);
+    await run(prompt, sandbox, displayLayer, sandboxDir);
     const entries = await Effect.runPromise(Ref.get(displayRef));
     expect(entries.filter((e) => e._tag === "taskLog")).toHaveLength(0);
   });

--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -29,7 +29,6 @@ vi.mock("./WorktreeManager.js", () => ({
 
 import * as WorktreeManager from "./WorktreeManager.js";
 import {
-  Sandbox,
   SandboxFactory,
   SandboxConfig,
   WorktreeDockerSandboxFactory,
@@ -129,7 +128,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(layerWithBranch)),
     );
 
@@ -143,7 +142,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeLayer())),
     );
 
@@ -184,7 +183,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(layer)),
     );
 
@@ -197,7 +196,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeLayer())),
     );
 
@@ -219,7 +218,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeLayer())),
     );
 
@@ -243,7 +242,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeLayer())),
     );
 
@@ -261,7 +260,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeLayer())),
     );
 
@@ -274,7 +273,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeLayer())),
     );
 
@@ -287,7 +286,7 @@ describe("WorktreeDockerSandboxFactory", () => {
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox(() => Effect.die("boom"));
+          yield* factory.withSandbox((_, sandbox) => Effect.die("boom"));
         }).pipe(Effect.provide(makeLayer())),
       ),
     ).rejects.toThrow();
@@ -301,7 +300,7 @@ describe("WorktreeDockerSandboxFactory", () => {
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox(() =>
+          yield* factory.withSandbox((_, sandbox) =>
             Effect.fail(new WorktreeError({ message: "boom" })),
           );
         }).pipe(Effect.provide(makeLayer())),
@@ -319,7 +318,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     const exit = await Effect.runPromiseExit(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() =>
+        yield* factory.withSandbox((_, sandbox) =>
           Effect.fail(
             new AgentIdleTimeoutError({
               message: "timed out",
@@ -345,7 +344,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     const exit = await Effect.runPromiseExit(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() =>
+        yield* factory.withSandbox((_, sandbox) =>
           Effect.fail(new AgentError({ message: "agent failed" })),
         );
       }).pipe(Effect.provide(makeLayer())),
@@ -385,7 +384,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(layerWithCopy)),
     );
 
@@ -403,7 +402,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeLayer())),
     );
 
@@ -418,7 +417,9 @@ describe("WorktreeDockerSandboxFactory", () => {
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        return yield* factory.withSandbox(() => Effect.succeed("done"));
+        return yield* factory.withSandbox((_, sandbox) =>
+          Effect.succeed("done"),
+        );
       }).pipe(Effect.provide(makeLayer())),
     );
 
@@ -434,7 +435,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeLayer())),
     );
 
@@ -451,7 +452,7 @@ describe("WorktreeDockerSandboxFactory", () => {
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox(() =>
+          yield* factory.withSandbox((_, sandbox) =>
             Effect.fail(new AgentError({ message: "agent failed" })),
           );
         }).pipe(Effect.provide(makeLayer())),
@@ -489,7 +490,7 @@ describe("WorktreeDockerSandboxFactory", () => {
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox(() => Effect.void);
+          yield* factory.withSandbox((_, sandbox) => Effect.void);
         }).pipe(Effect.provide(layer)),
       ),
     ).rejects.toThrow();
@@ -505,7 +506,7 @@ describe("WorktreeDockerSandboxFactory", () => {
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox(() =>
+          yield* factory.withSandbox((_, sandbox) =>
             Effect.fail(new AgentError({ message: "agent failed" })),
           );
         }).pipe(Effect.provide(makeLayer())),
@@ -522,7 +523,7 @@ describe("WorktreeDockerSandboxFactory", () => {
     const exit = await Effect.runPromiseExit(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() =>
+        yield* factory.withSandbox((_, sandbox) =>
           Effect.fail(
             new AgentIdleTimeoutError({
               message: "timed out",
@@ -552,7 +553,7 @@ describe("WorktreeDockerSandboxFactory", () => {
       await Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox(() => Effect.void);
+          yield* factory.withSandbox((_, sandbox) => Effect.void);
         }).pipe(Effect.provide(makeHeadLayer())),
       );
 
@@ -565,7 +566,7 @@ describe("WorktreeDockerSandboxFactory", () => {
       await Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox(() => Effect.void);
+          yield* factory.withSandbox((_, sandbox) => Effect.void);
         }).pipe(Effect.provide(makeHeadLayer())),
       );
 
@@ -585,7 +586,9 @@ describe("WorktreeDockerSandboxFactory", () => {
       const result = await Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          return yield* factory.withSandbox(() => Effect.succeed("done"));
+          return yield* factory.withSandbox((_, sandbox) =>
+            Effect.succeed("done"),
+          );
         }).pipe(Effect.provide(makeHeadLayer())),
       );
 
@@ -615,7 +618,9 @@ describe("WorktreeDockerSandboxFactory", () => {
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        return yield* factory.withSandbox(() => Effect.succeed("done"));
+        return yield* factory.withSandbox((_, sandbox) =>
+          Effect.succeed("done"),
+        );
       }).pipe(Effect.provide(makeLayer())),
     );
 
@@ -693,9 +698,8 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() =>
+        yield* factory.withSandbox((_, sandbox) =>
           Effect.gen(function* () {
-            const sandbox = yield* Sandbox;
             const result = yield* sandbox.exec("cat extra.txt");
             fileContent = result.stdout.trim();
           }),
@@ -721,9 +725,8 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() =>
+        yield* factory.withSandbox((_, sandbox) =>
           Effect.gen(function* () {
-            const sandbox = yield* Sandbox;
             const result = yield* sandbox.exec("cat subdir/config.json");
             fileContent = result.stdout.trim();
           }),
@@ -747,9 +750,8 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() =>
+        yield* factory.withSandbox((_, sandbox) =>
           Effect.gen(function* () {
-            const sandbox = yield* Sandbox;
             const result = yield* sandbox.exec("cat hello.txt");
             fileContent = result.stdout.trim();
           }),
@@ -777,9 +779,8 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() =>
+        yield* factory.withSandbox((_, sandbox) =>
           Effect.gen(function* () {
-            const sandbox = yield* Sandbox;
             contentA = (yield* sandbox.exec("cat config/a.json")).stdout.trim();
             contentB = (yield* sandbox.exec(
               "cat config/nested/b.json",
@@ -804,7 +805,7 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeIsolatedLayer(hostDir, ["nonexistent.txt"]))),
     );
   });
@@ -830,7 +831,7 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeIsolatedLayer(hostDir))),
     );
 
@@ -867,7 +868,7 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(layer)),
     );
 
@@ -923,7 +924,7 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeIsolatedLayer(hostDir))),
     );
 
@@ -947,7 +948,7 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox(() => Effect.die("boom"));
+          yield* factory.withSandbox((_, sandbox) => Effect.die("boom"));
         }).pipe(Effect.provide(makeIsolatedLayer(hostDir))),
       ),
     ).rejects.toThrow();
@@ -993,7 +994,7 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox(() => Effect.void);
+          yield* factory.withSandbox((_, sandbox) => Effect.void);
         }).pipe(Effect.provide(layer)),
       ),
     ).rejects.toThrow();
@@ -1025,7 +1026,7 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(Effect.provide(makeIsolatedLayer(hostDir))),
     );
 
@@ -1054,9 +1055,8 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((info) =>
+        yield* factory.withSandbox((info, sandbox) =>
           Effect.gen(function* () {
-            const sandbox = yield* Sandbox;
             yield* sandbox.exec(
               'git config user.email "test@test.com" && git config user.name "Test"',
             );
@@ -1121,10 +1121,9 @@ describe("WorktreeDockerSandboxFactory — no-sandbox provider", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((info) => {
+        yield* factory.withSandbox((info, sandbox) => {
           receivedInfo = info;
           return Effect.gen(function* () {
-            const sandbox = yield* Sandbox;
             const r = yield* sandbox.exec("cat hello.txt");
             execOut = r.stdout.trim();
           });
@@ -1157,7 +1156,7 @@ describe("WorktreeDockerSandboxFactory — no-sandbox provider", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox(() => Effect.void);
+        yield* factory.withSandbox((_, sandbox) => Effect.void);
       }).pipe(
         Effect.provide(makeNoSandboxLayer(hostDir, { type: "merge-to-head" })),
       ),
@@ -1210,7 +1209,7 @@ describe("WorktreeDockerSandboxFactory — no-sandbox provider", () => {
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox(() => Effect.void);
+          yield* factory.withSandbox((_, sandbox) => Effect.void);
         }).pipe(Effect.provide(layer)),
       ),
     ).rejects.toThrow();

--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -1,18 +1,18 @@
 import { Effect, Exit, Layer, Ref } from "effect";
 import { NodeFileSystem } from "@effect/platform-node";
 import { exec } from "node:child_process";
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdtemp, mkdir, readdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { AgentError, AgentIdleTimeoutError, WorktreeError } from "./errors.js";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { AgentError, AgentIdleTimeoutError } from "./errors.js";
 import { SilentDisplay, type DisplayEntry } from "./Display.js";
 import {
   createBindMountSandboxProvider,
   createIsolatedSandboxProvider,
   type SandboxProvider,
-  type BindMountSandboxHandle,
   type BranchStrategy,
   type NoSandboxProvider,
 } from "./SandboxProvider.js";
@@ -20,14 +20,6 @@ import { testIsolated } from "./sandboxes/test-isolated.js";
 import { testStubProvider } from "./sandboxes/test-shared.js";
 import { noSandbox } from "./sandboxes/no-sandbox.js";
 
-vi.mock("./WorktreeManager.js", () => ({
-  create: vi.fn(),
-  remove: vi.fn(),
-  pruneStale: vi.fn(),
-  hasUncommittedChanges: vi.fn(),
-}));
-
-import * as WorktreeManager from "./WorktreeManager.js";
 import {
   SandboxFactory,
   SandboxConfig,
@@ -35,12 +27,49 @@ import {
   SANDBOX_REPO_DIR,
 } from "./SandboxFactory.js";
 
-const mockCreate = vi.mocked(WorktreeManager.create);
-const mockRemove = vi.mocked(WorktreeManager.remove);
-const mockPruneStale = vi.mocked(WorktreeManager.pruneStale);
-const mockHasUncommittedChanges = vi.mocked(
-  WorktreeManager.hasUncommittedChanges,
-);
+const execAsync = promisify(exec);
+
+const initRepo = async (dir: string) => {
+  await execAsync("git init -b main", { cwd: dir });
+  await execAsync('git config user.email "test@test.com"', { cwd: dir });
+  await execAsync('git config user.name "Test"', { cwd: dir });
+};
+
+const commitFile = async (
+  dir: string,
+  name: string,
+  content: string,
+  message: string,
+) => {
+  await writeFile(join(dir, name), content);
+  await execAsync(`git add "${name}"`, { cwd: dir });
+  await execAsync(`git commit -m "${message}"`, { cwd: dir });
+};
+
+/** Initialize a real git repo with an initial commit so WorktreeManager.create succeeds. */
+const initRepoWithCommit = async (dir: string) => {
+  await initRepo(dir);
+  await commitFile(dir, "initial.txt", "initial", "initial commit");
+};
+
+/** Find the sole worktree directory created under hostDir/.sandcastle/worktrees. */
+const findCreatedWorktree = async (
+  hostDir: string,
+): Promise<string | undefined> => {
+  const worktreesDir = join(hostDir, ".sandcastle", "worktrees");
+  if (!existsSync(worktreesDir)) return undefined;
+  const entries = await readdir(worktreesDir);
+  if (entries.length === 0) return undefined;
+  return join(worktreesDir, entries[0]!);
+};
+
+/** Get the branch checked out at a worktree directory. */
+const branchAt = async (dir: string): Promise<string> => {
+  const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD", {
+    cwd: dir,
+  });
+  return stdout.trim();
+};
 
 /** Create a mock sandbox provider that records calls and delegates to a no-op handle. */
 const makeMockProvider = (): {
@@ -61,21 +90,9 @@ const makeMockProvider = (): {
   };
 };
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
 describe("WorktreeDockerSandboxFactory", () => {
   let hostRepoDir: string;
-  const worktreePath = "/tmp/sandcastle-worktrees/sandcastle-123";
   const tempDirs: string[] = [];
-
-  const makeTempRepo = async () => {
-    const dir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
-    tempDirs.push(dir);
-    await mkdir(join(dir, ".git"));
-    return dir;
-  };
 
   let mockProvider: ReturnType<typeof makeMockProvider>;
 
@@ -98,18 +115,10 @@ describe("WorktreeDockerSandboxFactory", () => {
     );
 
   beforeEach(async () => {
-    hostRepoDir = await makeTempRepo();
+    hostRepoDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
+    tempDirs.push(hostRepoDir);
+    await initRepoWithCommit(hostRepoDir);
     mockProvider = makeMockProvider();
-    mockCreate.mockReturnValue(
-      Effect.succeed({
-        path: worktreePath,
-        branch: "sandcastle/20240101-000000",
-      }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockPruneStale.mockReturnValue(Effect.void);
-    // Default: clean worktree (no uncommitted changes)
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
   });
 
   afterEach(async () => {
@@ -119,50 +128,53 @@ describe("WorktreeDockerSandboxFactory", () => {
     tempDirs.length = 0;
   });
 
-  it("passes branch from branchStrategy config to WorktreeManager.create when branch is specified", async () => {
+  it("creates a real worktree on the given branch when branch is specified", async () => {
     const layerWithBranch = makeLayer(
       Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]),
       { type: "branch", branch: "feature/my-branch" },
     );
 
+    let observedBranch: string | undefined;
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox((info) =>
+          Effect.promise(async () => {
+            observedBranch = await branchAt(info.hostWorktreePath!);
+          }),
+        );
       }).pipe(Effect.provide(layerWithBranch)),
     );
 
-    expect(mockCreate).toHaveBeenCalledWith(hostRepoDir, {
-      branch: "feature/my-branch",
-      baseBranch: undefined,
-    });
+    expect(observedBranch).toBe("feature/my-branch");
   });
 
-  it("calls create without branch options when no branch in config", async () => {
+  it("creates a worktree on a generated sandcastle/<timestamp> branch when no branch is specified", async () => {
+    let observedBranch: string | undefined;
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox((info) =>
+          Effect.promise(async () => {
+            observedBranch = await branchAt(info.hostWorktreePath!);
+          }),
+        );
       }).pipe(Effect.provide(makeLayer())),
     );
 
-    expect(mockCreate).toHaveBeenCalledWith(hostRepoDir, {
-      name: undefined,
-    });
+    expect(observedBranch).toMatch(/^sandcastle\//);
   });
 
-  it("creates a worktree before calling the provider", async () => {
+  it("creates the worktree before calling provider.create", async () => {
     const callOrder: string[] = [];
-    mockCreate.mockImplementation(() =>
-      Effect.sync(() => {
-        callOrder.push("worktree-create");
-        return { path: worktreePath, branch: "sandcastle/20240101-000000" };
-      }),
-    );
     const { provider } = makeMockProvider();
     const origCreate = provider.create;
     (provider as any).create = async (opts: any) => {
       callOrder.push("provider-create");
+      // Verify the worktree directory already exists at this point
+      if (existsSync(opts.worktreePath)) {
+        callOrder.push("worktree-exists-before-provider-create");
+      }
       return origCreate(opts);
     };
 
@@ -183,148 +195,109 @@ describe("WorktreeDockerSandboxFactory", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox(() => Effect.void);
       }).pipe(Effect.provide(layer)),
     );
 
-    expect(callOrder.indexOf("worktree-create")).toBeLessThan(
-      callOrder.indexOf("provider-create"),
-    );
+    expect(callOrder).toContain("worktree-exists-before-provider-create");
   });
 
   it("passes worktree path and git mounts to provider.create", async () => {
+    let observedWorktree: string | undefined;
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox((info) =>
+          Effect.sync(() => {
+            observedWorktree = info.hostWorktreePath;
+          }),
+        );
       }).pipe(Effect.provide(makeLayer())),
     );
 
     expect(mockProvider.createCalls).toHaveLength(1);
     const opts = mockProvider.createCalls[0];
-    // Should include worktree mount
+    expect(observedWorktree).toBeDefined();
     expect(opts.mounts).toContainEqual({
-      hostPath: worktreePath,
+      hostPath: observedWorktree,
       sandboxPath: SANDBOX_REPO_DIR,
     });
-    // Should include git mount
     expect(opts.mounts).toContainEqual({
       hostPath: `${hostRepoDir}/.git`,
       sandboxPath: `${hostRepoDir}/.git`,
     });
   });
 
-  it("removes worktree after the effect completes", async () => {
+  it("removes the worktree after the effect completes (clean state)", async () => {
+    let observedWorktreePath: string | undefined;
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox((info) =>
+          Effect.sync(() => {
+            observedWorktreePath = info.hostWorktreePath;
+          }),
+        );
       }).pipe(Effect.provide(makeLayer())),
     );
 
-    expect(mockRemove).toHaveBeenCalledWith(worktreePath);
-  });
-
-  it("prunes stale worktrees before creating a new worktree", async () => {
-    const callOrder: string[] = [];
-    mockPruneStale.mockImplementation(() =>
-      Effect.sync(() => {
-        callOrder.push("pruneStale");
-      }),
-    );
-    mockCreate.mockImplementation(() =>
-      Effect.sync(() => {
-        callOrder.push("create");
-        return { path: worktreePath, branch: "sandcastle/20240101-000000" };
-      }),
-    );
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
-      }).pipe(Effect.provide(makeLayer())),
-    );
-
-    expect(mockPruneStale).toHaveBeenCalledWith(hostRepoDir);
-    expect(callOrder.indexOf("pruneStale")).toBeLessThan(
-      callOrder.indexOf("create"),
-    );
-  });
-
-  it("continues creating the worktree even if pruning fails", async () => {
-    mockPruneStale.mockReturnValue(
-      Effect.fail(new WorktreeError({ message: "prune failed" })),
-    );
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
-      }).pipe(Effect.provide(makeLayer())),
-    );
-
-    expect(mockCreate).toHaveBeenCalledWith(hostRepoDir, {
-      name: undefined,
-    });
+    expect(observedWorktreePath).toBeDefined();
+    expect(existsSync(observedWorktreePath!)).toBe(false);
   });
 
   it("closes provider handle on release", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox(() => Effect.void);
       }).pipe(Effect.provide(makeLayer())),
     );
 
     expect(mockProvider.closeCalls).toBe(1);
   });
 
-  it("preserves worktree (does not remove) when the effect fails with dirty worktree", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(true));
+  it("preserves worktree when the effect fails with uncommitted changes in the worktree", async () => {
+    let observedWorktreePath: string | undefined;
     await expect(
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox((_, sandbox) => Effect.die("boom"));
-        }).pipe(Effect.provide(makeLayer())),
-      ),
-    ).rejects.toThrow();
-
-    expect(mockRemove).not.toHaveBeenCalled();
-  });
-
-  it("closes provider handle but preserves worktree on typed failure with dirty worktree", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(true));
-    await expect(
-      Effect.runPromise(
-        Effect.gen(function* () {
-          const factory = yield* SandboxFactory;
-          yield* factory.withSandbox((_, sandbox) =>
-            Effect.fail(new WorktreeError({ message: "boom" })),
+          yield* factory.withSandbox((info) =>
+            Effect.gen(function* () {
+              observedWorktreePath = info.hostWorktreePath;
+              // Create an uncommitted change inside the worktree
+              yield* Effect.promise(() =>
+                writeFile(join(info.hostWorktreePath!, "dirty.txt"), "dirty"),
+              );
+              return yield* Effect.die("boom");
+            }),
           );
         }).pipe(Effect.provide(makeLayer())),
       ),
     ).rejects.toThrow();
 
-    // Worktree must NOT be removed
-    expect(mockRemove).not.toHaveBeenCalled();
-    // Provider handle must be closed
-    expect(mockProvider.closeCalls).toBe(1);
+    expect(observedWorktreePath).toBeDefined();
+    expect(existsSync(observedWorktreePath!)).toBe(true);
   });
 
   it("attaches preservedWorktreePath to AgentIdleTimeoutError on failure with dirty worktree", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(true));
+    let observedWorktreePath: string | undefined;
     const exit = await Effect.runPromiseExit(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) =>
-          Effect.fail(
-            new AgentIdleTimeoutError({
-              message: "timed out",
-              timeoutMs: 30_000,
-            }),
-          ),
+        yield* factory.withSandbox((info) =>
+          Effect.gen(function* () {
+            observedWorktreePath = info.hostWorktreePath;
+            yield* Effect.promise(() =>
+              writeFile(join(info.hostWorktreePath!, "dirty.txt"), "dirty"),
+            );
+            return yield* Effect.fail(
+              new AgentIdleTimeoutError({
+                message: "timed out",
+                timeoutMs: 30_000,
+              }),
+            );
+          }),
         );
       }).pipe(Effect.provide(makeLayer())),
     );
@@ -336,16 +309,24 @@ describe("WorktreeDockerSandboxFactory", () => {
     expect(exit.cause.error).toBeInstanceOf(AgentIdleTimeoutError);
     expect(
       (exit.cause.error as AgentIdleTimeoutError).preservedWorktreePath,
-    ).toBe(worktreePath);
+    ).toBe(observedWorktreePath);
   });
 
   it("attaches preservedWorktreePath to AgentError on failure with dirty worktree", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(true));
+    let observedWorktreePath: string | undefined;
     const exit = await Effect.runPromiseExit(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) =>
-          Effect.fail(new AgentError({ message: "agent failed" })),
+        yield* factory.withSandbox((info) =>
+          Effect.gen(function* () {
+            observedWorktreePath = info.hostWorktreePath;
+            yield* Effect.promise(() =>
+              writeFile(join(info.hostWorktreePath!, "dirty.txt"), "dirty"),
+            );
+            return yield* Effect.fail(
+              new AgentError({ message: "agent failed" }),
+            );
+          }),
         );
       }).pipe(Effect.provide(makeLayer())),
     );
@@ -356,11 +337,13 @@ describe("WorktreeDockerSandboxFactory", () => {
     if (exit.cause._tag !== "Fail") throw new Error("unreachable");
     expect(exit.cause.error).toBeInstanceOf(AgentError);
     expect((exit.cause.error as AgentError).preservedWorktreePath).toBe(
-      worktreePath,
+      observedWorktreePath,
     );
   });
 
   it("logs copy-to-sandbox as a spinner when copyToWorktree paths are provided", async () => {
+    await writeFile(join(hostRepoDir, "some-file.txt"), "content");
+
     const ref = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]);
     const layerWithCopy = Layer.provide(
       WorktreeDockerSandboxFactory.layer,
@@ -368,7 +351,7 @@ describe("WorktreeDockerSandboxFactory", () => {
         Layer.succeed(SandboxConfig, {
           env: {},
           hostRepoDir,
-          copyToWorktree: ["node_modules"],
+          copyToWorktree: ["some-file.txt"],
           sandboxProvider: mockProvider.provider,
           branchStrategy: { type: "merge-to-head" },
         }),
@@ -377,14 +360,10 @@ describe("WorktreeDockerSandboxFactory", () => {
       ),
     );
 
-    vi.mock("./CopyToWorktree.js", () => ({
-      copyToWorktree: vi.fn(() => Effect.succeed(undefined)),
-    }));
-
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox(() => Effect.void);
       }).pipe(Effect.provide(layerWithCopy)),
     );
 
@@ -396,75 +375,90 @@ describe("WorktreeDockerSandboxFactory", () => {
   });
 
   it("removes worktree silently on success with clean worktree", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
+    let observedWorktreePath: string | undefined;
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox((info) =>
+          Effect.sync(() => {
+            observedWorktreePath = info.hostWorktreePath;
+          }),
+        );
       }).pipe(Effect.provide(makeLayer())),
     );
 
-    expect(mockRemove).toHaveBeenCalledWith(worktreePath);
+    expect(existsSync(observedWorktreePath!)).toBe(false);
     expect(stderrSpy).not.toHaveBeenCalled();
     stderrSpy.mockRestore();
   });
 
   it("preserves worktree and returns preservedWorktreePath on success with dirty worktree", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(true));
-
+    let observedWorktreePath: string | undefined;
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        return yield* factory.withSandbox((_, sandbox) =>
-          Effect.succeed("done"),
+        return yield* factory.withSandbox((info) =>
+          Effect.gen(function* () {
+            observedWorktreePath = info.hostWorktreePath;
+            yield* Effect.promise(() =>
+              writeFile(join(info.hostWorktreePath!, "dirty.txt"), "dirty"),
+            );
+            return "done";
+          }),
         );
       }).pipe(Effect.provide(makeLayer())),
     );
 
-    expect(mockRemove).not.toHaveBeenCalled();
-    expect(result.preservedWorktreePath).toBe(worktreePath);
+    expect(result.preservedWorktreePath).toBe(observedWorktreePath);
     expect(result.value).toBe("done");
+    expect(existsSync(observedWorktreePath!)).toBe(true);
   });
 
   it("prints uncommitted changes message on success with dirty worktree", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(true));
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
+    let observedWorktreePath: string | undefined;
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox((info) =>
+          Effect.gen(function* () {
+            observedWorktreePath = info.hostWorktreePath;
+            yield* Effect.promise(() =>
+              writeFile(join(info.hostWorktreePath!, "dirty.txt"), "dirty"),
+            );
+          }),
+        );
       }).pipe(Effect.provide(makeLayer())),
     );
 
     const output = stderrSpy.mock.calls.map((c) => c[0]).join(" ");
     expect(output).toContain("uncommitted changes");
-    expect(output).toContain(worktreePath);
+    expect(output).toContain(observedWorktreePath);
     stderrSpy.mockRestore();
   });
 
   it("removes worktree on failure with clean worktree", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
-
+    let observedWorktreePath: string | undefined;
     await expect(
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox((_, sandbox) =>
-            Effect.fail(new AgentError({ message: "agent failed" })),
-          );
+          yield* factory.withSandbox((info) => {
+            observedWorktreePath = info.hostWorktreePath;
+            return Effect.fail(new AgentError({ message: "agent failed" }));
+          });
         }).pipe(Effect.provide(makeLayer())),
       ),
     ).rejects.toThrow();
 
-    expect(mockRemove).toHaveBeenCalledWith(worktreePath);
+    expect(observedWorktreePath).toBeDefined();
+    expect(existsSync(observedWorktreePath!)).toBe(false);
   });
 
   it("removes worktree when sandbox start fails (e.g. missing image)", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
-
     const failingProvider = createBindMountSandboxProvider({
       name: "failing-provider",
       create: async () => {
@@ -490,23 +484,24 @@ describe("WorktreeDockerSandboxFactory", () => {
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox((_, sandbox) => Effect.void);
+          yield* factory.withSandbox(() => Effect.void);
         }).pipe(Effect.provide(layer)),
       ),
     ).rejects.toThrow();
 
-    expect(mockRemove).toHaveBeenCalledWith(worktreePath);
+    // No worktree should remain on disk
+    const worktree = await findCreatedWorktree(hostRepoDir);
+    expect(worktree).toBeUndefined();
   });
 
   it("prints 'no uncommitted changes' message on failure with clean worktree", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
     const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox((_, sandbox) =>
+          yield* factory.withSandbox(() =>
             Effect.fail(new AgentError({ message: "agent failed" })),
           );
         }).pipe(Effect.provide(makeLayer())),
@@ -519,11 +514,10 @@ describe("WorktreeDockerSandboxFactory", () => {
   });
 
   it("does not attach preservedWorktreePath to AgentIdleTimeoutError when worktree is clean on failure", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
     const exit = await Effect.runPromiseExit(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) =>
+        yield* factory.withSandbox(() =>
           Effect.fail(
             new AgentIdleTimeoutError({
               message: "timed out",
@@ -549,24 +543,23 @@ describe("WorktreeDockerSandboxFactory", () => {
       displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]),
     ) => makeLayer(displayRef, { type: "head" });
 
-    it("does not create or remove a worktree", async () => {
+    it("does not create a worktree", async () => {
       await Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox((_, sandbox) => Effect.void);
+          yield* factory.withSandbox(() => Effect.void);
         }).pipe(Effect.provide(makeHeadLayer())),
       );
 
-      expect(mockCreate).not.toHaveBeenCalled();
-      expect(mockRemove).not.toHaveBeenCalled();
-      expect(mockPruneStale).not.toHaveBeenCalled();
+      const worktree = await findCreatedWorktree(hostRepoDir);
+      expect(worktree).toBeUndefined();
     });
 
     it("passes host repo dir and git mounts to provider", async () => {
       await Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox((_, sandbox) => Effect.void);
+          yield* factory.withSandbox(() => Effect.void);
         }).pipe(Effect.provide(makeHeadLayer())),
       );
 
@@ -586,9 +579,7 @@ describe("WorktreeDockerSandboxFactory", () => {
       const result = await Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          return yield* factory.withSandbox((_, sandbox) =>
-            Effect.succeed("done"),
-          );
+          return yield* factory.withSandbox(() => Effect.succeed("done"));
         }).pipe(Effect.provide(makeHeadLayer())),
       );
 
@@ -613,14 +604,10 @@ describe("WorktreeDockerSandboxFactory", () => {
   });
 
   it("returns undefined preservedWorktreePath on success with clean worktree", async () => {
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
-
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        return yield* factory.withSandbox((_, sandbox) =>
-          Effect.succeed("done"),
-        );
+        return yield* factory.withSandbox(() => Effect.succeed("done"));
       }).pipe(Effect.provide(makeLayer())),
     );
 
@@ -628,25 +615,6 @@ describe("WorktreeDockerSandboxFactory", () => {
     expect(result.value).toBe("done");
   });
 });
-
-const execAsync = promisify(exec);
-
-const initRepo = async (dir: string) => {
-  await execAsync("git init -b main", { cwd: dir });
-  await execAsync('git config user.email "test@test.com"', { cwd: dir });
-  await execAsync('git config user.name "Test"', { cwd: dir });
-};
-
-const commitFile = async (
-  dir: string,
-  name: string,
-  content: string,
-  message: string,
-) => {
-  await writeFile(join(dir, name), content);
-  await execAsync(`git add "${name}"`, { cwd: dir });
-  await execAsync(`git commit -m "${message}"`, { cwd: dir });
-};
 
 describe("WorktreeDockerSandboxFactory — isolated providers", () => {
   const tempDirs: string[] = [];
@@ -667,16 +635,6 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
       ),
     );
 
-  /** Set up WorktreeManager mocks so the worktree path points at the real repo. */
-  const setupWorktreeMocks = (hostDir: string) => {
-    mockCreate.mockReturnValue(
-      Effect.succeed({ path: hostDir, branch: "sandcastle/20240101-000000" }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockPruneStale.mockReturnValue(Effect.void);
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
-  };
-
   afterEach(async () => {
     await Promise.all(
       tempDirs.map((d) => rm(d, { recursive: true, force: true })),
@@ -687,12 +645,8 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
   it("copies copyToWorktree files into the isolated sandbox via copyIn", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
-    setupWorktreeMocks(hostDir);
-
-    // Create a file to copy (not tracked by git)
-    await writeFile(join(hostDir, "extra.txt"), "extra content");
+    await initRepoWithCommit(hostDir);
+    await commitFile(hostDir, "extra.txt", "extra content", "add extra");
 
     let fileContent = "";
     await Effect.runPromise(
@@ -713,13 +667,15 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
   it("copies nested copyToWorktree paths, creating parent directories", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
-    setupWorktreeMocks(hostDir);
-
-    // Create a nested file to copy
+    await initRepoWithCommit(hostDir);
     await mkdir(join(hostDir, "subdir"), { recursive: true });
     await writeFile(join(hostDir, "subdir", "config.json"), '{"key":"value"}');
+    await execAsync(
+      'git add subdir/config.json && git commit -m "add config"',
+      {
+        cwd: hostDir,
+      },
+    );
 
     let fileContent = "";
     await Effect.runPromise(
@@ -742,9 +698,8 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
   it("works without copyToWorktree (no regression)", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello world", "initial");
-    setupWorktreeMocks(hostDir);
+    await initRepoWithCommit(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello world", "add hello");
 
     let fileContent = "";
     await Effect.runPromise(
@@ -765,14 +720,13 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
   it("copies copyToWorktree directories into the isolated sandbox via copyIn", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
-    setupWorktreeMocks(hostDir);
-
-    // Create a directory to copy (not tracked by git)
+    await initRepoWithCommit(hostDir);
     await mkdir(join(hostDir, "config", "nested"), { recursive: true });
     await writeFile(join(hostDir, "config", "a.json"), '{"a":1}');
     await writeFile(join(hostDir, "config", "nested", "b.json"), '{"b":2}');
+    await execAsync('git add config && git commit -m "add config dir"', {
+      cwd: hostDir,
+    });
 
     let contentA = "";
     let contentB = "";
@@ -797,15 +751,12 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
   it("skips missing copyToWorktree paths without error", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
-    setupWorktreeMocks(hostDir);
+    await initRepoWithCommit(hostDir);
 
-    // Request a file that doesn't exist — should not fail
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox(() => Effect.void);
       }).pipe(Effect.provide(makeIsolatedLayer(hostDir, ["nonexistent.txt"]))),
     );
   });
@@ -818,38 +769,23 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
   it("creates a worktree before starting the isolated sandbox", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
-
-    mockCreate.mockReturnValue(
-      Effect.succeed({ path: hostDir, branch: "sandcastle/20240101-000000" }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockPruneStale.mockReturnValue(Effect.void);
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
+    await initRepoWithCommit(hostDir);
 
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox(() => Effect.void);
       }).pipe(Effect.provide(makeIsolatedLayer(hostDir))),
     );
 
-    expect(mockCreate).toHaveBeenCalledWith(hostDir, { name: undefined });
+    // After cleanup the worktree dir is gone, but the .sandcastle/worktrees dir exists
+    expect(existsSync(join(hostDir, ".sandcastle", "worktrees"))).toBe(true);
   });
 
   it("creates a worktree with a named branch for branch strategy", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
-
-    mockCreate.mockReturnValue(
-      Effect.succeed({ path: hostDir, branch: "feature/my-branch" }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockPruneStale.mockReturnValue(Effect.void);
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
+    await initRepoWithCommit(hostDir);
 
     const layer = Layer.provide(
       WorktreeDockerSandboxFactory.layer,
@@ -865,34 +801,25 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
       ),
     );
 
+    let observedBranch: string | undefined;
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox((info) =>
+          Effect.promise(async () => {
+            observedBranch = await branchAt(info.hostWorktreePath!);
+          }),
+        );
       }).pipe(Effect.provide(layer)),
     );
 
-    expect(mockCreate).toHaveBeenCalledWith(hostDir, {
-      branch: "feature/my-branch",
-    });
+    expect(observedBranch).toBe("feature/my-branch");
   });
 
   it("provides hostWorktreePath in SandboxInfo", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
-
-    const fakeWorktreePath = hostDir;
-    mockCreate.mockReturnValue(
-      Effect.succeed({
-        path: fakeWorktreePath,
-        branch: "sandcastle/20240101-000000",
-      }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockPruneStale.mockReturnValue(Effect.void);
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
+    await initRepoWithCommit(hostDir);
 
     let receivedInfo: { hostWorktreePath?: string } | undefined;
     await Effect.runPromise(
@@ -905,69 +832,62 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
       }).pipe(Effect.provide(makeIsolatedLayer(hostDir))),
     );
 
-    expect(receivedInfo?.hostWorktreePath).toBe(fakeWorktreePath);
+    expect(receivedInfo?.hostWorktreePath).toBeDefined();
+    expect(receivedInfo!.hostWorktreePath).toContain(
+      join(hostDir, ".sandcastle", "worktrees"),
+    );
   });
 
   it("removes worktree on success with clean worktree", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
+    await initRepoWithCommit(hostDir);
 
-    mockCreate.mockReturnValue(
-      Effect.succeed({ path: hostDir, branch: "sandcastle/20240101-000000" }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockPruneStale.mockReturnValue(Effect.void);
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
-
+    let observedWorktreePath: string | undefined;
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox((info) =>
+          Effect.sync(() => {
+            observedWorktreePath = info.hostWorktreePath;
+          }),
+        );
       }).pipe(Effect.provide(makeIsolatedLayer(hostDir))),
     );
 
-    expect(mockRemove).toHaveBeenCalledWith(hostDir);
+    expect(existsSync(observedWorktreePath!)).toBe(false);
   });
 
   it("preserves worktree on failure with dirty worktree", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
+    await initRepoWithCommit(hostDir);
 
-    mockCreate.mockReturnValue(
-      Effect.succeed({ path: hostDir, branch: "sandcastle/20240101-000000" }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockPruneStale.mockReturnValue(Effect.void);
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(true));
-
+    let observedWorktreePath: string | undefined;
     await expect(
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox((_, sandbox) => Effect.die("boom"));
+          yield* factory.withSandbox((info) =>
+            Effect.gen(function* () {
+              observedWorktreePath = info.hostWorktreePath;
+              yield* Effect.promise(() =>
+                writeFile(join(info.hostWorktreePath!, "dirty.txt"), "dirty"),
+              );
+              return yield* Effect.die("boom");
+            }),
+          );
         }).pipe(Effect.provide(makeIsolatedLayer(hostDir))),
       ),
     ).rejects.toThrow();
 
-    expect(mockRemove).not.toHaveBeenCalled();
+    expect(existsSync(observedWorktreePath!)).toBe(true);
   });
 
   it("removes worktree when isolated sandbox start fails", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
-
-    mockCreate.mockReturnValue(
-      Effect.succeed({ path: hostDir, branch: "sandcastle/20240101-000000" }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockPruneStale.mockReturnValue(Effect.void);
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
+    await initRepoWithCommit(hostDir);
 
     const failingProvider = createIsolatedSandboxProvider({
       name: "failing-isolated",
@@ -994,69 +914,29 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox((_, sandbox) => Effect.void);
+          yield* factory.withSandbox(() => Effect.void);
         }).pipe(Effect.provide(layer)),
       ),
     ).rejects.toThrow();
 
-    expect(mockRemove).toHaveBeenCalledWith(hostDir);
-  });
-
-  it("prunes stale worktrees before creating a new one", async () => {
-    const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
-    tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
-
-    const callOrder: string[] = [];
-    mockPruneStale.mockImplementation(() =>
-      Effect.sync(() => {
-        callOrder.push("pruneStale");
-      }),
-    );
-    mockCreate.mockImplementation(() =>
-      Effect.sync(() => {
-        callOrder.push("create");
-        return { path: hostDir, branch: "sandcastle/20240101-000000" };
-      }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
-      }).pipe(Effect.provide(makeIsolatedLayer(hostDir))),
-    );
-
-    expect(callOrder.indexOf("pruneStale")).toBeLessThan(
-      callOrder.indexOf("create"),
-    );
+    // No worktree should remain
+    const worktree = await findCreatedWorktree(hostDir);
+    expect(worktree).toBeUndefined();
   });
 
   it("provides applyToHost callback that syncs commits to worktree", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hello", "initial");
+    await initRepoWithCommit(hostDir);
 
-    // Use hostDir as worktree path — applyToHost runs syncOut targeting the worktree
-    mockCreate.mockReturnValue(
-      Effect.succeed({ path: hostDir, branch: "sandcastle/20240101-000000" }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockPruneStale.mockReturnValue(Effect.void);
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
-
-    // The sandbox makes a commit inside the sandbox. Calling applyToHost should
-    // run syncOut which lands the commit on the worktree (hostDir in this test).
+    let observedWorktreePath: string | undefined;
     let commitMade = false;
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
         yield* factory.withSandbox((info, sandbox) =>
           Effect.gen(function* () {
+            observedWorktreePath = info.hostWorktreePath;
             yield* sandbox.exec(
               'git config user.email "test@test.com" && git config user.name "Test"',
             );
@@ -1064,7 +944,6 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
               'echo "new content" > new-file.txt && git add new-file.txt && git commit -m "sandbox commit"',
             );
             commitMade = true;
-            // Caller (lifecycle) is responsible for calling applyToHost
             if (!info.applyToHost)
               throw new Error("applyToHost not provided for isolated sandbox");
             yield* info.applyToHost();
@@ -1074,8 +953,10 @@ describe("WorktreeDockerSandboxFactory — isolated providers", () => {
     );
 
     expect(commitMade).toBe(true);
-    // Verify the commit landed on the worktree (hostDir)
-    const { stdout } = await execAsync("git log --oneline -1", {
+    expect(observedWorktreePath).toBeDefined();
+    // applyToHost runs syncOut, transferring the sandbox commit onto the
+    // worktree branch via format-patch/am. The branch remains after cleanup.
+    const { stdout } = await execAsync("git log --oneline --all", {
       cwd: hostDir,
     });
     expect(stdout).toContain("sandbox commit");
@@ -1113,8 +994,8 @@ describe("WorktreeDockerSandboxFactory — no-sandbox provider", () => {
   it("head mode: does not create a worktree and runs in hostRepoDir", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hi", "initial");
+    await initRepoWithCommit(hostDir);
+    await commitFile(hostDir, "hello.txt", "hi", "add hello");
 
     let receivedInfo: { hostWorktreePath?: string } | undefined;
     let execOut = "";
@@ -1131,8 +1012,8 @@ describe("WorktreeDockerSandboxFactory — no-sandbox provider", () => {
       }).pipe(Effect.provide(makeNoSandboxLayer(hostDir))),
     );
 
-    expect(mockCreate).not.toHaveBeenCalled();
-    expect(mockRemove).not.toHaveBeenCalled();
+    const worktree = await findCreatedWorktree(hostDir);
+    expect(worktree).toBeUndefined();
     expect(receivedInfo?.hostWorktreePath).toBe(hostDir);
     expect(execOut).toBe("hi");
   });
@@ -1140,47 +1021,33 @@ describe("WorktreeDockerSandboxFactory — no-sandbox provider", () => {
   it("worktree mode: creates worktree, runs in it, cleans up on success", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hi", "initial");
+    await initRepoWithCommit(hostDir);
 
-    mockCreate.mockReturnValue(
-      Effect.succeed({
-        path: hostDir,
-        branch: "sandcastle/20240101-000000",
-      }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockPruneStale.mockReturnValue(Effect.void);
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
-
+    let observedWorktreePath: string | undefined;
     await Effect.runPromise(
       Effect.gen(function* () {
         const factory = yield* SandboxFactory;
-        yield* factory.withSandbox((_, sandbox) => Effect.void);
+        yield* factory.withSandbox((info) =>
+          Effect.sync(() => {
+            observedWorktreePath = info.hostWorktreePath;
+          }),
+        );
       }).pipe(
         Effect.provide(makeNoSandboxLayer(hostDir, { type: "merge-to-head" })),
       ),
     );
 
-    expect(mockCreate).toHaveBeenCalledWith(hostDir, { name: undefined });
-    expect(mockRemove).toHaveBeenCalledWith(hostDir);
+    expect(observedWorktreePath).toBeDefined();
+    expect(observedWorktreePath).toContain(
+      join(hostDir, ".sandcastle", "worktrees"),
+    );
+    expect(existsSync(observedWorktreePath!)).toBe(false);
   });
 
   it("worktree mode: removes worktree when sandbox start fails", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
-    await initRepo(hostDir);
-    await commitFile(hostDir, "hello.txt", "hi", "initial");
-
-    mockCreate.mockReturnValue(
-      Effect.succeed({
-        path: hostDir,
-        branch: "sandcastle/20240101-000000",
-      }),
-    );
-    mockRemove.mockReturnValue(Effect.void);
-    mockPruneStale.mockReturnValue(Effect.void);
-    mockHasUncommittedChanges.mockReturnValue(Effect.succeed(false));
+    await initRepoWithCommit(hostDir);
 
     const failingProvider: NoSandboxProvider = {
       tag: "none",
@@ -1209,11 +1076,12 @@ describe("WorktreeDockerSandboxFactory — no-sandbox provider", () => {
       Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox((_, sandbox) => Effect.void);
+          yield* factory.withSandbox(() => Effect.void);
         }).pipe(Effect.provide(layer)),
       ),
     ).rejects.toThrow();
 
-    expect(mockRemove).toHaveBeenCalledWith(hostDir);
+    const worktree = await findCreatedWorktree(hostDir);
+    expect(worktree).toBeUndefined();
   });
 });

--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -17,6 +17,7 @@ import {
   type NoSandboxProvider,
 } from "./SandboxProvider.js";
 import { testIsolated } from "./sandboxes/test-isolated.js";
+import { testStubProvider } from "./sandboxes/test-shared.js";
 import { noSandbox } from "./sandboxes/no-sandbox.js";
 
 vi.mock("./WorktreeManager.js", () => ({
@@ -45,32 +46,18 @@ const mockHasUncommittedChanges = vi.mocked(
 /** Create a mock sandbox provider that records calls and delegates to a no-op handle. */
 const makeMockProvider = (): {
   provider: SandboxProvider;
-  createCalls: any[];
-  closeCalls: number;
+  createCalls: unknown[];
+  readonly closeCalls: number;
 } => {
-  const createCalls: any[] = [];
-  let closeCalls = 0;
-  const provider = createBindMountSandboxProvider({
+  const stub = testStubProvider({
     name: "test-provider",
-    create: async (options) => {
-      createCalls.push(options);
-      const handle: BindMountSandboxHandle = {
-        worktreePath: SANDBOX_REPO_DIR,
-        exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
-        copyFileIn: async () => {},
-        copyFileOut: async () => {},
-        close: async () => {
-          closeCalls++;
-        },
-      };
-      return handle;
-    },
+    worktreePath: SANDBOX_REPO_DIR,
   });
   return {
-    provider,
-    createCalls,
+    provider: stub.provider,
+    createCalls: stub.createCalls as unknown[],
     get closeCalls() {
-      return closeCalls;
+      return stub.closeCalls.count;
     },
   };
 };

--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -46,7 +46,7 @@ const mockHasUncommittedChanges = vi.mocked(
 /** Create a mock sandbox provider that records calls and delegates to a no-op handle. */
 const makeMockProvider = (): {
   provider: SandboxProvider;
-  createCalls: unknown[];
+  createCalls: any[];
   readonly closeCalls: number;
 } => {
   const stub = testStubProvider({
@@ -55,7 +55,7 @@ const makeMockProvider = (): {
   });
   return {
     provider: stub.provider,
-    createCalls: stub.createCalls as unknown[],
+    createCalls: stub.createCalls as any[],
     get closeCalls() {
       return stub.closeCalls.count;
     },

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -59,11 +59,6 @@ export interface SandboxService {
   ) => Effect.Effect<void, CopyError>;
 }
 
-export class Sandbox extends Context.Tag("Sandbox")<
-  Sandbox,
-  SandboxService
->() {}
-
 const getCopyIn = (
   handle: BindMountSandboxHandle | IsolatedSandboxHandle | NoSandboxHandle,
 ): SandboxService["copyIn"] => {
@@ -98,44 +93,42 @@ const getCopyIn = (
 };
 
 /**
- * Wrap a Promise-based sandbox handle into an Effect-based SandboxService layer.
+ * Wrap a Promise-based sandbox handle into an Effect-based SandboxService.
  * Delegates copyIn/copyFileOut to the handle when available.
  */
-export const makeSandboxLayerFromHandle = (
+export const makeSandboxFromHandle = (
   handle: BindMountSandboxHandle | IsolatedSandboxHandle | NoSandboxHandle,
-): Layer.Layer<Sandbox> =>
-  Layer.succeed(Sandbox, {
-    exec: (command, options) =>
-      Effect.tryPromise({
-        try: () => handle.exec(command, options),
-        catch: (e) =>
-          new ExecError({
-            command,
-            message: `exec failed: ${e instanceof Error ? e.message : String(e)}`,
-          }),
-      }),
-    copyIn: getCopyIn(handle),
-    copyFileOut:
-      "copyFileOut" in handle
-        ? (sandboxPath, hostPath) =>
-            Effect.tryPromise({
-              try: () =>
-                (
-                  handle as IsolatedSandboxHandle | BindMountSandboxHandle
-                ).copyFileOut(sandboxPath, hostPath),
-              catch: (e) =>
-                new CopyError({
-                  message: `copyFileOut failed: ${e instanceof Error ? e.message : String(e)}`,
-                }),
-            })
-        : () =>
-            Effect.fail(
+): SandboxService => ({
+  exec: (command, options) =>
+    Effect.tryPromise({
+      try: () => handle.exec(command, options),
+      catch: (e) =>
+        new ExecError({
+          command,
+          message: `exec failed: ${e instanceof Error ? e.message : String(e)}`,
+        }),
+    }),
+  copyIn: getCopyIn(handle),
+  copyFileOut:
+    "copyFileOut" in handle
+      ? (sandboxPath, hostPath) =>
+          Effect.tryPromise({
+            try: () =>
+              (
+                handle as IsolatedSandboxHandle | BindMountSandboxHandle
+              ).copyFileOut(sandboxPath, hostPath),
+            catch: (e) =>
               new CopyError({
-                message:
-                  "copyFileOut is not supported for this sandbox provider",
+                message: `copyFileOut failed: ${e instanceof Error ? e.message : String(e)}`,
               }),
-            ),
-  });
+          })
+      : () =>
+          Effect.fail(
+            new CopyError({
+              message: "copyFileOut is not supported for this sandbox provider",
+            }),
+          ),
+});
 
 /** The mount point inside the sandbox where the project worktree is bound. */
 export const SANDBOX_REPO_DIR = "/home/agent/workspace";
@@ -161,12 +154,11 @@ export class SandboxFactory extends Context.Tag("SandboxFactory")<
   SandboxFactory,
   {
     readonly withSandbox: <A, E, R>(
-      makeEffect: (info: SandboxInfo) => Effect.Effect<A, E, R | Sandbox>,
-    ) => Effect.Effect<
-      WithSandboxResult<A>,
-      E | SandboxError,
-      Exclude<R, Sandbox>
-    >;
+      makeEffect: (
+        info: SandboxInfo,
+        sandbox: SandboxService,
+      ) => Effect.Effect<A, E, R>,
+    ) => Effect.Effect<WithSandboxResult<A>, E | SandboxError, R>;
   }
 >() {}
 
@@ -342,12 +334,11 @@ export const WorktreeDockerSandboxFactory = {
 
       return {
         withSandbox: <A, E, R>(
-          makeEffect: (info: SandboxInfo) => Effect.Effect<A, E, R | Sandbox>,
-        ): Effect.Effect<
-          WithSandboxResult<A>,
-          E | SandboxError,
-          Exclude<R, Sandbox>
-        > => {
+          makeEffect: (
+            info: SandboxInfo,
+            sandbox: SandboxService,
+          ) => Effect.Effect<A, E, R>,
+        ): Effect.Effect<WithSandboxResult<A>, E | SandboxError, R> => {
           // No-sandbox providers: run directly on the host, no container or mounts.
           if (sandboxProvider.tag === "none") {
             let preservedPath: string | undefined;
@@ -371,15 +362,14 @@ export const WorktreeDockerSandboxFactory = {
                       env,
                       worktreeOrRepoPath: hostRepoDir,
                     }),
-                    ({ sandboxLayer, worktreePath, handle }) =>
-                      makeEffect({
-                        hostWorktreePath: hostRepoDir,
-                        sandboxRepoPath: worktreePath,
-                      }).pipe(Effect.provide(sandboxLayer)) as Effect.Effect<
-                        A,
-                        E | SandboxError,
-                        Exclude<R, Sandbox>
-                      >,
+                    ({ sandbox, worktreePath }) =>
+                      makeEffect(
+                        {
+                          hostWorktreePath: hostRepoDir,
+                          sandboxRepoPath: worktreePath,
+                        },
+                        sandbox,
+                      ) as Effect.Effect<A, E | SandboxError, R>,
                     ({ handle }) =>
                       Effect.tryPromise({
                         try: () => handle.close(),
@@ -431,11 +421,14 @@ export const WorktreeDockerSandboxFactory = {
                         env,
                         worktreeOrRepoPath: worktreeInfo.path,
                       }),
-                      ({ sandboxLayer, worktreePath }) =>
-                        makeEffect({
-                          hostWorktreePath: worktreeInfo.path,
-                          sandboxRepoPath: worktreePath,
-                        }).pipe(Effect.provide(sandboxLayer)),
+                      ({ sandbox, worktreePath }) =>
+                        makeEffect(
+                          {
+                            hostWorktreePath: worktreeInfo.path,
+                            sandboxRepoPath: worktreePath,
+                          },
+                          sandbox,
+                        ),
                       ({ handle }) =>
                         Effect.tryPromise({
                           try: () => handle.close(),
@@ -443,7 +436,7 @@ export const WorktreeDockerSandboxFactory = {
                         }).pipe(Effect.orDie),
                     ),
                   ),
-                ) as Effect.Effect<A, E | SandboxError, Exclude<R, Sandbox>>,
+                ) as Effect.Effect<A, E | SandboxError, R>,
               (worktreeInfo, exit) =>
                 cleanupWorktree(worktreeInfo.path, exit).pipe(
                   Effect.tap((p) => {
@@ -489,16 +482,19 @@ export const WorktreeDockerSandboxFactory = {
                         env,
                         copyPaths,
                       }),
-                      ({ sandboxLayer, worktreePath, handle }) =>
-                        makeEffect({
-                          hostWorktreePath: worktreeInfo.path,
-                          sandboxRepoPath: worktreePath,
-                          applyToHost: () =>
-                            syncOut(
-                              worktreeInfo.path,
-                              handle as IsolatedSandboxHandle,
-                            ),
-                        }).pipe(Effect.provide(sandboxLayer)),
+                      ({ sandbox, worktreePath, handle }) =>
+                        makeEffect(
+                          {
+                            hostWorktreePath: worktreeInfo.path,
+                            sandboxRepoPath: worktreePath,
+                            applyToHost: () =>
+                              syncOut(
+                                worktreeInfo.path,
+                                handle as IsolatedSandboxHandle,
+                              ),
+                          },
+                          sandbox,
+                        ),
                       ({ handle }) =>
                         Effect.tryPromise({
                           try: () => handle.close(),
@@ -506,7 +502,7 @@ export const WorktreeDockerSandboxFactory = {
                         }).pipe(Effect.orDie),
                     ),
                   ),
-                ) as Effect.Effect<A, E | SandboxError, Exclude<R, Sandbox>>,
+                ) as Effect.Effect<A, E | SandboxError, R>,
               (worktreeInfo, exit) =>
                 cleanupWorktree(worktreeInfo.path, exit).pipe(
                   Effect.tap((p) => {
@@ -568,16 +564,15 @@ export const WorktreeDockerSandboxFactory = {
                     repoDir: SANDBOX_REPO_DIR,
                   }),
                   // Use
-                  ({ sandboxLayer, worktreePath, handle }) =>
-                    makeEffect({
-                      hostWorktreePath: hostRepoDir,
-                      sandboxRepoPath: worktreePath,
-                      bindMountHandle: handle as BindMountSandboxHandle,
-                    }).pipe(Effect.provide(sandboxLayer)) as Effect.Effect<
-                      A,
-                      E | SandboxError,
-                      Exclude<R, Sandbox>
-                    >,
+                  ({ sandbox, worktreePath, handle }) =>
+                    makeEffect(
+                      {
+                        hostWorktreePath: hostRepoDir,
+                        sandboxRepoPath: worktreePath,
+                        bindMountHandle: handle as BindMountSandboxHandle,
+                      },
+                      sandbox,
+                    ) as Effect.Effect<A, E | SandboxError, R>,
                   // Release
                   ({ handle }) =>
                     Effect.tryPromise({
@@ -668,12 +663,15 @@ export const WorktreeDockerSandboxFactory = {
                       gitMounts,
                       repoDir: SANDBOX_REPO_DIR,
                     }),
-                    ({ sandboxLayer, worktreePath, handle }) =>
-                      makeEffect({
-                        hostWorktreePath: worktreeInfo.path,
-                        sandboxRepoPath: worktreePath,
-                        bindMountHandle: handle as BindMountSandboxHandle,
-                      }).pipe(Effect.provide(sandboxLayer)),
+                    ({ sandbox, worktreePath, handle }) =>
+                      makeEffect(
+                        {
+                          hostWorktreePath: worktreeInfo.path,
+                          sandboxRepoPath: worktreePath,
+                          bindMountHandle: handle as BindMountSandboxHandle,
+                        },
+                        sandbox,
+                      ),
                     ({ handle }) =>
                       Effect.tryPromise({
                         try: () => handle.close(),
@@ -681,7 +679,7 @@ export const WorktreeDockerSandboxFactory = {
                       }).pipe(Effect.orDie),
                   ),
                 ),
-              ) as Effect.Effect<A, E | SandboxError, Exclude<R, Sandbox>>,
+              ) as Effect.Effect<A, E | SandboxError, R>,
             // Release: remove or preserve the worktree based on dirty state.
             (worktreeInfo, exit) =>
               cleanupWorktree(worktreeInfo.path, exit).pipe(

--- a/src/SandboxLifecycle.test.ts
+++ b/src/SandboxLifecycle.test.ts
@@ -6,8 +6,8 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { type DisplayEntry, SilentDisplay } from "./Display.js";
-import { Sandbox, type SandboxService } from "./SandboxFactory.js";
-import { makeLocalSandboxLayer } from "./testSandbox.js";
+import { type SandboxService } from "./SandboxFactory.js";
+import { makeLocalSandbox } from "./testSandbox.js";
 import { ExecError, SyncError } from "./errors.js";
 import { withSandboxLifecycle, runHostHooks } from "./SandboxLifecycle.js";
 
@@ -19,14 +19,11 @@ import { withSandboxLifecycle, runHostHooks } from "./SandboxLifecycle.js";
 const makePathTranslatingSandbox = (
   hostPath: string,
   containerPath: string,
-  _baseLayer: Layer.Layer<Sandbox>,
 ): SandboxService => {
   const translateCwd = (cwd?: string) =>
     cwd === containerPath ? hostPath : cwd;
 
-  const baseSandbox = Effect.runSync(
-    Effect.provide(Sandbox, makeLocalSandboxLayer(hostPath)),
-  );
+  const baseSandbox = makeLocalSandbox(hostPath);
 
   return {
     exec: (command, options) =>
@@ -71,8 +68,8 @@ const setup = async () => {
   const hostDir = await mkdtemp(join(tmpdir(), "host-"));
   const sandboxDir = await mkdtemp(join(tmpdir(), "sandbox-"));
   const sandboxRepoDir = join(sandboxDir, "repo");
-  const layer = makeLocalSandboxLayer(sandboxDir);
-  return { hostDir, sandboxDir, sandboxRepoDir, layer };
+  const sandbox = makeLocalSandbox(sandboxDir);
+  return { hostDir, sandboxDir, sandboxRepoDir, sandbox };
 };
 
 describe("withSandboxLifecycle (worktree mode)", () => {
@@ -94,12 +91,12 @@ describe("withSandboxLifecycle (worktree mode)", () => {
       { cwd: hostDir },
     );
 
-    const layer = makeLocalSandboxLayer(worktreeDir);
-    return { hostDir, worktreeDir, layer };
+    const sandbox = makeLocalSandbox(worktreeDir);
+    return { hostDir, worktreeDir, sandbox };
   };
 
   it("skips sync-in — worktree files are already accessible", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     await Effect.runPromise(
       withSandboxLifecycle(
@@ -107,6 +104,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           hostRepoDir: hostDir,
           sandboxRepoDir: worktreeDir,
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             // Files from the host repo are already visible — no sync-in needed
@@ -115,12 +113,12 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             });
             expect(result.stdout.trim()).toBe("original");
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
   });
 
   it("commits in worktree are cherry-picked onto host's current branch", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     await Effect.runPromise(
       withSandboxLifecycle(
@@ -128,6 +126,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           hostRepoDir: hostDir,
           sandboxRepoDir: worktreeDir,
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             yield* ctx.sandbox.exec('git config user.email "test@test.com"', {
@@ -141,7 +140,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               { cwd: ctx.sandboxRepoDir },
             );
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // Commit is cherry-picked onto host's current branch (main)
@@ -156,7 +155,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("onSandboxReady hooks still run in worktree mode", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     await Effect.runPromise(
       withSandboxLifecycle(
@@ -170,6 +169,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             },
           },
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             const result = yield* ctx.sandbox.exec("cat ready-marker.txt", {
@@ -177,7 +177,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             });
             expect(result.stdout.trim()).toBe("ready");
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
   });
 
@@ -190,14 +190,14 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     }> = [];
 
     // Custom sandbox layer that records exec calls
-    const spySandboxLayer = Layer.succeed(Sandbox, {
+    const sandbox: SandboxService = {
       exec: (command, options) => {
         execCalls.push({ command, options });
         return Effect.succeed({ stdout: "", stderr: "", exitCode: 0 });
       },
       copyIn: () => Effect.succeed(undefined as never),
       copyFileOut: () => Effect.succeed(undefined as never),
-    });
+    };
 
     await Effect.runPromise(
       withSandboxLifecycle(
@@ -214,8 +214,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             },
           },
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(spySandboxLayer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // Find the hook exec calls (after git config calls)
@@ -241,7 +242,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     // Track the order of start/end events to verify parallel execution
     const events: string[] = [];
 
-    const spySandboxLayer = Layer.succeed(Sandbox, {
+    const sandbox: SandboxService = {
       exec: (command, options) => {
         if (command === "slow-hook-a" || command === "slow-hook-b") {
           events.push(`start:${command}`);
@@ -256,7 +257,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
       },
       copyIn: () => Effect.succeed(undefined as never),
       copyFileOut: () => Effect.succeed(undefined as never),
-    });
+    };
 
     await Effect.runPromise(
       withSandboxLifecycle(
@@ -273,8 +274,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             },
           },
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(spySandboxLayer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // With parallel execution, both hooks should start before either ends
@@ -287,7 +289,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("returns commits made in the worktree", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     const result = await Effect.runPromise(
       withSandboxLifecycle(
@@ -295,6 +297,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           hostRepoDir: hostDir,
           sandboxRepoDir: worktreeDir,
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             yield* ctx.sandbox.exec('git config user.email "test@test.com"', {
@@ -308,7 +311,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               { cwd: ctx.sandboxRepoDir },
             );
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     expect(result.commits).toHaveLength(1);
@@ -317,7 +320,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("returns empty commits when no work is done in worktree mode", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     const result = await Effect.runPromise(
       withSandboxLifecycle(
@@ -325,8 +328,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           hostRepoDir: hostDir,
           sandboxRepoDir: worktreeDir,
         },
+        sandbox,
         () => Effect.succeed("no-op"),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     expect(result.commits).toHaveLength(0);
@@ -334,7 +338,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("temp branch is deleted after cherry-pick", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     await Effect.runPromise(
       withSandboxLifecycle(
@@ -342,6 +346,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           hostRepoDir: hostDir,
           sandboxRepoDir: worktreeDir,
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             yield* ctx.sandbox.exec('git config user.email "test@test.com"', {
@@ -355,7 +360,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               { cwd: ctx.sandboxRepoDir },
             );
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // The temp branch should no longer exist
@@ -366,7 +371,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("temp branch is deleted even when no commits were made", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     await Effect.runPromise(
       withSandboxLifecycle(
@@ -374,8 +379,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           hostRepoDir: hostDir,
           sandboxRepoDir: worktreeDir,
         },
+        sandbox,
         () => Effect.succeed("no-op"),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // Temp branch deleted even with no commits
@@ -386,7 +392,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("preserves temp branch and throws on merge conflict", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     await expect(
       Effect.runPromise(
@@ -395,6 +401,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             hostRepoDir: hostDir,
             sandboxRepoDir: worktreeDir,
           },
+          sandbox,
           (ctx) =>
             Effect.gen(function* () {
               // Commit a change to file.txt in the worktree
@@ -416,7 +423,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
                 );
               });
             }),
-        ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+        ).pipe(Effect.provide(testDisplayLayer)),
       ),
     ).rejects.toThrow(/merge.*failed/i);
 
@@ -428,7 +435,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("succeeds with merge commit when host branch has diverged (non-conflicting)", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     await Effect.runPromise(
       withSandboxLifecycle(
@@ -436,6 +443,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           hostRepoDir: hostDir,
           sandboxRepoDir: worktreeDir,
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             yield* ctx.sandbox.exec('git config user.email "test@test.com"', {
@@ -457,7 +465,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               );
             });
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // Both files should exist on main after the merge
@@ -477,19 +485,10 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("cherry-pick works when sandboxRepoDir differs from host worktree path", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir } = await setupWorktree();
 
-    // Simulate a bind-mount provider: sandboxRepoDir is the container mount point,
-    // which differs from the actual host worktree path. In production the sandbox
-    // sees /home/agent/workspace while the host sees .sandcastle/worktrees/<name>.
-    //
-    // We use a PathTranslating sandbox that maps the container path to the real
-    // worktree path — exactly what a bind-mount provider does.
     const containerPath = "/home/agent/workspace";
-    const translatingLayer = Layer.succeed(
-      Sandbox,
-      makePathTranslatingSandbox(worktreeDir, containerPath, layer),
-    );
+    const sandbox = makePathTranslatingSandbox(worktreeDir, containerPath);
 
     const result = await Effect.runPromise(
       withSandboxLifecycle(
@@ -499,6 +498,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
 
           hostWorktreePath: worktreeDir,
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             yield* ctx.sandbox.exec('git config user.email "test@test.com"', {
@@ -512,7 +512,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               { cwd: ctx.sandboxRepoDir },
             );
           }),
-      ).pipe(Effect.provide(Layer.merge(translatingLayer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // Commit should be cherry-picked onto host's current branch (main)
@@ -532,7 +532,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("cherry-pick succeeds when worktree commits include a merge commit", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     const result = await Effect.runPromise(
       withSandboxLifecycle(
@@ -540,6 +540,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           hostRepoDir: hostDir,
           sandboxRepoDir: worktreeDir,
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             yield* ctx.sandbox.exec('git config user.email "test@test.com"', {
@@ -560,7 +561,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               { cwd: ctx.sandboxRepoDir },
             );
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // The feature commit should be cherry-picked onto main
@@ -580,7 +581,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     // git rev-list --no-merges walks into the merged branches and collects all original
     // commits, then cherry-picking them sequentially onto main fails because they
     // touch overlapping files from the same base.
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     const result = await Effect.runPromise(
       withSandboxLifecycle(
@@ -588,6 +589,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           hostRepoDir: hostDir,
           sandboxRepoDir: worktreeDir,
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             yield* ctx.sandbox.exec('git config user.email "test@test.com"', {
@@ -618,7 +620,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               { cwd: ctx.sandboxRepoDir },
             );
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // Both changes should be on the host's main branch
@@ -631,7 +633,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("sets host git user.name and user.email as global config in the sandbox", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     // setupWorktree sets user.email "test@test.com" and user.name "Test" locally in hostDir.
     // Verify these are propagated as --global config inside the sandbox.
@@ -643,6 +645,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           sandboxRepoDir: worktreeDir,
           branch: "sandcastle/test",
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             // Read the globally-set git config (--global) to confirm auto-propagation
@@ -657,7 +660,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               name: nameResult.stdout.trim(),
             };
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     expect(result.result.email).toBe("test@test.com");
@@ -665,7 +668,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("gracefully skips git identity propagation when host has no git config", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     // Unset local user config so git config user.name/email returns nothing
     await execAsync("git config --unset user.email", { cwd: hostDir }).catch(
@@ -683,14 +686,15 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             hostRepoDir: hostDir,
             sandboxRepoDir: worktreeDir,
           },
+          sandbox,
           () => Effect.succeed("ok"),
-        ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+        ).pipe(Effect.provide(testDisplayLayer)),
       ),
     ).resolves.toBeDefined();
   });
 
   it("no cherry-pick when explicit branch is given", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     const result = await Effect.runPromise(
       withSandboxLifecycle(
@@ -700,6 +704,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           // explicit branch — commits stay on that branch, no cherry-pick
           branch: "sandcastle/test",
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             yield* ctx.sandbox.exec('git config user.email "test@test.com"', {
@@ -713,7 +718,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               { cwd: ctx.sandboxRepoDir },
             );
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // Branch stays as the explicit branch
@@ -734,7 +739,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("calls applyToHost after work completes but before merge operations", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     const callOrder: string[] = [];
 
@@ -748,6 +753,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               callOrder.push("applyToHost");
             }) as Effect.Effect<void, SyncError>,
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             callOrder.push("work");
@@ -762,7 +768,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               { cwd: ctx.sandboxRepoDir },
             );
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // applyToHost should be called after work but before the merge
@@ -772,14 +778,11 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("records baseHead from the host worktree, not from inside the sandbox", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir } = await setupWorktree();
 
     // Use a container path that differs from the host worktree path
     const containerPath = "/home/agent/workspace";
-    const translatingLayer = Layer.succeed(
-      Sandbox,
-      makePathTranslatingSandbox(worktreeDir, containerPath, layer),
-    );
+    const sandbox = makePathTranslatingSandbox(worktreeDir, containerPath);
 
     let capturedBaseHead = "";
     await Effect.runPromise(
@@ -789,11 +792,12 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           sandboxRepoDir: containerPath,
           hostWorktreePath: worktreeDir,
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             capturedBaseHead = ctx.baseHead;
           }),
-      ).pipe(Effect.provide(Layer.merge(translatingLayer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // baseHead should match the host worktree HEAD, not some sandbox-internal value
@@ -802,7 +806,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("applyToHost error propagates as SyncError", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     await expect(
       Effect.runPromise(
@@ -813,14 +817,15 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             applyToHost: () =>
               Effect.fail(new SyncError({ message: "sync failed" })),
           },
+          sandbox,
           () => Effect.succeed("ok"),
-        ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+        ).pipe(Effect.provide(testDisplayLayer)),
       ),
     ).rejects.toThrow("sync failed");
   });
 
   it("logs 'No commits to sync out' when applyToHost is provided but no commits", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
     const displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]);
     const displayLayer = SilentDisplay.layer(displayRef);
 
@@ -833,10 +838,11 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             branch: "sandcastle/test",
             applyToHost: () => Effect.void,
           },
+          sandbox,
           () => Effect.succeed("ok"),
         );
         return yield* Ref.get(displayRef);
-      }).pipe(Effect.provide(Layer.merge(layer, displayLayer))),
+      }).pipe(Effect.provide(displayLayer)),
     );
 
     const syncLog = entries.find(
@@ -846,7 +852,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("logs 'Syncing N commits to host' when applyToHost is provided with commits", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
     const displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]);
     const displayLayer = SilentDisplay.layer(displayRef);
 
@@ -859,6 +865,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             branch: "sandcastle/test",
             applyToHost: () => Effect.void,
           },
+          sandbox,
           (ctx) =>
             Effect.gen(function* () {
               yield* ctx.sandbox.exec(
@@ -868,7 +875,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             }),
         );
         return yield* Ref.get(displayRef);
-      }).pipe(Effect.provide(Layer.merge(layer, displayLayer))),
+      }).pipe(Effect.provide(displayLayer)),
     );
 
     const syncLog = entries.find(
@@ -878,7 +885,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("does not log sync taskLog when applyToHost is not provided", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
     const displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]);
     const displayLayer = SilentDisplay.layer(displayRef);
 
@@ -890,10 +897,11 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             sandboxRepoDir: worktreeDir,
             branch: "sandcastle/test",
           },
+          sandbox,
           () => Effect.succeed("ok"),
         );
         return yield* Ref.get(displayRef);
-      }).pipe(Effect.provide(Layer.merge(layer, displayLayer))),
+      }).pipe(Effect.provide(displayLayer)),
     );
 
     const syncLog = entries.find(
@@ -905,7 +913,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("logs 'Merging to {branch}' taskLog in temp branch mode with commits", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
     const displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]);
     const displayLayer = SilentDisplay.layer(displayRef);
 
@@ -916,6 +924,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             hostRepoDir: hostDir,
             sandboxRepoDir: worktreeDir,
           },
+          sandbox,
           (ctx) =>
             Effect.gen(function* () {
               yield* ctx.sandbox.exec('git config user.email "test@test.com"', {
@@ -931,7 +940,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             }),
         );
         return yield* Ref.get(displayRef);
-      }).pipe(Effect.provide(Layer.merge(layer, displayLayer))),
+      }).pipe(Effect.provide(displayLayer)),
     );
 
     const mergeLog = entries.find(
@@ -941,7 +950,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("logs 'Collecting commits' taskLog after agent work", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
     const displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]);
     const displayLayer = SilentDisplay.layer(displayRef);
 
@@ -953,10 +962,11 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             sandboxRepoDir: worktreeDir,
             branch: "sandcastle/test",
           },
+          sandbox,
           () => Effect.succeed("ok"),
         );
         return yield* Ref.get(displayRef);
-      }).pipe(Effect.provide(Layer.merge(layer, displayLayer))),
+      }).pipe(Effect.provide(displayLayer)),
     );
 
     const commitLog = entries.find(
@@ -966,7 +976,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("host.onSandboxReady hooks run on the host with worktree cwd", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     await Effect.runPromise(
       withSandboxLifecycle(
@@ -982,8 +992,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             },
           },
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // The marker should exist on the host worktree (cwd = worktreeDir)
@@ -995,7 +1006,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("host.onSandboxReady and sandbox.onSandboxReady run in parallel", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     await Effect.runPromise(
       withSandboxLifecycle(
@@ -1014,8 +1025,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             },
           },
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     // Both markers should exist
@@ -1033,7 +1045,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("host.onSandboxReady hook is killed when signal fires", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
     const ac = new AbortController();
 
     const promise = Effect.runPromise(
@@ -1049,8 +1061,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             },
           },
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     setTimeout(() => ac.abort("cancelled"), 50);
@@ -1058,7 +1071,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("sandbox.onSandboxReady hook is killed when signal fires", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
     const ac = new AbortController();
 
     const promise = Effect.runPromise(
@@ -1074,8 +1087,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             },
           },
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     setTimeout(() => ac.abort("cancelled"), 50);
@@ -1083,7 +1097,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("hooks receive never-aborted signal when no signal is provided", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     // Should work normally — hooks complete without issues
     await Effect.runPromise(
@@ -1103,8 +1117,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             },
           },
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     const content = await readFile(
@@ -1115,7 +1130,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("host.onSandboxReady hook failure propagates error", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     await expect(
       Effect.runPromise(
@@ -1130,8 +1145,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               },
             },
           },
+          sandbox,
           () => Effect.succeed("ok"),
-        ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+        ).pipe(Effect.provide(testDisplayLayer)),
       ),
     ).rejects.toThrow(/Host hook failed/);
   });
@@ -1139,7 +1155,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   it("sandbox.onSandboxReady respects per-hook timeoutMs", async () => {
     const { hostDir, worktreeDir } = await setupWorktree();
 
-    const spySandboxLayer = Layer.succeed(Sandbox, {
+    const sandbox: SandboxService = {
       exec: (command, _options) => {
         if (command === "slow-install") {
           // Simulate a command that takes longer than the short timeout
@@ -1152,7 +1168,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
       },
       copyIn: () => Effect.succeed(undefined as never),
       copyFileOut: () => Effect.succeed(undefined as never),
-    });
+    };
 
     const result = Effect.runPromise(
       withSandboxLifecycle(
@@ -1166,15 +1182,16 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             },
           },
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(spySandboxLayer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     await expect(result).rejects.toThrow(/timed out/);
   });
 
   it("host.onSandboxReady respects per-hook timeoutMs", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     const result = Effect.runPromise(
       withSandboxLifecycle(
@@ -1188,15 +1205,16 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             },
           },
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     await expect(result).rejects.toThrow(/timed out/);
   });
 
   it("sandbox.onSandboxReady uses default timeout when timeoutMs omitted", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     // A fast hook with no timeoutMs should succeed with the default 60s timeout
     await Effect.runPromise(
@@ -1211,6 +1229,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             },
           },
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             const result = yield* ctx.sandbox.exec("cat dt.txt", {
@@ -1218,7 +1237,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             });
             expect(result.stdout.trim()).toBe("default-timeout");
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
   });
 
@@ -1230,7 +1249,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     // (overlayfs/exec race seen under heavy parallelism), then succeeds.
     // Effect.sync defers per-run so retries re-evaluate, matching how the
     // real exec (Effect.tryPromise) re-invokes the SDK on each attempt.
-    const flakySandboxLayer = Layer.succeed(Sandbox, {
+    const sandbox: SandboxService = {
       exec: (command, _options) =>
         Effect.sync(() => {
           if (command.includes("safe.directory")) {
@@ -1243,7 +1262,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
         }),
       copyIn: () => Effect.succeed(undefined as never),
       copyFileOut: () => Effect.succeed(undefined as never),
-    });
+    };
 
     const result = await Effect.runPromise(
       withSandboxLifecycle(
@@ -1252,8 +1271,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           sandboxRepoDir: worktreeDir,
           branch: "sandcastle/test",
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(flakySandboxLayer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     expect(safeDirAttempts).toBe(2);
@@ -1264,7 +1284,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     const { hostDir, worktreeDir } = await setupWorktree();
 
     let safeDirAttempts = 0;
-    const failingSandboxLayer = Layer.succeed(Sandbox, {
+    const sandbox: SandboxService = {
       exec: (command, _options) =>
         Effect.sync(() => {
           if (command.includes("safe.directory")) {
@@ -1275,7 +1295,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
         }),
       copyIn: () => Effect.succeed(undefined as never),
       copyFileOut: () => Effect.succeed(undefined as never),
-    });
+    };
 
     await expect(
       Effect.runPromise(
@@ -1285,10 +1305,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             sandboxRepoDir: worktreeDir,
             branch: "sandcastle/test",
           },
+          sandbox,
           () => Effect.succeed("ok"),
-        ).pipe(
-          Effect.provide(Layer.merge(failingSandboxLayer, testDisplayLayer)),
-        ),
+        ).pipe(Effect.provide(testDisplayLayer)),
       ),
     ).rejects.toThrow(/exit 1/);
 
@@ -1301,7 +1320,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     // The git safe.directory setup command takes longer than the short
     // gitSetupMs override, so it should time out rather than succeed under
     // the default 10s timeout.
-    const slowGitSetupLayer = Layer.succeed(Sandbox, {
+    const sandbox: SandboxService = {
       exec: (command, _options) => {
         if (command.includes("safe.directory")) {
           return Effect.gen(function* () {
@@ -1313,7 +1332,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
       },
       copyIn: () => Effect.succeed(undefined as never),
       copyFileOut: () => Effect.succeed(undefined as never),
-    });
+    };
 
     const result = Effect.runPromise(
       withSandboxLifecycle(
@@ -1323,15 +1342,16 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           branch: "sandcastle/test",
           timeouts: { gitSetupMs: 300 },
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(slowGitSetupLayer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     await expect(result).rejects.toThrow(/Git command timed out after 300ms/);
   });
 
   it("respects a commitCollectionMs timeout override", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     // A 1ms budget cannot outrun spawning the `git rev-list` process, so
     // commit collection should time out under the override (default is 30s).
@@ -1343,8 +1363,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           branch: "sandcastle/test",
           timeouts: { commitCollectionMs: 1 },
         },
+        sandbox,
         () => Effect.succeed("ok"),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     await expect(result).rejects.toThrow(
@@ -1353,7 +1374,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
   });
 
   it("respects a mergeToHostMs timeout override", async () => {
-    const { hostDir, worktreeDir, layer } = await setupWorktree();
+    const { hostDir, worktreeDir, sandbox } = await setupWorktree();
 
     // Merge-to-head path (no explicit branch) with a real commit, so the
     // host-side merge runs and times out under the 1ms override (default 30s).
@@ -1364,6 +1385,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
           sandboxRepoDir: worktreeDir,
           timeouts: { mergeToHostMs: 1 },
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             yield* ctx.sandbox.exec('git config user.email "test@test.com"', {
@@ -1377,7 +1399,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
               { cwd: ctx.sandboxRepoDir },
             );
           }),
-      ).pipe(Effect.provide(Layer.merge(layer, testDisplayLayer))),
+      ).pipe(Effect.provide(testDisplayLayer)),
     );
 
     await expect(result).rejects.toThrow(/timed out after 1ms/);
@@ -1387,7 +1409,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
     const { hostDir, worktreeDir } = await setupWorktree();
 
     let safeDirAttempts = 0;
-    const alwaysFlakyLayer = Layer.succeed(Sandbox, {
+    const sandbox: SandboxService = {
       exec: (command, _options) =>
         Effect.sync(() => {
           if (command.includes("safe.directory")) {
@@ -1398,7 +1420,7 @@ describe("withSandboxLifecycle (worktree mode)", () => {
         }),
       copyIn: () => Effect.succeed(undefined as never),
       copyFileOut: () => Effect.succeed(undefined as never),
-    });
+    };
 
     await expect(
       Effect.runPromise(
@@ -1408,8 +1430,9 @@ describe("withSandboxLifecycle (worktree mode)", () => {
             sandboxRepoDir: worktreeDir,
             branch: "sandcastle/test",
           },
+          sandbox,
           () => Effect.succeed("ok"),
-        ).pipe(Effect.provide(Layer.merge(alwaysFlakyLayer, testDisplayLayer))),
+        ).pipe(Effect.provide(testDisplayLayer)),
       ),
     ).rejects.toThrow(/exit 126/);
 

--- a/src/SandboxLifecycle.ts
+++ b/src/SandboxLifecycle.ts
@@ -12,11 +12,7 @@ import {
   withTimeout,
   type SandboxError,
 } from "./errors.js";
-import {
-  Sandbox,
-  type ExecResult,
-  type SandboxService,
-} from "./SandboxFactory.js";
+import { type ExecResult, type SandboxService } from "./SandboxFactory.js";
 import type { Timeouts } from "./run.js";
 
 const GIT_SETUP_TIMEOUT_MS = 10_000;
@@ -176,12 +172,10 @@ export interface SandboxLifecycleResult<A> {
 
 export const withSandboxLifecycle = <A>(
   options: SandboxLifecycleOptions,
-  work: (
-    ctx: SandboxContext,
-  ) => Effect.Effect<A, SandboxError, Sandbox | Display>,
-): Effect.Effect<SandboxLifecycleResult<A>, SandboxError, Sandbox | Display> =>
+  sandbox: SandboxService,
+  work: (ctx: SandboxContext) => Effect.Effect<A, SandboxError, Display>,
+): Effect.Effect<SandboxLifecycleResult<A>, SandboxError, Display> =>
   Effect.gen(function* () {
-    const sandbox = yield* Sandbox;
     const display = yield* Display;
     const { hostRepoDir, sandboxRepoDir, hooks, branch, hostWorktreePath } =
       options;

--- a/src/SessionStore.test.ts
+++ b/src/SessionStore.test.ts
@@ -1,46 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
-  type SessionStore,
   encodeProjectPath,
   findClaudeSessionOnHost,
   findCodexSessionOnHost,
-  hostSessionStore,
-  sandboxSessionStore,
+  locateCodexHostSession,
   transferClaudeSession,
-  codexHostSessionStore,
   transferCodexSession,
 } from "./SessionStore.js";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { BindMountSandboxHandle } from "./SandboxProvider.js";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** In-memory SessionStore for testing transferClaudeSession without filesystem. */
-const createMemoryStore = (
-  cwd: string,
-  initial?: Record<string, string>,
-): SessionStore & { data: Map<string, string> } => {
-  const data = new Map<string, string>(initial ? Object.entries(initial) : []);
-  return {
-    cwd,
-    data,
-    sessionFilePath: (id: string): string => `${cwd}/sessions/${id}.jsonl`,
-    exists: async (id: string): Promise<boolean> => data.has(id),
-    readSession: async (id: string): Promise<string> => {
-      const content = data.get(id);
-      if (content === undefined)
-        throw new Error(`session ${id} not found in memory store`);
-      return content;
-    },
-    writeSession: async (id: string, content: string): Promise<void> => {
-      data.set(id, content);
-    },
-  };
-};
 
 // ---------------------------------------------------------------------------
 // encodeProjectPath
@@ -65,7 +34,6 @@ describe("encodeProjectPath", () => {
     expect(encodeProjectPath("/home/user/")).toBe("-home-user");
   });
 
-  // Windows-style paths
   it("encodes Windows path with backslashes and drive letter", () => {
     expect(encodeProjectPath("D:\\projektit\\super-app")).toBe(
       "D-projektit-super-app",
@@ -92,11 +60,11 @@ describe("encodeProjectPath", () => {
 });
 
 // ---------------------------------------------------------------------------
-// transferClaudeSession — cwd rewriting
+// transferClaudeSession — pure cwd rewriting
 // ---------------------------------------------------------------------------
 
 describe("transferClaudeSession", () => {
-  it("rewrites cwd fields in JSONL entries from source cwd to target cwd", async () => {
+  it("rewrites cwd fields in JSONL entries from source cwd to target cwd", () => {
     const jsonl = [
       JSON.stringify({ type: "system", cwd: "/sandbox/worktree" }),
       JSON.stringify({ type: "message", content: "hello" }),
@@ -107,19 +75,17 @@ describe("transferClaudeSession", () => {
       }),
     ].join("\n");
 
-    const source = createMemoryStore("/sandbox/worktree", { sess123: jsonl });
-    const target = createMemoryStore("/home/user/repos/project");
-
-    await transferClaudeSession(source, target, "sess123");
-
-    const written = target.data.get("sess123")!;
+    const written = transferClaudeSession(
+      jsonl,
+      "/sandbox/worktree",
+      "/home/user/repos/project",
+    );
     const lines = written.split("\n");
 
     expect(JSON.parse(lines[0]!)).toEqual({
       type: "system",
       cwd: "/home/user/repos/project",
     });
-    // Line without cwd should be unchanged
     expect(JSON.parse(lines[1]!)).toEqual({
       type: "message",
       content: "hello",
@@ -131,18 +97,7 @@ describe("transferClaudeSession", () => {
     });
   });
 
-  it("preserves session ID key through transfer", async () => {
-    const jsonl = JSON.stringify({ type: "init", cwd: "/a" });
-    const source = createMemoryStore("/a", { "my-session-id": jsonl });
-    const target = createMemoryStore("/b");
-
-    await transferClaudeSession(source, target, "my-session-id");
-
-    expect(target.data.has("my-session-id")).toBe(true);
-    expect(target.data.has("sess123")).toBe(false);
-  });
-
-  it("round-trips bytes through transfer for entries without cwd", async () => {
+  it("round-trips bytes for entries without cwd", () => {
     const jsonl = [
       JSON.stringify({ type: "message", content: "hello world" }),
       JSON.stringify({
@@ -151,134 +106,53 @@ describe("transferClaudeSession", () => {
       }),
     ].join("\n");
 
-    const source = createMemoryStore("/src", { s1: jsonl });
-    const target = createMemoryStore("/dst");
-
-    await transferClaudeSession(source, target, "s1");
-
-    expect(target.data.get("s1")).toBe(jsonl);
+    expect(transferClaudeSession(jsonl, "/src", "/dst")).toBe(jsonl);
   });
 
-  it("handles empty JSONL", async () => {
-    const source = createMemoryStore("/a", { s1: "" });
-    const target = createMemoryStore("/b");
-
-    await transferClaudeSession(source, target, "s1");
-
-    expect(target.data.get("s1")).toBe("");
+  it("handles empty JSONL", () => {
+    expect(transferClaudeSession("", "/a", "/b")).toBe("");
   });
 
-  it("only rewrites cwd fields that match source cwd exactly", async () => {
+  it("only rewrites cwd fields that match source cwd exactly", () => {
     const jsonl = [
       JSON.stringify({ type: "a", cwd: "/sandbox/worktree" }),
       JSON.stringify({ type: "b", cwd: "/other/path" }),
     ].join("\n");
 
-    const source = createMemoryStore("/sandbox/worktree", { s1: jsonl });
-    const target = createMemoryStore("/host/repo");
-
-    await transferClaudeSession(source, target, "s1");
-
-    const lines = target.data.get("s1")!.split("\n");
+    const out = transferClaudeSession(jsonl, "/sandbox/worktree", "/host/repo");
+    const lines = out.split("\n");
     expect(JSON.parse(lines[0]!).cwd).toBe("/host/repo");
-    // Non-matching cwd should remain unchanged
     expect(JSON.parse(lines[1]!).cwd).toBe("/other/path");
   });
+});
 
-  it("throws when session ID does not exist in source", async () => {
-    const source = createMemoryStore("/a");
-    const target = createMemoryStore("/b");
+// ---------------------------------------------------------------------------
+// transferCodexSession — pure cwd rewriting on session_meta payload
+// ---------------------------------------------------------------------------
 
-    await expect(
-      transferClaudeSession(source, target, "missing"),
-    ).rejects.toThrow("session missing not found");
+describe("transferCodexSession", () => {
+  it("rewrites cwd in session_meta payload and top-level cwd fields", () => {
+    const jsonl = [
+      JSON.stringify({
+        type: "session_meta",
+        payload: { id: "abc", cwd: "/sandbox/repo" },
+      }),
+      JSON.stringify({ type: "turn_context", cwd: "/sandbox/repo" }),
+    ].join("\n");
+
+    const out = transferCodexSession(jsonl, "/sandbox/repo", "/host/repo");
+    const lines = out.split("\n");
+    expect(JSON.parse(lines[0]!).payload.cwd).toBe("/host/repo");
+    expect(JSON.parse(lines[1]!).cwd).toBe("/host/repo");
+  });
+
+  it("handles empty JSONL", () => {
+    expect(transferCodexSession("", "/a", "/b")).toBe("");
   });
 });
 
 // ---------------------------------------------------------------------------
-// hostSessionStore — path encoding and filesystem
-// ---------------------------------------------------------------------------
-
-describe("hostSessionStore", () => {
-  let tempDir: string;
-
-  const setup = async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "sandcastle-session-test-"));
-    return tempDir;
-  };
-
-  const teardown = async () => {
-    await rm(tempDir, { recursive: true, force: true });
-  };
-
-  it("writes session to encoded project path", async () => {
-    const dir = await setup();
-    try {
-      const store = hostSessionStore("/home/user/project", dir);
-      await store.writeSession(
-        "sess-1",
-        JSON.stringify({ type: "init", cwd: "/home/user/project" }),
-      );
-
-      const encoded = encodeProjectPath("/home/user/project");
-      const filePath = join(dir, encoded, "sess-1.jsonl");
-      const content = await readFile(filePath, "utf-8");
-      expect(content).toContain("init");
-    } finally {
-      await teardown();
-    }
-  });
-
-  it("reads back a written session", async () => {
-    const dir = await setup();
-    try {
-      const store = hostSessionStore("/my/repo", dir);
-      const jsonl = JSON.stringify({ type: "system", cwd: "/my/repo" });
-
-      await store.writeSession("s1", jsonl);
-      const result = await store.readSession("s1");
-
-      expect(result).toBe(jsonl);
-    } finally {
-      await teardown();
-    }
-  });
-
-  it("throws on read of non-existent session", async () => {
-    const dir = await setup();
-    try {
-      const store = hostSessionStore("/my/repo", dir);
-      await expect(store.readSession("nope")).rejects.toThrow();
-    } finally {
-      await teardown();
-    }
-  });
-
-  it("uses cwd as the store cwd", async () => {
-    const dir = await setup();
-    try {
-      const store = hostSessionStore("/my/repo", dir);
-      expect(store.cwd).toBe("/my/repo");
-    } finally {
-      await teardown();
-    }
-  });
-
-  it("reports whether a session exists", async () => {
-    const dir = await setup();
-    try {
-      const store = hostSessionStore("/my/repo", dir);
-      expect(await store.exists("s1")).toBe(false);
-      await store.writeSession("s1", "{}");
-      expect(await store.exists("s1")).toBe(true);
-    } finally {
-      await teardown();
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// findClaudeSessionOnHost — locate by id across encoded project dirs
+// findClaudeSessionOnHost
 // ---------------------------------------------------------------------------
 
 describe("findClaudeSessionOnHost", () => {
@@ -286,8 +160,6 @@ describe("findClaudeSessionOnHost", () => {
     const dir = await mkdtemp(join(tmpdir(), "sandcastle-find-claude-"));
     try {
       const id = "session-xyz";
-      // A directory name that no host-repo-dir encoding would reconstruct
-      // (mimics a realpath'd worktree path with `.`→`-` applied by the agent).
       const projectDir = join(
         dir,
         "-private-tmp-myrepo--sandcastle-worktrees-feature",
@@ -325,7 +197,7 @@ describe("findClaudeSessionOnHost", () => {
 });
 
 // ---------------------------------------------------------------------------
-// findCodexSessionOnHost — locate rollout file by id
+// findCodexSessionOnHost & locateCodexHostSession
 // ---------------------------------------------------------------------------
 
 describe("findCodexSessionOnHost", () => {
@@ -364,38 +236,9 @@ describe("findCodexSessionOnHost", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// codexHostSessionStore — date-nested rollout files
-// ---------------------------------------------------------------------------
-
-describe("codexHostSessionStore", () => {
-  it("locates sessions by rollout filename suffix", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "sandcastle-codex-store-"));
-    try {
-      const id = "9ba1c695-2222-4444-8888-e7e847bf34dd";
-      const sessionPath = join(
-        dir,
-        "2026",
-        "05",
-        "26",
-        `rollout-2026-05-26T08-00-00-${id}.jsonl`,
-      );
-      await mkdir(join(sessionPath, ".."), { recursive: true });
-      await writeFile(sessionPath, JSON.stringify({ type: "session_meta" }));
-
-      const store = codexHostSessionStore("/repo", dir);
-
-      expect(await store.exists(id)).toBe(true);
-      expect(await store.readSession(id)).toContain("session_meta");
-      expect(store.sessionFilePath(id)).toBe(sessionPath);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("transfers sessions while preserving relative date path and rewriting session_meta cwd", async () => {
-    const sourceDir = await mkdtemp(join(tmpdir(), "sandcastle-codex-src-"));
-    const targetDir = await mkdtemp(join(tmpdir(), "sandcastle-codex-dst-"));
+describe("locateCodexHostSession", () => {
+  it("returns absolute path and relative date-nested path", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sandcastle-locate-codex-"));
     try {
       const id = "9ba1c695-2222-4444-8888-e7e847bf34dd";
       const relativePath = join(
@@ -404,200 +247,16 @@ describe("codexHostSessionStore", () => {
         "26",
         `rollout-2026-05-26T08-00-00-${id}.jsonl`,
       );
-      const sourcePath = join(sourceDir, relativePath);
-      await mkdir(join(sourcePath, ".."), { recursive: true });
-      await writeFile(
-        sourcePath,
-        [
-          JSON.stringify({
-            type: "session_meta",
-            payload: { id, cwd: "/sandbox/repo" },
-          }),
-          JSON.stringify({ type: "turn_context", cwd: "/sandbox/repo" }),
-        ].join("\n"),
-      );
+      const sessionPath = join(dir, relativePath);
+      await mkdir(join(sessionPath, ".."), { recursive: true });
+      await writeFile(sessionPath, "{}");
 
-      const source = codexHostSessionStore("/sandbox/repo", sourceDir);
-      const target = codexHostSessionStore("/host/repo", targetDir);
+      const result = await locateCodexHostSession(id, dir);
 
-      await transferCodexSession(source, target, id);
-
-      const targetPath = join(targetDir, relativePath);
-      const lines = (await readFile(targetPath, "utf-8")).split("\n");
-      expect(JSON.parse(lines[0]!).payload.cwd).toBe("/host/repo");
-      expect(JSON.parse(lines[1]!).cwd).toBe("/host/repo");
-      expect(target.sessionFilePath(id)).toBe(targetPath);
+      expect(result.path).toBe(sessionPath);
+      expect(result.relativePath).toBe(relativePath);
     } finally {
-      await rm(sourceDir, { recursive: true, force: true });
-      await rm(targetDir, { recursive: true, force: true });
+      await rm(dir, { recursive: true, force: true });
     }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// sandboxSessionStore — uses bind-mount handle
-// ---------------------------------------------------------------------------
-
-describe("sandboxSessionStore", () => {
-  it("uses copyFileOut for readSession", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "sandcastle-sbx-store-"));
-    try {
-      const jsonl = JSON.stringify({ type: "init", cwd: "/workspace" });
-
-      // Write a file to the "sandbox" location to simulate copyFileOut reading it
-      const sandboxCwd = "/workspace";
-      const encoded = encodeProjectPath(sandboxCwd);
-      const sandboxProjectDir = join(tempDir, ".claude", "projects", encoded);
-      await mkdir(sandboxProjectDir, { recursive: true });
-      await writeFile(join(sandboxProjectDir, "s1.jsonl"), jsonl);
-
-      const copyFileOutCalls: Array<{ from: string; to: string }> = [];
-
-      const handle: Pick<
-        BindMountSandboxHandle,
-        "copyFileIn" | "copyFileOut" | "exec"
-      > = {
-        copyFileIn: async () => {},
-        copyFileOut: async (sandboxPath: string, hostPath: string) => {
-          copyFileOutCalls.push({ from: sandboxPath, to: hostPath });
-          // Simulate actual copy for the read to work
-          const content = await readFile(sandboxPath, "utf-8");
-          await mkdir(join(hostPath, ".."), { recursive: true });
-          await writeFile(hostPath, content);
-        },
-        exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
-      };
-
-      const store = sandboxSessionStore(
-        sandboxCwd,
-        handle as BindMountSandboxHandle,
-        join(tempDir, ".claude", "projects"),
-      );
-
-      const result = await store.readSession("s1");
-
-      expect(copyFileOutCalls.length).toBe(1);
-      expect(copyFileOutCalls[0]!.from).toContain("s1.jsonl");
-      expect(result).toBe(jsonl);
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it("uses copyFileIn for writeSession", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "sandcastle-sbx-store-"));
-    try {
-      const jsonl = JSON.stringify({ type: "init" });
-
-      const copyFileInCalls: Array<{ from: string; to: string }> = [];
-
-      const handle: Pick<
-        BindMountSandboxHandle,
-        "copyFileIn" | "copyFileOut" | "exec"
-      > = {
-        copyFileIn: async (hostPath: string, sandboxPath: string) => {
-          copyFileInCalls.push({ from: hostPath, to: sandboxPath });
-        },
-        copyFileOut: async () => {},
-        exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
-      };
-
-      const sandboxCwd = "/workspace";
-      const store = sandboxSessionStore(
-        sandboxCwd,
-        handle as BindMountSandboxHandle,
-        join(tempDir, ".claude", "projects"),
-      );
-
-      await store.writeSession("s2", jsonl);
-
-      expect(copyFileInCalls.length).toBe(1);
-      expect(copyFileInCalls[0]!.to).toContain("s2.jsonl");
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it("stages host-side temp files outside the sandbox projectsDir", async () => {
-    // projectsDir is a sandbox-only path that does not exist on the host.
-    // copyFileOut receives (sandboxPath, hostTmpPath); the hostTmpPath must be
-    // writable on the host — i.e. not under the sandbox-only projectsDir.
-    const sandboxOnlyProjectsDir = "/nonexistent-on-host/.claude/projects";
-    const sessionContent = JSON.stringify({ type: "init" });
-
-    const handle: Pick<
-      BindMountSandboxHandle,
-      "copyFileIn" | "copyFileOut" | "exec"
-    > = {
-      copyFileIn: async (hostPath: string) => {
-        // Must be able to read from the host tmp path.
-        await readFile(hostPath, "utf-8");
-      },
-      copyFileOut: async (_sandboxPath: string, hostPath: string) => {
-        // Must be able to write to the host tmp path.
-        await writeFile(hostPath, sessionContent);
-      },
-      exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
-    };
-
-    const store = sandboxSessionStore(
-      "/workspace",
-      handle as BindMountSandboxHandle,
-      sandboxOnlyProjectsDir,
-    );
-
-    await expect(store.readSession("s1")).resolves.toBe(sessionContent);
-    await expect(store.writeSession("s2", "x")).resolves.toBeUndefined();
-  });
-
-  it("mkdirs the sandbox project directory before copyFileIn on writeSession", async () => {
-    // Regression: docker/podman `cp` require the destination's parent directory
-    // to exist. Fresh sandboxes don't have ~/.claude/projects/<encoded>/ yet,
-    // so writeSession must create it before copying the file in.
-    const calls: string[] = [];
-
-    const handle: Pick<
-      BindMountSandboxHandle,
-      "copyFileIn" | "copyFileOut" | "exec"
-    > = {
-      copyFileIn: async () => {
-        calls.push("copyFileIn");
-      },
-      copyFileOut: async () => {},
-      exec: async (command: string) => {
-        calls.push(`exec:${command}`);
-        return { stdout: "", stderr: "", exitCode: 0 };
-      },
-    };
-
-    const store = sandboxSessionStore(
-      "/home/agent/workspace",
-      handle as BindMountSandboxHandle,
-      "/home/agent/.claude/projects",
-    );
-
-    await store.writeSession("s1", "{}");
-
-    expect(calls.length).toBe(2);
-    expect(calls[0]).toMatch(/^exec:mkdir -p /);
-    expect(calls[0]).toContain(
-      "/home/agent/.claude/projects/-home-agent-workspace",
-    );
-    expect(calls[1]).toBe("copyFileIn");
-  });
-
-  it("exposes cwd", () => {
-    const handle = {
-      copyFileIn: async () => {},
-      copyFileOut: async () => {},
-      exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
-    } as unknown as BindMountSandboxHandle;
-
-    const store = sandboxSessionStore(
-      "/sandbox/work",
-      handle,
-      "/tmp/.claude/projects",
-    );
-    expect(store.cwd).toBe("/sandbox/work");
   });
 });

--- a/src/SessionStore.ts
+++ b/src/SessionStore.ts
@@ -1,29 +1,19 @@
 /**
- * SessionStore — keyed collection of agent session JSONLs.
+ * Session JSONL transfer primitives.
  *
- * Provides read/write access to agent session files, with host-backed
- * (filesystem) and sandbox-backed (via bind-mount handle file-transfer
- * primitives) implementations. Per ADR 0012, the per-provider `transfer`
- * op (e.g. `transferClaudeSession`, `transferCodexSession`) copies a session
- * between stores and applies any format-specific content rewriting — for
- * JSONL agents, rewriting `cwd` fields from source cwd to target cwd via the
- * shared `rewriteSessionCwd` primitive.
+ * The transfer functions are pure: they take a JSONL string and the source/
+ * target cwds, and return the rewritten JSONL string. Call sites do their own
+ * file I/O (reading the source, writing the destination). Per ADR 0012, the
+ * cwd rewrite is specific to each agent's JSONL format, so each agent owns
+ * its own transfer function.
  */
 
-import {
-  access,
-  mkdir,
-  readdir,
-  readFile,
-  rm,
-  writeFile,
-} from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join, posix, relative } from "node:path";
+import { access, readdir } from "node:fs/promises";
+import { join, posix, relative } from "node:path";
 import type { BindMountSandboxHandle } from "./SandboxProvider.js";
 
 // ---------------------------------------------------------------------------
-// SessionStore interface
+// Host session lookup
 // ---------------------------------------------------------------------------
 
 /**
@@ -39,20 +29,6 @@ export interface HostSessionLookup {
   readonly searchedRoot: string;
 }
 
-/** A keyed collection of agent session JSONLs associated with a cwd. */
-export interface SessionStore {
-  /** The working directory this store is associated with. */
-  readonly cwd: string;
-  /** Whether a session exists in this store. */
-  exists(id: string): Promise<boolean>;
-  /** Absolute path where a session is stored, when the store is file-backed and locatable. */
-  sessionFilePath(id: string): string | undefined;
-  /** Read a session's JSONL content by ID. Throws if not found. */
-  readSession(id: string): Promise<string>;
-  /** Write a session's JSONL content by ID. Creates or overwrites. */
-  writeSession(id: string, content: string): Promise<void>;
-}
-
 const pathExists = async (path: string): Promise<boolean> => {
   try {
     await access(path);
@@ -63,7 +39,7 @@ const pathExists = async (path: string): Promise<boolean> => {
 };
 
 // ---------------------------------------------------------------------------
-// Path encoding
+// Claude Code session paths and transfer
 // ---------------------------------------------------------------------------
 
 /**
@@ -76,50 +52,28 @@ export const encodeProjectPath = (cwd: string): string => {
   return normalized.replace(/^([A-Za-z]):/, "$1").replace(/[\\/]/g, "-");
 };
 
-// ---------------------------------------------------------------------------
-// Host-backed SessionStore
-// ---------------------------------------------------------------------------
-
-/**
- * Create a host-backed SessionStore that reads/writes session JSONLs on the
- * host filesystem using Claude Code's `~/.claude/projects/<encoded>/` layout.
- *
- * @param cwd - The host repo directory this store is associated with.
- * @param projectsDir - Override for the projects directory (default: `~/.claude/projects`).
- */
-export const hostSessionStore = (
+/** Absolute host path to a Claude session JSONL file. */
+export const claudeHostSessionPath = (
   cwd: string,
+  id: string,
   projectsDir?: string,
-): SessionStore => {
-  const baseDir =
+): string => {
+  const base =
     projectsDir ?? join(process.env.HOME ?? "~", ".claude", "projects");
-  const encoded = encodeProjectPath(cwd);
-  const projectDir = join(baseDir, encoded);
-
-  return {
-    cwd,
-    sessionFilePath: (id: string): string => join(projectDir, `${id}.jsonl`),
-    exists: async (id: string): Promise<boolean> =>
-      pathExists(join(projectDir, `${id}.jsonl`)),
-    readSession: async (id: string): Promise<string> => {
-      return await readFile(join(projectDir, `${id}.jsonl`), "utf-8");
-    },
-    writeSession: async (id: string, content: string): Promise<void> => {
-      await mkdir(projectDir, { recursive: true });
-      await writeFile(join(projectDir, `${id}.jsonl`), content);
-    },
-  };
+  return join(base, encodeProjectPath(cwd), `${id}.jsonl`);
 };
+
+/** Sandbox-side path to a Claude session JSONL file (always POSIX separators). */
+export const claudeSandboxSessionPath = (
+  cwd: string,
+  id: string,
+  projectsDir: string,
+): string => posix.join(projectsDir, encodeProjectPath(cwd), `${id}.jsonl`);
 
 /**
  * Locate a Claude Code session JSONL on the host by its unique id, scanning each
  * `~/.claude/projects/<encoded-cwd>/` directory rather than reconstructing the
- * cwd encoding. The session id is globally unique, so the first match wins. Used
- * by the no-sandbox resume precheck, where the agent wrote the file in place
- * under a cwd-derived directory Sandcastle cannot reliably reconstruct.
- *
- * @param id - The session id (file basename without `.jsonl`).
- * @param projectsDir - Override for the projects directory (default: `~/.claude/projects`).
+ * cwd encoding. The session id is globally unique, so the first match wins.
  */
 export const findClaudeSessionOnHost = async (
   id: string,
@@ -143,296 +97,11 @@ export const findClaudeSessionOnHost = async (
   return { path: undefined, searchedRoot: root };
 };
 
-// ---------------------------------------------------------------------------
-// Sandbox-backed SessionStore
-// ---------------------------------------------------------------------------
-
-/**
- * Create a sandbox-backed SessionStore that uses a bind-mount handle's
- * `copyFileIn`/`copyFileOut` to transfer session files.
- *
- * @param cwd - The sandbox-side working directory.
- * @param handle - The bind-mount sandbox handle for file transfer.
- * @param projectsDir - The sandbox-side path to `~/.claude/projects`.
- */
-export const sandboxSessionStore = (
-  cwd: string,
-  handle: Pick<BindMountSandboxHandle, "copyFileIn" | "copyFileOut" | "exec">,
-  projectsDir: string,
-): SessionStore => {
-  const encoded = encodeProjectPath(cwd);
-  // Sandbox-side paths target a Linux container, so they must use POSIX
-  // separators regardless of host platform — platform-aware `join` produces
-  // backslashes on Windows hosts, which the container daemon rejects.
-  const projectDir = posix.join(projectsDir, encoded);
-
-  return {
-    cwd,
-    sessionFilePath: (id: string): string =>
-      posix.join(projectDir, `${id}.jsonl`),
-    exists: async (id: string): Promise<boolean> => {
-      const result = await handle.exec(
-        `test -f ${JSON.stringify(posix.join(projectDir, `${id}.jsonl`))}`,
-      );
-      return result.exitCode === 0;
-    },
-    readSession: async (id: string): Promise<string> => {
-      const sandboxPath = posix.join(projectDir, `${id}.jsonl`);
-      const tmpPath = join(
-        tmpdir(),
-        `sandcastle-session-${id}-${Date.now()}.jsonl`,
-      );
-      await handle.copyFileOut(sandboxPath, tmpPath);
-      try {
-        return await readFile(tmpPath, "utf-8");
-      } finally {
-        await rm(tmpPath, { force: true }).catch(() => {});
-      }
-    },
-    writeSession: async (id: string, content: string): Promise<void> => {
-      const sandboxPath = posix.join(projectDir, `${id}.jsonl`);
-      const tmpPath = join(
-        tmpdir(),
-        `sandcastle-session-${id}-${Date.now()}.jsonl`,
-      );
-      await writeFile(tmpPath, content);
-      try {
-        // Ensure the sandbox-side project directory exists — `docker cp` /
-        // `podman cp` require the destination's parent directory to exist.
-        await handle.exec(`mkdir -p ${JSON.stringify(projectDir)}`);
-        await handle.copyFileIn(tmpPath, sandboxPath);
-      } finally {
-        await rm(tmpPath, { force: true }).catch(() => {});
-      }
-    },
-  };
-};
-
-/**
- * claudeCode's `sessionStorage.transfer` (ADR 0012). Copies a Claude Code
- * session between stores, rewriting `cwd` fields in the JSONL entries from the
- * source store's cwd to the target store's cwd. The rewrite is specific to
- * Claude Code's JSONL format, so it lives with the provider rather than in
- * central code.
- */
-export const transferClaudeSession = async (
-  from: SessionStore,
-  to: SessionStore,
-  id: string,
-): Promise<void> => {
-  const content = await from.readSession(id);
-
-  if (content === "") {
-    await to.writeSession(id, "");
-    return;
-  }
-
-  const rewritten = rewriteSessionCwd(content, from.cwd, to.cwd);
-  await to.writeSession(id, rewritten);
-};
-
-// ---------------------------------------------------------------------------
-// Codex session stores
-// ---------------------------------------------------------------------------
-
-/**
- * A file-backed `SessionStore` that can locate a session's on-disk path and
- * write content at a specific relative path. Codex sessions are date-nested
- * (`YYYY/MM/DD/rollout-*-<id>.jsonl`) rather than cwd-partitioned, so `transfer`
- * must preserve the source's relative path on the target. Not part of the
- * public API — the codex factory pairs these stores with `transferCodexSession`.
- */
-export interface LocatableSessionStore extends SessionStore {
-  locateSession(id: string): Promise<{ path: string; relativePath: string }>;
-  writeSessionAt(relativePath: string, content: string): Promise<void>;
-}
-
-const isCodexSessionFilename = (filename: string, id: string): boolean =>
-  filename.startsWith("rollout-") && filename.endsWith(`-${id}.jsonl`);
-
-const codexIdFromFilename = (filename: string): string | undefined => {
-  const match =
-    /([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.jsonl$/.exec(
-      filename,
-    );
-  return match?.[1];
-};
-
-const findCodexSessionPath = async (
-  rootDir: string,
-  id: string,
-): Promise<string | undefined> => {
-  const visit = async (dir: string): Promise<string | undefined> => {
-    let entries;
-    try {
-      entries = await readdir(dir, { withFileTypes: true });
-    } catch {
-      return undefined;
-    }
-
-    for (const entry of entries) {
-      const child = join(dir, entry.name);
-      if (entry.isFile() && isCodexSessionFilename(entry.name, id)) {
-        return child;
-      }
-      if (entry.isDirectory()) {
-        const found = await visit(child);
-        if (found) return found;
-      }
-    }
-    return undefined;
-  };
-
-  return visit(rootDir);
-};
-
-/**
- * Locate a Codex session rollout file on the host by its id, reusing the
- * date-nested scan. Used by the no-sandbox resume precheck.
- *
- * @param id - The session id.
- * @param sessionsDir - Override for the sessions directory (default: `~/.codex/sessions`).
- */
-export const findCodexSessionOnHost = async (
-  id: string,
-  sessionsDir?: string,
-): Promise<HostSessionLookup> => {
-  const root =
-    sessionsDir ?? join(process.env.HOME ?? "~", ".codex", "sessions");
-  const path = await findCodexSessionPath(root, id);
-  return { path, searchedRoot: root };
-};
-
-export const codexHostSessionStore = (
-  cwd: string,
-  sessionsDir?: string,
-): LocatableSessionStore => {
-  const rootDir =
-    sessionsDir ?? join(process.env.HOME ?? "~", ".codex", "sessions");
-  const locatedPaths = new Map<string, string>();
-
-  const locateSession = async (
-    id: string,
-  ): Promise<{ path: string; relativePath: string }> => {
-    const path = await findCodexSessionPath(rootDir, id);
-    if (!path) {
-      throw new Error(`session ${id} not found in ${rootDir}`);
-    }
-    locatedPaths.set(id, path);
-    return { path, relativePath: relative(rootDir, path) };
-  };
-
-  return {
-    cwd,
-    locateSession,
-    sessionFilePath: (id: string): string | undefined => locatedPaths.get(id),
-    exists: async (id: string): Promise<boolean> => {
-      return (await findCodexSessionPath(rootDir, id)) !== undefined;
-    },
-    readSession: async (id: string): Promise<string> => {
-      const located = await locateSession(id);
-      return readFile(located.path, "utf-8");
-    },
-    writeSession: async (id: string, content: string): Promise<void> => {
-      const existing = await findCodexSessionPath(rootDir, id);
-      const target =
-        existing ??
-        join(rootDir, "unknown-date", `rollout-${Date.now()}-${id}.jsonl`);
-      await mkdir(dirname(target), { recursive: true });
-      await writeFile(target, content);
-      locatedPaths.set(id, target);
-    },
-    writeSessionAt: async (
-      relativePath: string,
-      content: string,
-    ): Promise<void> => {
-      const target = join(rootDir, relativePath);
-      await mkdir(dirname(target), { recursive: true });
-      await writeFile(target, content);
-      const id = codexIdFromFilename(posix.basename(relativePath));
-      if (id) locatedPaths.set(id, target);
-    },
-  };
-};
-
-export const codexSandboxSessionStore = (
-  cwd: string,
-  handle: Pick<BindMountSandboxHandle, "copyFileIn" | "copyFileOut" | "exec">,
-  sessionsDir: string = posix.join("/home/agent", ".codex", "sessions"),
-): LocatableSessionStore => {
-  const locatedPaths = new Map<string, string>();
-
-  const writeSessionAt = async (
-    relativePath: string,
-    content: string,
-  ): Promise<void> => {
-    const sandboxPath = posix.join(sessionsDir, relativePath);
-    const tmpPath = join(
-      tmpdir(),
-      `sandcastle-codex-session-${Date.now()}.jsonl`,
-    );
-    await writeFile(tmpPath, content);
-    try {
-      await handle.exec(
-        `mkdir -p ${JSON.stringify(posix.dirname(sandboxPath))}`,
-      );
-      await handle.copyFileIn(tmpPath, sandboxPath);
-      const id = codexIdFromFilename(posix.basename(relativePath));
-      if (id) locatedPaths.set(id, sandboxPath);
-    } finally {
-      await rm(tmpPath, { force: true }).catch(() => {});
-    }
-  };
-
-  const locateSession = async (
-    id: string,
-  ): Promise<{ path: string; relativePath: string }> => {
-    const result = await handle.exec(
-      `find ${JSON.stringify(sessionsDir)} -type f -name ${JSON.stringify(`rollout-*-${id}.jsonl`)} -print -quit`,
-    );
-    const path = result.stdout.trim().split("\n")[0];
-    if (result.exitCode !== 0 || !path) {
-      throw new Error(`session ${id} not found in ${sessionsDir}`);
-    }
-    locatedPaths.set(id, path);
-    return { path, relativePath: posix.relative(sessionsDir, path) };
-  };
-
-  return {
-    cwd,
-    locateSession,
-    sessionFilePath: (id: string): string | undefined => locatedPaths.get(id),
-    exists: async (id: string): Promise<boolean> => {
-      const result = await handle.exec(
-        `find ${JSON.stringify(sessionsDir)} -type f -name ${JSON.stringify(`rollout-*-${id}.jsonl`)} -print -quit`,
-      );
-      return result.exitCode === 0 && result.stdout.trim().length > 0;
-    },
-    readSession: async (id: string): Promise<string> => {
-      const located = await locateSession(id);
-      const tmpPath = join(
-        tmpdir(),
-        `sandcastle-codex-session-${id}-${Date.now()}.jsonl`,
-      );
-      await handle.copyFileOut(located.path, tmpPath);
-      try {
-        return await readFile(tmpPath, "utf-8");
-      } finally {
-        await rm(tmpPath, { force: true }).catch(() => {});
-      }
-    },
-    writeSession: async (id: string, content: string): Promise<void> => {
-      const existing = await locateSession(id).catch(() => undefined);
-      const relativePath =
-        existing?.relativePath ??
-        posix.join("unknown-date", `rollout-${Date.now()}-${id}.jsonl`);
-      await writeSessionAt(relativePath, content);
-    },
-    writeSessionAt,
-  };
-};
-
-const rewriteSessionCwd = (content: string, fromCwd: string, toCwd: string) => {
+const rewriteSessionCwd = (
+  content: string,
+  fromCwd: string,
+  toCwd: string,
+): string => {
   if (content === "") return "";
   return content
     .split("\n")
@@ -457,19 +126,101 @@ const rewriteSessionCwd = (content: string, fromCwd: string, toCwd: string) => {
 };
 
 /**
- * codex's `sessionStorage.transfer` (ADR 0012). Copies a Codex session between
- * locatable stores, rewriting the `cwd` in the `session_meta` line and
- * preserving the source's relative date-path on the target so Codex's id-scan
- * rediscovers the file.
+ * Rewrite a Claude Code session JSONL string, replacing `cwd` fields that
+ * match `fromCwd` with `toCwd`. Pure function — no file I/O.
  */
-export const transferCodexSession = async (
-  from: LocatableSessionStore,
-  to: LocatableSessionStore,
+export const transferClaudeSession = (
+  jsonl: string,
+  fromCwd: string,
+  toCwd: string,
+): string => rewriteSessionCwd(jsonl, fromCwd, toCwd);
+
+// ---------------------------------------------------------------------------
+// Codex session paths and transfer
+// ---------------------------------------------------------------------------
+
+const isCodexSessionFilename = (filename: string, id: string): boolean =>
+  filename.startsWith("rollout-") && filename.endsWith(`-${id}.jsonl`);
+
+const findCodexSessionPath = async (
+  rootDir: string,
   id: string,
-): Promise<void> => {
-  const located = await from.locateSession(id);
-  const content = await from.readSession(id);
-  const rewritten = rewriteSessionCwd(content, from.cwd, to.cwd);
-  await to.writeSessionAt(located.relativePath, rewritten);
-  await to.locateSession(id).catch(() => undefined);
+): Promise<string | undefined> => {
+  const visit = async (dir: string): Promise<string | undefined> => {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return undefined;
+    }
+    for (const entry of entries) {
+      const child = join(dir, entry.name);
+      if (entry.isFile() && isCodexSessionFilename(entry.name, id)) {
+        return child;
+      }
+      if (entry.isDirectory()) {
+        const found = await visit(child);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  };
+  return visit(rootDir);
 };
+
+/**
+ * Locate a Codex session rollout file on the host by its id, reusing the
+ * date-nested scan.
+ */
+export const findCodexSessionOnHost = async (
+  id: string,
+  sessionsDir?: string,
+): Promise<HostSessionLookup> => {
+  const root =
+    sessionsDir ?? join(process.env.HOME ?? "~", ".codex", "sessions");
+  const path = await findCodexSessionPath(root, id);
+  return { path, searchedRoot: root };
+};
+
+/** Codex host session lookup that also returns the relative date-nested path. */
+export interface CodexSessionLocation {
+  readonly path: string;
+  readonly relativePath: string;
+}
+
+export const locateCodexHostSession = async (
+  id: string,
+  sessionsDir?: string,
+): Promise<CodexSessionLocation> => {
+  const root =
+    sessionsDir ?? join(process.env.HOME ?? "~", ".codex", "sessions");
+  const path = await findCodexSessionPath(root, id);
+  if (!path) throw new Error(`session ${id} not found in ${root}`);
+  return { path, relativePath: relative(root, path) };
+};
+
+export const locateCodexSandboxSession = async (
+  id: string,
+  handle: Pick<BindMountSandboxHandle, "exec">,
+  sessionsDir: string,
+): Promise<CodexSessionLocation> => {
+  const result = await handle.exec(
+    `find ${JSON.stringify(sessionsDir)} -type f -name ${JSON.stringify(`rollout-*-${id}.jsonl`)} -print -quit`,
+  );
+  const path = result.stdout.trim().split("\n")[0];
+  if (result.exitCode !== 0 || !path) {
+    throw new Error(`session ${id} not found in ${sessionsDir}`);
+  }
+  return { path, relativePath: posix.relative(sessionsDir, path) };
+};
+
+/**
+ * Rewrite a Codex session JSONL string, replacing `cwd` fields (both top-level
+ * and `session_meta.payload.cwd`) that match `fromCwd` with `toCwd`. Pure
+ * function — no file I/O.
+ */
+export const transferCodexSession = (
+  jsonl: string,
+  fromCwd: string,
+  toCwd: string,
+): string => rewriteSessionCwd(jsonl, fromCwd, toCwd);

--- a/src/SessionStore.windowsPath.test.ts
+++ b/src/SessionStore.windowsPath.test.ts
@@ -12,57 +12,19 @@ vi.mock("node:path", async (importOriginal) => {
   };
 });
 
-import type { BindMountSandboxHandle } from "./SandboxProvider.js";
-import { sandboxSessionStore } from "./SessionStore.js";
+import { claudeSandboxSessionPath } from "./SessionStore.js";
 
-describe("sandboxSessionStore on Windows-style hosts", () => {
-  it("uses POSIX separators for in-container paths regardless of host platform", async () => {
-    const copyOutCalls: Array<{ from: string; to: string }> = [];
-    const copyInCalls: Array<{ from: string; to: string }> = [];
-    const execCalls: string[] = [];
-
-    const handle: Pick<
-      BindMountSandboxHandle,
-      "copyFileIn" | "copyFileOut" | "exec"
-    > = {
-      copyFileIn: async (from, to) => {
-        copyInCalls.push({ from, to });
-      },
-      copyFileOut: async (from, to) => {
-        copyOutCalls.push({ from, to });
-        const fs = await import("node:fs/promises");
-        await fs.writeFile(to, "");
-      },
-      exec: async (cmd) => {
-        execCalls.push(cmd);
-        return { stdout: "", stderr: "", exitCode: 0 };
-      },
-    };
-
-    const store = sandboxSessionStore(
+describe("claudeSandboxSessionPath on Windows-style hosts", () => {
+  it("uses POSIX separators for in-container paths regardless of host platform", () => {
+    const path = claudeSandboxSessionPath(
       "/home/agent/workspace",
-      handle as BindMountSandboxHandle,
+      "abc",
       "/home/agent/.claude/projects",
     );
 
-    expect(store.sessionFilePath("abc")).not.toMatch(/\\/);
-
-    await store.readSession("abc");
-    expect(copyOutCalls).toHaveLength(1);
-    expect(copyOutCalls[0]!.from).not.toMatch(/\\/);
-    expect(copyOutCalls[0]!.from).toBe(
+    expect(path).not.toMatch(/\\/);
+    expect(path).toBe(
       "/home/agent/.claude/projects/-home-agent-workspace/abc.jsonl",
-    );
-
-    await store.writeSession("xyz", "{}");
-    expect(copyInCalls).toHaveLength(1);
-    expect(copyInCalls[0]!.to).not.toMatch(/\\/);
-    expect(copyInCalls[0]!.to).toBe(
-      "/home/agent/.claude/projects/-home-agent-workspace/xyz.jsonl",
-    );
-    expect(execCalls[0]).not.toMatch(/\\/);
-    expect(execCalls[0]).toContain(
-      "/home/agent/.claude/projects/-home-agent-workspace",
     );
   });
 });

--- a/src/createSandbox.test.ts
+++ b/src/createSandbox.test.ts
@@ -8,13 +8,13 @@ import { Effect, Layer } from "effect";
 import { describe, expect, it } from "vitest";
 import { claudeCode, pi } from "./AgentProvider.js";
 import { createSandbox, type CreateSandboxOptions } from "./createSandbox.js";
-import { Sandbox } from "./SandboxFactory.js";
+import type { SandboxService } from "./SandboxFactory.js";
 import {
   createBindMountSandboxProvider,
   createIsolatedSandboxProvider,
 } from "./SandboxProvider.js";
 import { testIsolated } from "./sandboxes/test-isolated.js";
-import { makeLocalSandboxLayer } from "./testSandbox.js";
+import { makeLocalSandbox } from "./testSandbox.js";
 
 /** Dummy sandbox provider used to satisfy the required `sandbox` field in test mode. */
 const testSandbox = createBindMountSandboxProvider({
@@ -99,13 +99,13 @@ const AGENT_PREFIXES: { prefix: string; toStream: (o: string) => string }[] = [
 const makeMockAgentLayer = (
   sandboxDir: string,
   mockAgentBehavior: (sandboxRepoDir: string) => Promise<string>,
-): Layer.Layer<Sandbox> => {
-  const fsLayer = makeLocalSandboxLayer(sandboxDir);
+): SandboxService => {
+  const real = makeLocalSandbox(sandboxDir);
 
   const matchAgent = (command: string) =>
     AGENT_PREFIXES.find((a) => command.startsWith(a.prefix));
 
-  return Layer.succeed(Sandbox, {
+  return {
     exec: (command, options) => {
       const agent = matchAgent(command);
       if (agent && options?.onLine) {
@@ -127,19 +127,12 @@ const makeMockAgentLayer = (
           return { stdout: output, stderr: "", exitCode: 0 };
         });
       }
-      return Effect.flatMap(Sandbox, (real) =>
-        real.exec(command, options),
-      ).pipe(Effect.provide(fsLayer));
+      return real.exec(command, options);
     },
-    copyIn: (hostPath, sandboxPath) =>
-      Effect.flatMap(Sandbox, (real) =>
-        real.copyIn(hostPath, sandboxPath),
-      ).pipe(Effect.provide(fsLayer)),
+    copyIn: (hostPath, sandboxPath) => real.copyIn(hostPath, sandboxPath),
     copyFileOut: (sandboxPath, hostPath) =>
-      Effect.flatMap(Sandbox, (real) =>
-        real.copyFileOut(sandboxPath, hostPath),
-      ).pipe(Effect.provide(fsLayer)),
-  });
+      real.copyFileOut(sandboxPath, hostPath),
+  };
 };
 
 /**
@@ -193,7 +186,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+        buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
       },
     });
 
@@ -217,7 +210,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) =>
+        buildSandbox: (sandboxDir) =>
           makeMockAgentLayer(sandboxDir, async () => "agent output"),
       },
     });
@@ -248,7 +241,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+        buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
       },
     });
 
@@ -270,7 +263,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+        buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
       },
     });
 
@@ -300,7 +293,7 @@ describe("createSandbox", () => {
         sandbox: testSandbox,
         cwd: hostDir,
         _test: {
-          buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+          buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
         },
       });
       worktreePath = sandbox.worktreePath;
@@ -321,7 +314,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+        buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
       },
     });
 
@@ -331,7 +324,7 @@ describe("createSandbox", () => {
         sandbox: testSandbox,
         cwd: hostDir,
         _test: {
-          buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+          buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
         },
       });
 
@@ -354,7 +347,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+        buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
       },
     });
 
@@ -367,7 +360,7 @@ describe("createSandbox", () => {
         sandbox: testSandbox,
         cwd: hostDir,
         _test: {
-          buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+          buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
         },
       });
 
@@ -393,7 +386,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) =>
+        buildSandbox: (sandboxDir) =>
           makeMockAgentLayer(sandboxDir, async (cwd) => {
             await writeFile(join(cwd, "agent-created.txt"), "new file");
             await execAsync("git add agent-created.txt", { cwd });
@@ -427,7 +420,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+        buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
       },
     });
 
@@ -449,7 +442,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) =>
+        buildSandbox: (sandboxDir) =>
           makeMockAgentLayer(sandboxDir, async () => "mock output"),
       },
     });
@@ -488,7 +481,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) =>
+        buildSandbox: (sandboxDir) =>
           makeMockAgentLayer(sandboxDir, async (cwd) => {
             runCount++;
             const fname = `file-${runCount}.txt`;
@@ -549,7 +542,7 @@ describe("createSandbox", () => {
       },
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+        buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
       },
     });
 
@@ -720,7 +713,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) =>
+        buildSandbox: (sandboxDir) =>
           makeMockAgentLayer(sandboxDir, async (cwd) => {
             runNumber++;
             if (runNumber === 1) {
@@ -1164,7 +1157,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) =>
+        buildSandbox: (sandboxDir) =>
           makeMockAgentLayer(sandboxDir, async () => "agent output"),
       },
     });
@@ -1193,7 +1186,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) =>
+        buildSandbox: (sandboxDir) =>
           makeMockAgentLayer(sandboxDir, async () => "agent output"),
       },
     });
@@ -1226,7 +1219,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) =>
+        buildSandbox: (sandboxDir) =>
           makeMockAgentLayer(sandboxDir, async () => "agent output"),
       },
     });
@@ -1266,7 +1259,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) =>
+        buildSandbox: (sandboxDir) =>
           makeMockAgentLayer(sandboxDir, async () => "agent output"),
       },
     });
@@ -1411,7 +1404,7 @@ describe("createSandbox", () => {
       sandbox: testSandbox,
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+        buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
       },
     });
 
@@ -1475,7 +1468,7 @@ describe("createSandbox", () => {
       copyToWorktree: ["config.json"],
       cwd: hostDir,
       _test: {
-        buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+        buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
       },
     });
 

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -30,10 +30,11 @@ import {
   type SandboxHooks,
 } from "./SandboxLifecycle.js";
 import {
-  Sandbox as SandboxTag,
+  type SandboxService,
   SandboxFactory,
   SANDBOX_REPO_DIR,
   resolveGitMounts,
+  makeSandboxFromHandle,
 } from "./SandboxFactory.js";
 import type {
   SandboxProvider,
@@ -76,9 +77,7 @@ export interface CreateSandboxOptions {
   readonly timeouts?: Timeouts;
   /** @internal Test-only overrides to bypass the sandbox provider. */
   readonly _test?: {
-    readonly buildSandboxLayer?: (
-      sandboxDir: string,
-    ) => Layer.Layer<SandboxTag>;
+    readonly buildSandbox?: (sandboxDir: string) => SandboxService;
   };
 }
 
@@ -182,7 +181,7 @@ interface SandboxHandleContext {
   readonly worktreePath: string;
   readonly hostRepoDir: string;
   readonly sandboxRepoDir: string;
-  readonly sandboxLayer: Layer.Layer<SandboxTag>;
+  readonly sandbox: SandboxService;
   readonly providerHandle:
     | BindMountSandboxHandle
     | IsolatedSandboxHandle
@@ -207,7 +206,7 @@ const buildSandboxHandle = (
     worktreePath,
     hostRepoDir,
     sandboxRepoDir,
-    sandboxLayer,
+    sandbox,
     providerHandle,
     applyToHost,
     timeouts,
@@ -292,12 +291,14 @@ const buildSandboxHandle = (
 
       const reuseFactoryLayer = Layer.succeed(SandboxFactory, {
         withSandbox: (makeEffect) =>
-          makeEffect({
-            hostWorktreePath: worktreePath,
-            sandboxRepoPath: sandboxRepoDir,
-            applyToHost,
-          }).pipe(
-            Effect.provide(sandboxLayer),
+          makeEffect(
+            {
+              hostWorktreePath: worktreePath,
+              sandboxRepoPath: sandboxRepoDir,
+              applyToHost,
+            },
+            sandbox,
+          ).pipe(
             Effect.map((value) => ({
               value,
               preservedWorktreePath: undefined,
@@ -420,6 +421,7 @@ const buildSandboxHandle = (
                 applyToHost,
                 timeouts,
               },
+              sandbox,
               (ctx) =>
                 Effect.gen(function* () {
                   const fullPrompt = isInlinePrompt
@@ -470,7 +472,6 @@ const buildSandboxHandle = (
                 }),
             );
           }).pipe(
-            Effect.provide(sandboxLayer),
             Effect.provide(ClackDisplay.layer),
             Effect.provide(NodeContext.layer),
           ),
@@ -507,9 +508,7 @@ export interface CreateSandboxFromWorktreeOptions {
   readonly copyToWorktree?: string[];
   readonly timeouts?: Timeouts;
   readonly _test?: {
-    readonly buildSandboxLayer?: (
-      sandboxDir: string,
-    ) => Layer.Layer<SandboxTag>;
+    readonly buildSandbox?: (sandboxDir: string) => SandboxService;
   };
 }
 
@@ -522,7 +521,7 @@ export const createSandboxFromWorktree = async (
   options: CreateSandboxFromWorktreeOptions,
 ): Promise<Sandbox> => {
   const { branch, worktreePath, hostRepoDir } = options;
-  const isTestMode = !!options._test?.buildSandboxLayer;
+  const isTestMode = !!options._test?.buildSandbox;
 
   // 1. Copy files if requested (bind-mount only)
   if (
@@ -546,12 +545,12 @@ export const createSandboxFromWorktree = async (
     | IsolatedSandboxHandle
     | NoSandboxHandle
     | undefined;
-  let sandboxLayer: Layer.Layer<SandboxTag>;
+  let sandbox: SandboxService;
   let sandboxRepoDir: string;
   const isIsolated = options.sandbox.tag === "isolated";
 
   if (isTestMode) {
-    sandboxLayer = options._test!.buildSandboxLayer!(worktreePath);
+    sandbox = options._test!.buildSandbox!(worktreePath);
     sandboxRepoDir = worktreePath;
   } else {
     const resolvedEnv = await Effect.runPromise(
@@ -615,7 +614,7 @@ export const createSandboxFromWorktree = async (
     const startResult = await Effect.runPromise(startEffect);
 
     providerHandle = startResult.handle;
-    sandboxLayer = startResult.sandboxLayer;
+    sandbox = startResult.sandbox;
     sandboxRepoDir = startResult.worktreePath;
   }
 
@@ -626,7 +625,6 @@ export const createSandboxFromWorktree = async (
   if (sandboxOnReady?.length || hostOnReady?.length) {
     await Effect.runPromise(
       Effect.gen(function* () {
-        const sandbox = yield* SandboxTag;
         yield* sandbox.exec(
           `git config --global --add safe.directory "${sandboxRepoDir}"`,
         );
@@ -646,7 +644,7 @@ export const createSandboxFromWorktree = async (
         yield* Effect.all(allEffects, {
           concurrency: "unbounded",
         });
-      }).pipe(Effect.provide(sandboxLayer)),
+      }),
     );
   }
 
@@ -665,7 +663,7 @@ export const createSandboxFromWorktree = async (
       worktreePath,
       hostRepoDir,
       sandboxRepoDir,
-      sandboxLayer,
+      sandbox,
       providerHandle,
       applyToHost,
       timeouts: options.timeouts,
@@ -688,169 +686,167 @@ export const createSandbox = async (
   options: CreateSandboxOptions,
 ): Promise<Sandbox> => {
   const { branch } = options;
-  const isTestMode = !!options._test?.buildSandboxLayer;
+  const isTestMode = !!options._test?.buildSandbox;
   const isIsolated = options.sandbox.tag === "isolated";
 
   // Resolve cwd, create the worktree, and set up the sandbox in a single Effect.
   // Once the worktree exists, any later failure (e.g. a missing image surfacing
   // when the provider creates the container) tears down the container — if it
   // started — and removes the worktree so it is not orphaned on disk.
-  const {
-    hostRepoDir,
-    worktreePath,
-    providerHandle,
-    sandboxLayer,
-    sandboxRepoDir,
-  } = await Effect.runPromise(
-    Effect.gen(function* () {
-      const hostRepoDir = yield* resolveCwd(options.cwd);
+  const { hostRepoDir, worktreePath, providerHandle, sandbox, sandboxRepoDir } =
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const hostRepoDir = yield* resolveCwd(options.cwd);
 
-      yield* WorktreeManager.pruneStale(hostRepoDir).pipe(
-        Effect.catchAll(() => Effect.void),
-      );
-      const { path: worktreePath } = yield* WorktreeManager.create(
-        hostRepoDir,
-        { branch, baseBranch: options.baseBranch },
-      );
+        yield* WorktreeManager.pruneStale(hostRepoDir).pipe(
+          Effect.catchAll(() => Effect.void),
+        );
+        const { path: worktreePath } = yield* WorktreeManager.create(
+          hostRepoDir,
+          { branch, baseBranch: options.baseBranch },
+        );
 
-      const prepared = yield* Effect.gen(function* () {
-        // Copy files (bind-mount/no-sandbox only; isolated copies in startSandbox).
-        if (
-          options.copyToWorktree &&
-          options.copyToWorktree.length > 0 &&
-          options.sandbox.tag !== "isolated"
-        ) {
-          yield* copyToWorktree(
-            options.copyToWorktree,
-            hostRepoDir,
-            worktreePath,
-            options.timeouts?.copyToWorktreeMs,
-          );
-        }
+        const prepared = yield* Effect.gen(function* () {
+          // Copy files (bind-mount/no-sandbox only; isolated copies in startSandbox).
+          if (
+            options.copyToWorktree &&
+            options.copyToWorktree.length > 0 &&
+            options.sandbox.tag !== "isolated"
+          ) {
+            yield* copyToWorktree(
+              options.copyToWorktree,
+              hostRepoDir,
+              worktreePath,
+              options.timeouts?.copyToWorktreeMs,
+            );
+          }
 
-        // Run host.onWorktreeReady hooks (after copy, before sandbox creation).
-        if (options.hooks?.host?.onWorktreeReady?.length) {
-          yield* runHostHooks(options.hooks.host.onWorktreeReady, worktreePath);
-        }
+          // Run host.onWorktreeReady hooks (after copy, before sandbox creation).
+          if (options.hooks?.host?.onWorktreeReady?.length) {
+            yield* runHostHooks(
+              options.hooks.host.onWorktreeReady,
+              worktreePath,
+            );
+          }
 
-        // Start the sandbox via the test layer or the shared startSandbox helper.
-        let providerHandle:
-          | BindMountSandboxHandle
-          | IsolatedSandboxHandle
-          | NoSandboxHandle
-          | undefined;
-        let sandboxLayer: Layer.Layer<SandboxTag>;
-        let sandboxRepoDir: string;
+          // Start the sandbox via the test layer or the shared startSandbox helper.
+          let providerHandle:
+            | BindMountSandboxHandle
+            | IsolatedSandboxHandle
+            | NoSandboxHandle
+            | undefined;
+          let sandbox: SandboxService;
+          let sandboxRepoDir: string;
 
-        if (isTestMode) {
-          sandboxLayer = options._test!.buildSandboxLayer!(worktreePath);
-          sandboxRepoDir = worktreePath;
-        } else {
-          const resolvedEnv = yield* resolveEnv(hostRepoDir);
-          const env = mergeProviderEnv({
-            resolvedEnv,
-            agentProviderEnv: {},
-            sandboxProviderEnv: options.sandbox.env,
-          });
+          if (isTestMode) {
+            sandbox = options._test!.buildSandbox!(worktreePath);
+            sandboxRepoDir = worktreePath;
+          } else {
+            const resolvedEnv = yield* resolveEnv(hostRepoDir);
+            const env = mergeProviderEnv({
+              resolvedEnv,
+              agentProviderEnv: {},
+              sandboxProviderEnv: options.sandbox.env,
+            });
 
-          const provider = options.sandbox;
-          const startResult = yield* provider.tag === "isolated"
-            ? startSandbox({
-                provider,
-                hostRepoDir: worktreePath,
-                env,
-                copyPaths: options.copyToWorktree,
-              })
-            : provider.tag === "none"
+            const provider = options.sandbox;
+            const startResult = yield* provider.tag === "isolated"
               ? startSandbox({
                   provider,
-                  hostRepoDir,
+                  hostRepoDir: worktreePath,
                   env,
-                  worktreeOrRepoPath: worktreePath,
+                  copyPaths: options.copyToWorktree,
                 })
-              : resolveGitMounts(join(hostRepoDir, ".git")).pipe(
-                  Effect.provide(NodeFileSystem.layer),
-                  Effect.catchAll(() => Effect.succeed([])),
-                  // Patch git mounts for Windows worktree compatibility (ADR-0006)
-                  Effect.flatMap((gitMounts) =>
-                    Effect.tryPromise({
-                      try: () =>
-                        patchGitMountsForWindows(
-                          gitMounts,
-                          worktreePath,
-                          SANDBOX_REPO_DIR,
-                        ),
-                      catch: (e) =>
-                        new Error(
-                          `Failed to patch git mounts: ${e instanceof Error ? e.message : String(e)}`,
-                        ),
-                    }),
-                  ),
-                  Effect.flatMap((gitMounts) =>
-                    startSandbox({
-                      provider,
-                      hostRepoDir,
-                      env,
-                      worktreeOrRepoPath: worktreePath,
-                      gitMounts,
-                      repoDir: SANDBOX_REPO_DIR,
-                    }),
-                  ),
-                );
+              : provider.tag === "none"
+                ? startSandbox({
+                    provider,
+                    hostRepoDir,
+                    env,
+                    worktreeOrRepoPath: worktreePath,
+                  })
+                : resolveGitMounts(join(hostRepoDir, ".git")).pipe(
+                    Effect.provide(NodeFileSystem.layer),
+                    Effect.catchAll(() => Effect.succeed([])),
+                    // Patch git mounts for Windows worktree compatibility (ADR-0006)
+                    Effect.flatMap((gitMounts) =>
+                      Effect.tryPromise({
+                        try: () =>
+                          patchGitMountsForWindows(
+                            gitMounts,
+                            worktreePath,
+                            SANDBOX_REPO_DIR,
+                          ),
+                        catch: (e) =>
+                          new Error(
+                            `Failed to patch git mounts: ${e instanceof Error ? e.message : String(e)}`,
+                          ),
+                      }),
+                    ),
+                    Effect.flatMap((gitMounts) =>
+                      startSandbox({
+                        provider,
+                        hostRepoDir,
+                        env,
+                        worktreeOrRepoPath: worktreePath,
+                        gitMounts,
+                        repoDir: SANDBOX_REPO_DIR,
+                      }),
+                    ),
+                  );
 
-          providerHandle = startResult.handle;
-          sandboxLayer = startResult.sandboxLayer;
-          sandboxRepoDir = startResult.worktreePath;
-        }
+            providerHandle = startResult.handle;
+            sandbox = startResult.sandbox;
+            sandboxRepoDir = startResult.worktreePath;
+          }
 
-        // Run onSandboxReady hooks (sandbox-side and host-side in parallel). If
-        // they fail, tear down the container that just started before the outer
-        // handler removes the worktree.
-        const sandboxOnReady = options.hooks?.sandbox?.onSandboxReady;
-        const hostOnReady = options.hooks?.host?.onSandboxReady;
+          // Run onSandboxReady hooks (sandbox-side and host-side in parallel). If
+          // they fail, tear down the container that just started before the outer
+          // handler removes the worktree.
+          const sandboxOnReady = options.hooks?.sandbox?.onSandboxReady;
+          const hostOnReady = options.hooks?.host?.onSandboxReady;
 
-        if (sandboxOnReady?.length || hostOnReady?.length) {
-          yield* Effect.gen(function* () {
-            const sandbox = yield* SandboxTag;
-            yield* sandbox.exec(
-              `git config --global --add safe.directory "${sandboxRepoDir}"`,
+          if (sandboxOnReady?.length || hostOnReady?.length) {
+            yield* Effect.gen(function* () {
+              yield* sandbox.exec(
+                `git config --global --add safe.directory "${sandboxRepoDir}"`,
+              );
+              const sandboxEffects = (sandboxOnReady ?? []).map((hook) =>
+                sandbox.exec(hook.command, {
+                  cwd: sandboxRepoDir,
+                  sudo: hook.sudo,
+                }),
+              );
+              const allEffects = [...sandboxEffects] as Effect.Effect<
+                unknown,
+                unknown
+              >[];
+              if (hostOnReady?.length) {
+                allEffects.push(runHostHooks(hostOnReady, worktreePath));
+              }
+              yield* Effect.all(allEffects, { concurrency: "unbounded" });
+            }).pipe(
+              Effect.onError(() =>
+                providerHandle
+                  ? Effect.promise(() =>
+                      providerHandle!.close().catch(() => {}),
+                    )
+                  : Effect.void,
+              ),
             );
-            const sandboxEffects = (sandboxOnReady ?? []).map((hook) =>
-              sandbox.exec(hook.command, {
-                cwd: sandboxRepoDir,
-                sudo: hook.sudo,
-              }),
-            );
-            const allEffects = [...sandboxEffects] as Effect.Effect<
-              unknown,
-              unknown
-            >[];
-            if (hostOnReady?.length) {
-              allEffects.push(runHostHooks(hostOnReady, worktreePath));
-            }
-            yield* Effect.all(allEffects, { concurrency: "unbounded" });
-          }).pipe(
-            Effect.provide(sandboxLayer),
-            Effect.onError(() =>
-              providerHandle
-                ? Effect.promise(() => providerHandle!.close().catch(() => {}))
-                : Effect.void,
+          }
+
+          return { providerHandle, sandbox, sandboxRepoDir };
+        }).pipe(
+          Effect.onError(() =>
+            WorktreeManager.remove(worktreePath).pipe(
+              Effect.catchAll(() => Effect.void),
             ),
-          );
-        }
-
-        return { providerHandle, sandboxLayer, sandboxRepoDir };
-      }).pipe(
-        Effect.onError(() =>
-          WorktreeManager.remove(worktreePath).pipe(
-            Effect.catchAll(() => Effect.void),
           ),
-        ),
-      );
+        );
 
-      return { hostRepoDir, worktreePath, ...prepared };
-    }).pipe(Effect.provide(NodeContext.layer)),
-  );
+        return { hostRepoDir, worktreePath, ...prepared };
+      }).pipe(Effect.provide(NodeContext.layer)),
+    );
 
   // Build applyToHost callback (once, reused across runs)
   const applyToHost =
@@ -904,7 +900,7 @@ export const createSandbox = async (
       worktreePath,
       hostRepoDir,
       sandboxRepoDir,
-      sandboxLayer,
+      sandbox,
       providerHandle,
       applyToHost,
       timeouts: options.timeouts,

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -12,10 +12,7 @@ import {
 import { resolveEnv } from "./EnvResolver.js";
 import { mergeProviderEnv } from "./mergeProviderEnv.js";
 import { orchestrate, type IterationResult } from "./Orchestrator.js";
-import {
-  callbackAgentStreamEmitterLayer,
-  noopAgentStreamEmitterLayer,
-} from "./AgentStreamEmitter.js";
+import { agentStreamEmitterLayer } from "./AgentStreamEmitter.js";
 import {
   type PromptArgs,
   substitutePromptArgs,
@@ -308,15 +305,16 @@ const buildSandboxHandle = (
           ) as any,
       });
 
-      const agentStreamEmitterLayer =
-        resolvedLogging.type === "file" && resolvedLogging.onAgentStreamEvent
-          ? callbackAgentStreamEmitterLayer(resolvedLogging.onAgentStreamEvent)
-          : noopAgentStreamEmitterLayer;
+      const streamEmitterLayer = agentStreamEmitterLayer(
+        resolvedLogging.type === "file"
+          ? resolvedLogging.onAgentStreamEvent
+          : undefined,
+      );
 
       const runLayer = Layer.mergeAll(
         reuseFactoryLayer,
         runDisplayLayer,
-        agentStreamEmitterLayer,
+        streamEmitterLayer,
       );
 
       let result;

--- a/src/createWorktree.test.ts
+++ b/src/createWorktree.test.ts
@@ -20,7 +20,7 @@ import {
   type ExecResult,
   type SandboxProvider,
 } from "./SandboxProvider.js";
-import { makeLocalSandboxLayer } from "./testSandbox.js";
+import { makeLocalSandbox } from "./testSandbox.js";
 
 const execAsync = promisify(exec);
 
@@ -872,7 +872,7 @@ describe("worktree.createSandbox()", () => {
       const sandbox = await ws.createSandbox({
         sandbox: testSandbox,
         _test: {
-          buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+          buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
         },
       });
 
@@ -902,7 +902,7 @@ describe("worktree.createSandbox()", () => {
       const sandbox = await ws.createSandbox({
         sandbox: testSandbox,
         _test: {
-          buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+          buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
         },
       });
 
@@ -933,7 +933,7 @@ describe("worktree.createSandbox()", () => {
     const sandbox = await ws.createSandbox({
       sandbox: testSandbox,
       _test: {
-        buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+        buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
       },
     });
 
@@ -962,7 +962,7 @@ describe("worktree.createSandbox()", () => {
       const sandbox1 = await ws.createSandbox({
         sandbox: testSandbox,
         _test: {
-          buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+          buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
         },
       });
       expect(sandbox1.branch).toBe("sequential-sandbox");
@@ -972,7 +972,7 @@ describe("worktree.createSandbox()", () => {
       const sandbox2 = await ws.createSandbox({
         sandbox: testSandbox,
         _test: {
-          buildSandboxLayer: (sandboxDir) => makeLocalSandboxLayer(sandboxDir),
+          buildSandbox: (sandboxDir) => makeLocalSandbox(sandboxDir),
         },
       });
       expect(sandbox2.branch).toBe("sequential-sandbox");

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -7,7 +7,7 @@ import { preprocessPrompt } from "./PromptPreprocessor.js";
 import { resolvePrompt } from "./PromptResolver.js";
 import {
   SandboxFactory,
-  makeSandboxLayerFromHandle,
+  makeSandboxFromHandle,
   resolveGitMounts,
   SANDBOX_REPO_DIR,
 } from "./SandboxFactory.js";
@@ -173,9 +173,9 @@ export interface WorktreeCreateSandboxOptions {
   readonly timeouts?: Timeouts;
   /** @internal Test-only overrides to bypass the sandbox provider. */
   readonly _test?: {
-    readonly buildSandboxLayer?: (
+    readonly buildSandbox?: (
       sandboxDir: string,
-    ) => import("effect").Layer.Layer<import("./SandboxFactory.js").Sandbox>;
+    ) => import("./SandboxFactory.js").SandboxService;
   };
 }
 
@@ -375,7 +375,7 @@ export const createWorktree = async (
           );
         }
         const interactiveExecFn = handle.interactiveExec.bind(handle);
-        const sandboxLayer = makeSandboxLayerFromHandle(handle);
+        const sandbox = makeSandboxFromHandle(handle);
         const worktreePath = handle.worktreePath;
 
         const applyToHost =
@@ -393,6 +393,7 @@ export const createWorktree = async (
             applyToHost,
             timeouts: options.timeouts,
           },
+          sandbox,
           (ctx) =>
             Effect.gen(function* () {
               const fullPrompt =
@@ -425,9 +426,7 @@ export const createWorktree = async (
             }),
         );
 
-        const lifecycleResult = yield* lifecycleEffect.pipe(
-          Effect.provide(sandboxLayer),
-        );
+        const lifecycleResult = yield* lifecycleEffect;
 
         const exitCode = lifecycleResult.result;
 
@@ -566,7 +565,7 @@ export const createWorktree = async (
         sandboxRepoDir = startResult.worktreePath;
       }
 
-      const sandboxLayer = makeSandboxLayerFromHandle(handle);
+      const sandbox = makeSandboxFromHandle(handle);
       const applyToHost =
         sandboxProvider.tag === "isolated"
           ? () => syncOut(worktreeInfo.path, handle as IsolatedSandboxHandle)
@@ -601,12 +600,14 @@ export const createWorktree = async (
       // 6. Build a SandboxFactory that reuses the started sandbox
       const reuseFactoryLayer = Layer.succeed(SandboxFactory, {
         withSandbox: (makeEffect) =>
-          makeEffect({
-            hostWorktreePath: worktreeInfo.path,
-            sandboxRepoPath: sandboxRepoDir,
-            applyToHost,
-          }).pipe(
-            Effect.provide(sandboxLayer),
+          makeEffect(
+            {
+              hostWorktreePath: worktreeInfo.path,
+              sandboxRepoPath: sandboxRepoDir,
+              applyToHost,
+            },
+            sandbox,
+          ).pipe(
             Effect.map((value) => ({
               value,
               preservedWorktreePath: undefined,

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -31,10 +31,7 @@ import type { InteractiveResult } from "./interactive.js";
 import { buildLogFilename, printFileDisplayStartup } from "./run.js";
 import type { LoggingOption } from "./run.js";
 import { orchestrate, type IterationResult } from "./Orchestrator.js";
-import {
-  callbackAgentStreamEmitterLayer,
-  noopAgentStreamEmitterLayer,
-} from "./AgentStreamEmitter.js";
+import { agentStreamEmitterLayer } from "./AgentStreamEmitter.js";
 import { resolveEnv } from "./EnvResolver.js";
 import { mergeProviderEnv } from "./mergeProviderEnv.js";
 import { startSandbox } from "./startSandbox.js";
@@ -617,15 +614,16 @@ export const createWorktree = async (
           ) as any,
       });
 
-      const agentStreamEmitterLayer =
-        resolvedLogging.type === "file" && resolvedLogging.onAgentStreamEvent
-          ? callbackAgentStreamEmitterLayer(resolvedLogging.onAgentStreamEvent)
-          : noopAgentStreamEmitterLayer;
+      const streamEmitterLayer = agentStreamEmitterLayer(
+        resolvedLogging.type === "file"
+          ? resolvedLogging.onAgentStreamEvent
+          : undefined,
+      );
 
       const runLayer = Layer.mergeAll(
         reuseFactoryLayer,
         runDisplayLayer,
-        agentStreamEmitterLayer,
+        streamEmitterLayer,
       );
 
       // 7. Run orchestration

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,12 +32,15 @@ export type {
 export type { PromptArgs } from "./PromptArgumentSubstitution.js";
 export type { AgentStreamEvent } from "./AgentStreamEmitter.js";
 export {
-  hostSessionStore,
-  sandboxSessionStore,
-  codexHostSessionStore,
-  codexSandboxSessionStore,
+  transferClaudeSession,
+  transferCodexSession,
+  encodeProjectPath,
+  claudeHostSessionPath,
+  claudeSandboxSessionPath,
+  findClaudeSessionOnHost,
+  findCodexSessionOnHost,
 } from "./SessionStore.js";
-export type { SessionStore } from "./SessionStore.js";
+export type { HostSessionLookup } from "./SessionStore.js";
 export type { SandboxHooks } from "./SandboxLifecycle.js";
 export type { MountConfig } from "./MountConfig.js";
 export { Output, StructuredOutputError } from "./Output.js";

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -7,7 +7,7 @@ import { ClackDisplay, Display } from "./Display.js";
 import { preprocessPrompt } from "./PromptPreprocessor.js";
 import { resolvePrompt } from "./PromptResolver.js";
 import {
-  makeSandboxLayerFromHandle,
+  makeSandboxFromHandle,
   resolveGitMounts,
   SANDBOX_REPO_DIR,
 } from "./SandboxFactory.js";
@@ -350,8 +350,8 @@ export const interactive = async (
       }
       const interactiveExecFn = handle.interactiveExec.bind(handle);
 
-      // Build sandbox layer and run withSandboxLifecycle
-      const sandboxLayer = makeSandboxLayerFromHandle(handle);
+      // Build sandbox service and run withSandboxLifecycle
+      const sandbox = makeSandboxFromHandle(handle);
       const worktreePath = handle.worktreePath;
 
       const applyToHost =
@@ -369,6 +369,7 @@ export const interactive = async (
           applyToHost,
           timeouts: options.timeouts,
         },
+        sandbox,
         (ctx) =>
           Effect.gen(function* () {
             // Preprocess prompt (expand !`command` shell expressions inside sandbox).
@@ -404,9 +405,7 @@ export const interactive = async (
           }),
       );
 
-      const lifecycleResult = yield* lifecycleEffect.pipe(
-        Effect.provide(sandboxLayer),
-      );
+      const lifecycleResult = yield* lifecycleEffect;
 
       const exitCode = lifecycleResult.result;
 

--- a/src/resumePrecheck.test.ts
+++ b/src/resumePrecheck.test.ts
@@ -112,9 +112,12 @@ describe("assertResumeSessionExists", () => {
         sessionStorage: { hostProjectsDir: projectsDir },
       });
       const hostRepoDir = "/some/host/repo";
-      await provider.sessionStorage
-        .hostStore(hostRepoDir)
-        .writeSession(SESSION_ID, "{}");
+      const sessionPath = provider.sessionStorage.hostSessionFilePath(
+        hostRepoDir,
+        SESSION_ID,
+      )!;
+      await mkdir(join(sessionPath, ".."), { recursive: true });
+      await writeFile(sessionPath, "{}");
 
       await expect(
         assertResumeSessionExists({

--- a/src/resumePrecheck.ts
+++ b/src/resumePrecheck.ts
@@ -41,10 +41,15 @@ export const assertResumeSessionExists = async (params: {
     return;
   }
 
-  const hostStore = provider.sessionStorage.hostStore(hostRepoDir);
-  const exists = await hostStore.exists(resumeSession);
+  const exists = await provider.sessionStorage.existsOnHost(
+    hostRepoDir,
+    resumeSession,
+  );
   if (!exists) {
-    const sessionPath = hostStore.sessionFilePath(resumeSession);
+    const sessionPath = provider.sessionStorage.hostSessionFilePath(
+      hostRepoDir,
+      resumeSession,
+    );
     throw new Error(
       sessionPath
         ? `resumeSession "${resumeSession}" not found: expected session file at ${sessionPath}`

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -22,17 +22,9 @@ import type { WorktreeInteractiveOptions } from "./createWorktree.js";
 import { defaultImageName } from "./sandboxes/docker.js";
 import * as sandcastle from "./SandboxProvider.js";
 import { createBindMountSandboxProvider } from "./SandboxProvider.js";
+import { testStubProvider } from "./sandboxes/test-shared.js";
 
-const testSandbox = createBindMountSandboxProvider({
-  name: "test",
-  create: async () => ({
-    worktreePath: "/home/agent/workspace",
-    exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
-    copyFileIn: async () => {},
-    copyFileOut: async () => {},
-    close: async () => {},
-  }),
-});
+const testSandbox = testStubProvider({ name: "test" }).provider;
 
 describe("printFileDisplayStartup", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;

--- a/src/run.ts
+++ b/src/run.ts
@@ -27,8 +27,7 @@ import { resolveEnv } from "./EnvResolver.js";
 import { formatErrorMessage } from "./ErrorHandler.js";
 import type { SandboxError } from "./errors.js";
 import {
-  callbackAgentStreamEmitterLayer,
-  noopAgentStreamEmitterLayer,
+  agentStreamEmitterLayer,
   type AgentStreamEvent,
 } from "./AgentStreamEmitter.js";
 import type { SandboxHooks } from "./SandboxLifecycle.js";
@@ -502,15 +501,16 @@ export async function run(
     ),
   );
 
-  const agentStreamEmitterLayer =
-    resolvedLogging.type === "file" && resolvedLogging.onAgentStreamEvent
-      ? callbackAgentStreamEmitterLayer(resolvedLogging.onAgentStreamEvent)
-      : noopAgentStreamEmitterLayer;
+  const streamEmitterLayer = agentStreamEmitterLayer(
+    resolvedLogging.type === "file"
+      ? resolvedLogging.onAgentStreamEvent
+      : undefined,
+  );
 
   const runLayer = Layer.mergeAll(
     factoryLayer,
     displayLayer,
-    agentStreamEmitterLayer,
+    streamEmitterLayer,
   );
 
   const baseEffect = Effect.gen(function* () {

--- a/src/sandboxes/test-bind-mount.ts
+++ b/src/sandboxes/test-bind-mount.ts
@@ -6,18 +6,14 @@
  * requiring Docker or Podman.
  */
 
-import { execFile, spawn } from "node:child_process";
-import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { createInterface } from "node:readline";
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
 import {
   createBindMountSandboxProvider,
   type BindMountSandboxHandle,
   type BindMountSandboxProvider,
-  type ExecResult,
 } from "../SandboxProvider.js";
-import { BoundedTail, MAX_TAIL_CHARS } from "../boundedTail.js";
+import { createTempSandbox } from "./test-shared.js";
 
 /**
  * Create a filesystem-based test bind-mount sandbox provider.
@@ -30,98 +26,20 @@ export const testBindMount = (): BindMountSandboxProvider =>
   createBindMountSandboxProvider({
     name: "test-bind-mount",
     create: async (): Promise<BindMountSandboxHandle> => {
-      const sandboxRoot = await mkdtemp(join(tmpdir(), "sandcastle-test-bm-"));
-      const worktreePath = join(sandboxRoot, "workspace");
-      await mkdir(worktreePath, { recursive: true });
+      const temp = await createTempSandbox("sandcastle-test-bm-");
 
       return {
-        worktreePath,
-
-        exec: (
-          command: string,
-          options?: {
-            onLine?: (line: string) => void;
-            cwd?: string;
-            sudo?: boolean;
-          },
-        ): Promise<ExecResult> => {
-          if (options?.onLine) {
-            const onLine = options.onLine;
-            return new Promise((resolve, reject) => {
-              const proc = spawn("sh", ["-c", command], {
-                cwd: options?.cwd ?? worktreePath,
-                stdio: ["ignore", "pipe", "pipe"],
-              });
-
-              const stdoutTail = new BoundedTail(MAX_TAIL_CHARS, "\n");
-              const stderrTail = new BoundedTail(MAX_TAIL_CHARS, "");
-
-              const rl = createInterface({ input: proc.stdout! });
-              rl.on("line", (line) => {
-                stdoutTail.push(line);
-                onLine(line);
-              });
-
-              proc.stderr!.on("data", (chunk: Buffer) => {
-                stderrTail.push(chunk.toString());
-              });
-
-              proc.on("error", (error) => {
-                reject(new Error(`exec failed: ${error.message}`));
-              });
-
-              proc.on("close", (code) => {
-                resolve({
-                  stdout: stdoutTail.toString(),
-                  stderr: stderrTail.toString(),
-                  exitCode: code ?? 0,
-                });
-              });
-            });
-          }
-
-          return new Promise((resolve, reject) => {
-            execFile(
-              "sh",
-              ["-c", command],
-              {
-                cwd: options?.cwd ?? worktreePath,
-                maxBuffer: 10 * 1024 * 1024,
-              },
-              (error, stdout, stderr) => {
-                if (error && error.code === undefined) {
-                  reject(new Error(`exec failed: ${error.message}`));
-                } else {
-                  resolve({
-                    stdout: stdout.toString(),
-                    stderr: stderr.toString(),
-                    exitCode: typeof error?.code === "number" ? error.code : 0,
-                  });
-                }
-              },
-            );
-          });
-        },
-
-        copyFileIn: async (
-          hostPath: string,
-          sandboxPath: string,
-        ): Promise<void> => {
+        worktreePath: temp.worktreePath,
+        exec: temp.exec,
+        copyFileIn: async (hostPath, sandboxPath) => {
           await mkdir(dirname(sandboxPath), { recursive: true });
           await copyFile(hostPath, sandboxPath);
         },
-
-        copyFileOut: async (
-          sandboxPath: string,
-          hostPath: string,
-        ): Promise<void> => {
+        copyFileOut: async (sandboxPath, hostPath) => {
           await mkdir(dirname(hostPath), { recursive: true });
           await copyFile(sandboxPath, hostPath);
         },
-
-        close: async (): Promise<void> => {
-          await rm(sandboxRoot, { recursive: true, force: true });
-        },
+        close: temp.close,
       };
     },
   });

--- a/src/sandboxes/test-isolated.ts
+++ b/src/sandboxes/test-isolated.ts
@@ -6,18 +6,14 @@
  * requiring a real remote environment.
  */
 
-import { execFile, spawn } from "node:child_process";
-import { copyFile, cp, mkdir, mkdtemp, rm, stat } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { createInterface } from "node:readline";
+import { copyFile, cp, mkdir, stat } from "node:fs/promises";
+import { dirname } from "node:path";
 import {
   createIsolatedSandboxProvider,
-  type ExecResult,
   type IsolatedSandboxHandle,
   type IsolatedSandboxProvider,
 } from "../SandboxProvider.js";
-import { BoundedTail, MAX_TAIL_CHARS } from "../boundedTail.js";
+import { createTempSandbox } from "./test-shared.js";
 
 /**
  * Create a filesystem-based test isolated sandbox provider.
@@ -30,83 +26,12 @@ export const testIsolated = (): IsolatedSandboxProvider =>
   createIsolatedSandboxProvider({
     name: "test-isolated",
     create: async (): Promise<IsolatedSandboxHandle> => {
-      const sandboxRoot = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
-      const worktreePath = join(sandboxRoot, "workspace");
-      await mkdir(worktreePath, { recursive: true });
+      const temp = await createTempSandbox("sandcastle-test-");
 
       return {
-        worktreePath,
-
-        exec: (
-          command: string,
-          options?: {
-            onLine?: (line: string) => void;
-            cwd?: string;
-            sudo?: boolean;
-          },
-        ): Promise<ExecResult> => {
-          if (options?.onLine) {
-            const onLine = options.onLine;
-            return new Promise((resolve, reject) => {
-              const proc = spawn("sh", ["-c", command], {
-                cwd: options?.cwd ?? worktreePath,
-                stdio: ["ignore", "pipe", "pipe"],
-              });
-
-              const stdoutTail = new BoundedTail(MAX_TAIL_CHARS, "\n");
-              const stderrTail = new BoundedTail(MAX_TAIL_CHARS, "");
-
-              const rl = createInterface({ input: proc.stdout! });
-              rl.on("line", (line) => {
-                stdoutTail.push(line);
-                onLine(line);
-              });
-
-              proc.stderr!.on("data", (chunk: Buffer) => {
-                stderrTail.push(chunk.toString());
-              });
-
-              proc.on("error", (error) => {
-                reject(new Error(`exec failed: ${error.message}`));
-              });
-
-              proc.on("close", (code) => {
-                resolve({
-                  stdout: stdoutTail.toString(),
-                  stderr: stderrTail.toString(),
-                  exitCode: code ?? 0,
-                });
-              });
-            });
-          }
-
-          return new Promise((resolve, reject) => {
-            execFile(
-              "sh",
-              ["-c", command],
-              {
-                cwd: options?.cwd ?? worktreePath,
-                maxBuffer: 10 * 1024 * 1024,
-              },
-              (error, stdout, stderr) => {
-                if (error && error.code === undefined) {
-                  reject(new Error(`exec failed: ${error.message}`));
-                } else {
-                  resolve({
-                    stdout: stdout.toString(),
-                    stderr: stderr.toString(),
-                    exitCode: typeof error?.code === "number" ? error.code : 0,
-                  });
-                }
-              },
-            );
-          });
-        },
-
-        copyIn: async (
-          hostPath: string,
-          sandboxPath: string,
-        ): Promise<void> => {
+        worktreePath: temp.worktreePath,
+        exec: temp.exec,
+        copyIn: async (hostPath, sandboxPath) => {
           const info = await stat(hostPath);
           if (info.isDirectory()) {
             await cp(hostPath, sandboxPath, { recursive: true });
@@ -115,18 +40,11 @@ export const testIsolated = (): IsolatedSandboxProvider =>
             await copyFile(hostPath, sandboxPath);
           }
         },
-
-        copyFileOut: async (
-          sandboxPath: string,
-          hostPath: string,
-        ): Promise<void> => {
+        copyFileOut: async (sandboxPath, hostPath) => {
           await mkdir(dirname(hostPath), { recursive: true });
           await copyFile(sandboxPath, hostPath);
         },
-
-        close: async (): Promise<void> => {
-          await rm(sandboxRoot, { recursive: true, force: true });
-        },
+        close: temp.close,
       };
     },
   });

--- a/src/sandboxes/test-shared.ts
+++ b/src/sandboxes/test-shared.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared helper for filesystem-backed test sandbox providers.
+ *
+ * Implements "run commands in a temp directory" — process spawning,
+ * working-directory management, exit code propagation, cleanup. Both
+ * `testBindMount` and `testIsolated` are thin adaptors over this helper.
+ */
+
+import { execFile, spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import {
+  createBindMountSandboxProvider,
+  type BindMountSandboxHandle,
+  type BindMountSandboxProvider,
+  type ExecResult,
+} from "../SandboxProvider.js";
+import { BoundedTail, MAX_TAIL_CHARS } from "../boundedTail.js";
+
+export interface TempSandbox {
+  readonly worktreePath: string;
+  readonly exec: (
+    command: string,
+    options?: {
+      onLine?: (line: string) => void;
+      cwd?: string;
+      sudo?: boolean;
+    },
+  ) => Promise<ExecResult>;
+  readonly close: () => Promise<void>;
+}
+
+export const createTempSandbox = async (
+  prefix: string,
+): Promise<TempSandbox> => {
+  const sandboxRoot = await mkdtemp(join(tmpdir(), prefix));
+  const worktreePath = join(sandboxRoot, "workspace");
+  await mkdir(worktreePath, { recursive: true });
+
+  const exec = (
+    command: string,
+    options?: {
+      onLine?: (line: string) => void;
+      cwd?: string;
+      sudo?: boolean;
+    },
+  ): Promise<ExecResult> => {
+    if (options?.onLine) {
+      const onLine = options.onLine;
+      return new Promise((resolve, reject) => {
+        const proc = spawn("sh", ["-c", command], {
+          cwd: options?.cwd ?? worktreePath,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+
+        const stdoutTail = new BoundedTail(MAX_TAIL_CHARS, "\n");
+        const stderrTail = new BoundedTail(MAX_TAIL_CHARS, "");
+
+        const rl = createInterface({ input: proc.stdout! });
+        rl.on("line", (line) => {
+          stdoutTail.push(line);
+          onLine(line);
+        });
+
+        proc.stderr!.on("data", (chunk: Buffer) => {
+          stderrTail.push(chunk.toString());
+        });
+
+        proc.on("error", (error) => {
+          reject(new Error(`exec failed: ${error.message}`));
+        });
+
+        proc.on("close", (code) => {
+          resolve({
+            stdout: stdoutTail.toString(),
+            stderr: stderrTail.toString(),
+            exitCode: code ?? 0,
+          });
+        });
+      });
+    }
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        "sh",
+        ["-c", command],
+        {
+          cwd: options?.cwd ?? worktreePath,
+          maxBuffer: 10 * 1024 * 1024,
+        },
+        (error, stdout, stderr) => {
+          if (error && error.code === undefined) {
+            reject(new Error(`exec failed: ${error.message}`));
+          } else {
+            resolve({
+              stdout: stdout.toString(),
+              stderr: stderr.toString(),
+              exitCode: typeof error?.code === "number" ? error.code : 0,
+            });
+          }
+        },
+      );
+    });
+  };
+
+  return {
+    worktreePath,
+    exec,
+    close: () => rm(sandboxRoot, { recursive: true, force: true }),
+  };
+};
+
+export interface StubProviderRecord {
+  readonly provider: BindMountSandboxProvider;
+  readonly createCalls: ReadonlyArray<unknown>;
+  readonly closeCalls: { count: number };
+}
+
+/**
+ * Create a no-op bind-mount sandbox provider that records `create`/`close` calls.
+ * For tests that verify call contracts without exercising filesystem behaviour.
+ */
+export const testStubProvider = (
+  options: { name?: string; worktreePath?: string } = {},
+): StubProviderRecord => {
+  const createCalls: unknown[] = [];
+  const closeCalls = { count: 0 };
+  const provider = createBindMountSandboxProvider({
+    name: options.name ?? "test-stub",
+    create: async (createOptions) => {
+      createCalls.push(createOptions);
+      const handle: BindMountSandboxHandle = {
+        worktreePath: options.worktreePath ?? "/home/agent/workspace",
+        exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+        copyFileIn: async () => {},
+        copyFileOut: async () => {},
+        close: async () => {
+          closeCalls.count++;
+        },
+      };
+      return handle;
+    },
+  });
+  return { provider, createCalls, closeCalls };
+};

--- a/src/startSandbox.test.ts
+++ b/src/startSandbox.test.ts
@@ -11,7 +11,7 @@ import {
   type BindMountSandboxHandle,
   type IsolatedSandboxHandle,
 } from "./SandboxProvider.js";
-import { Sandbox, SANDBOX_REPO_DIR } from "./SandboxFactory.js";
+import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
 import { startSandbox, COPY_PATHS_TIMEOUT_MS } from "./startSandbox.js";
 import { testIsolated } from "./sandboxes/test-isolated.js";
 import { CopyToWorktreeTimeoutError } from "./errors.js";
@@ -77,7 +77,7 @@ describe("startSandbox", () => {
       expect(createCalls[0].env).toEqual({ FOO: "bar" });
       expect(result.worktreePath).toBe(SANDBOX_REPO_DIR);
       expect(result.handle).toBeDefined();
-      expect(result.sandboxLayer).toBeDefined();
+      expect(result.sandbox).toBeDefined();
     });
 
     it("returns a working sandboxLayer", async () => {
@@ -92,7 +92,7 @@ describe("startSandbox", () => {
         }),
       });
 
-      const { sandboxLayer } = await Effect.runPromise(
+      const { sandbox } = await Effect.runPromise(
         startSandbox({
           provider,
           hostRepoDir: "/repo",
@@ -105,9 +105,8 @@ describe("startSandbox", () => {
 
       const result = await Effect.runPromise(
         Effect.gen(function* () {
-          const sandbox = yield* Sandbox;
           return yield* sandbox.exec("echo hello");
-        }).pipe(Effect.provide(sandboxLayer)),
+        }),
       );
 
       expect(result.stdout).toBe("hello");
@@ -131,7 +130,7 @@ describe("startSandbox", () => {
       await commitFile(hostDir, "hello.txt", "hello world", "initial");
 
       const provider = testIsolated();
-      const { handle, sandboxLayer, worktreePath } = await Effect.runPromise(
+      const { handle, sandbox, worktreePath } = await Effect.runPromise(
         startSandbox({
           provider,
           hostRepoDir: hostDir,
@@ -142,9 +141,8 @@ describe("startSandbox", () => {
       // Verify the repo was synced - hello.txt should exist
       const result = await Effect.runPromise(
         Effect.gen(function* () {
-          const sandbox = yield* Sandbox;
           return yield* sandbox.exec("cat hello.txt");
-        }).pipe(Effect.provide(sandboxLayer)),
+        }),
       );
 
       expect(result.stdout.trim()).toBe("hello world");
@@ -160,7 +158,7 @@ describe("startSandbox", () => {
       await writeFile(join(hostDir, "extra.txt"), "extra content");
 
       const provider = testIsolated();
-      const { handle, sandboxLayer } = await Effect.runPromise(
+      const { handle, sandbox } = await Effect.runPromise(
         startSandbox({
           provider,
           hostRepoDir: hostDir,
@@ -171,9 +169,8 @@ describe("startSandbox", () => {
 
       const result = await Effect.runPromise(
         Effect.gen(function* () {
-          const sandbox = yield* Sandbox;
           return yield* sandbox.exec("cat extra.txt");
-        }).pipe(Effect.provide(sandboxLayer)),
+        }),
       );
 
       expect(result.stdout.trim()).toBe("extra content");

--- a/src/startSandbox.ts
+++ b/src/startSandbox.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect } from "effect";
 import { existsSync } from "node:fs";
 import { join, posix } from "node:path";
 import {
@@ -20,9 +20,9 @@ import type {
   NoSandboxHandle,
 } from "./SandboxProvider.js";
 import {
-  type Sandbox,
+  type SandboxService,
   type MountEntry,
-  makeSandboxLayerFromHandle,
+  makeSandboxFromHandle,
   SANDBOX_REPO_DIR,
 } from "./SandboxFactory.js";
 import { syncIn } from "./syncIn.js";
@@ -66,7 +66,7 @@ export type StartSandboxOptions =
 
 export interface StartSandboxResult {
   handle: BindMountSandboxHandle | IsolatedSandboxHandle | NoSandboxHandle;
-  sandboxLayer: Layer.Layer<Sandbox>;
+  sandbox: SandboxService;
   worktreePath: string;
 }
 
@@ -119,7 +119,7 @@ const startNoSandbox = (
   }).pipe(
     Effect.map((handle) => ({
       handle,
-      sandboxLayer: makeSandboxLayerFromHandle(handle),
+      sandbox: makeSandboxFromHandle(handle),
       worktreePath: handle.worktreePath,
     })),
   );
@@ -162,7 +162,7 @@ const startBindMountSandbox = (
   }).pipe(
     Effect.map((handle) => ({
       handle,
-      sandboxLayer: makeSandboxLayerFromHandle(handle),
+      sandbox: makeSandboxFromHandle(handle),
       worktreePath: handle.worktreePath,
     })),
     withTimeout(
@@ -249,7 +249,7 @@ const startIsolatedSandbox = (
 
     return {
       handle,
-      sandboxLayer: makeSandboxLayerFromHandle(handle),
+      sandbox: makeSandboxFromHandle(handle),
       worktreePath: handle.worktreePath,
     };
   });

--- a/src/testSandbox.ts
+++ b/src/testSandbox.ts
@@ -1,8 +1,8 @@
 /**
- * Test helper: creates a local (filesystem-based) Sandbox layer for unit tests.
+ * Test helper: creates a local (filesystem-based) SandboxService for unit tests.
  * This replaces FilesystemSandbox which has been removed.
  */
-import { Effect, Layer } from "effect";
+import { Effect } from "effect";
 import { spawn } from "node:child_process";
 import { copyFile, mkdir } from "node:fs/promises";
 import { mkdtempSync, writeFileSync } from "node:fs";
@@ -11,7 +11,7 @@ import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { BoundedTail, MAX_TAIL_CHARS } from "./boundedTail.js";
 import { CopyError, ExecError } from "./errors.js";
-import { type ExecResult, Sandbox } from "./SandboxFactory.js";
+import { type ExecResult, type SandboxService } from "./SandboxFactory.js";
 
 /**
  * Creates an isolated git global config env so that test sandbox
@@ -24,13 +24,11 @@ const createIsolatedGitEnv = (): Record<string, string> => {
   return { GIT_CONFIG_GLOBAL: globalConfigPath };
 };
 
-export const makeLocalSandboxLayer = (
-  sandboxDir: string,
-): Layer.Layer<Sandbox> => {
+export const makeLocalSandbox = (sandboxDir: string): SandboxService => {
   const gitEnv = createIsolatedGitEnv();
   const env = { ...process.env, ...gitEnv };
 
-  return Layer.succeed(Sandbox, {
+  return {
     exec: (command, options) => {
       return Effect.async<ExecResult, ExecError>((resume) => {
         const proc = spawn("sh", ["-c", command], {
@@ -125,5 +123,5 @@ export const makeLocalSandboxLayer = (
             message: `Failed to copy ${sandboxPath} -> ${hostPath}: ${e}`,
           }),
       }),
-  });
+  };
 };


### PR DESCRIPTION
Closes #757. All five sub-tasks from the PRD are landed in this PR. 1306 tests pass; \`npm run typecheck\` is clean.

## Sub-tasks

1. **AgentStreamEmitter collapse** — single \`agentStreamEmitterLayer(onEvent?)\` factory replaces the noop/callback split.

2. **Sandbox test fakes consolidated** — \`src/sandboxes/test-shared.ts\` owns the temp-dir helper; \`testBindMount\` and \`testIsolated\` become thin adaptors. \`testStubProvider()\` replaces inline stub providers in \`SandboxFactory.test.ts\` and \`run.test.ts\`.

3. **\`Sandbox\` Effect tag dropped** — \`SandboxFactory.withSandbox\` yields the \`SandboxService\` directly to its callback. Mechanical knock-ons: \`makeSandboxFromHandle\`, \`startSandbox\` returns \`{ sandbox }\`, \`withSandboxLifecycle\` takes \`sandbox\` as a third arg, \`makeLocalSandbox\` (was \`makeLocalSandboxLayer\`), \`_test.buildSandbox\` (was \`_test.buildSandboxLayer\`). ~50 \`Layer.succeed(Sandbox, {...})\` test sites became direct \`SandboxService\` objects.

4. **\`vi.mock\` of \`WorktreeManager\` removed** — \`SandboxFactory.test.ts\` rewritten to exercise the factory against a real temp git repo. Mock-based call assertions become filesystem-based assertions (worktree directory exists/is removed, branch name on the actual created worktree). Dirty-worktree paths produce a real uncommitted file inside the worktree instead of toggling a mock return.

5. **\`SessionStore\` refactor — pure JSONL transfer** — \`transferClaudeSession\` and \`transferCodexSession\` are now pure \`(jsonl, fromCwd, toCwd) → jsonl\`. \`SessionStore\` / \`LocatableSessionStore\` interfaces deleted along with \`hostSessionStore\`, \`sandboxSessionStore\`, \`codexHostSessionStore\`, \`codexSandboxSessionStore\`, and \`createMemoryStore\`. File I/O moved into provider-owned \`AgentSessionStorage\` (\`captureToHost\` / \`resumeIntoSandbox\`); call sites (Orchestrator, resumePrecheck) work against the high-level interface.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] Full vitest suite green (51 files, 1306 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)