### PR TITLE
docs: add missing agent providers and remove stale config.json reference

### DIFF
--- a/docs/content/docs/agents.mdx
+++ b/docs/content/docs/agents.mdx
@@ -32,7 +32,47 @@ Required environment variables:
 
 | Variable | Description |
 | --- | --- |
-| `GH_TOKEN` | GitHub personal access token |
+| `OPENCODE_API_KEY` | OpenCode API key |
+
+### Pi
+
+Uses Pi as the AI coding agent.
+
+Required environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `ANTHROPIC_API_KEY` | Anthropic API key |
+
+### Codex
+
+Uses OpenAI Codex CLI as the AI coding agent.
+
+Required environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `OPENAI_KEY` | OpenAI API key |
+
+### Cursor
+
+Uses Cursor as the AI coding agent.
+
+Required environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `CURSOR_API_KEY` | Cursor API key |
+
+### GitHub Copilot CLI
+
+Uses GitHub Copilot CLI as the AI coding agent.
+
+Required environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `GITHUB_TOKEN` | GitHub token with the "Copilot Requests" permission (a fine-grained PAT, or any token from `gh auth login`) |
 
 ## Custom Providers
 

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -7,28 +7,10 @@ description: Configure Sandcastle for your project.
 
 The `.sandcastle/` directory in your repository contains all Sandcastle configuration:
 
-- `config.json` -- Main configuration file
+- `main.ts` / `main.mts` -- Entry point that calls `run()` with your agent and sandbox options
 - `Dockerfile` -- Defines the sandbox environment
 - `prompt.md` -- The prompt sent to the agent each iteration
 - `.env` / `.env.example` -- Environment variables for the sandbox
-
-## Config File
-
-The `config.json` file controls how Sandcastle operates:
-
-```json
-{
-  "agent": "claude-code",
-  "maxIterations": 10
-}
-```
-
-### Options
-
-| Option | Description | Default |
-| --- | --- | --- |
-| `agent` | The agent provider to use | `"claude-code"` |
-| `maxIterations` | Maximum iterations per run | `10` |
 
 ## Prompt
 


### PR DESCRIPTION
Two things were out of sync with the actual codebase:

**agents.mdx** only listed Claude Code and OpenCode. The other four built-in providers from `InitService.ts` were missing. Added Pi, Codex, Cursor, and GitHub Copilot CLI with their required env vars. Also corrected OpenCode's env var — it's `OPENCODE_API_KEY`, not `GH_TOKEN`.

**configuration.mdx** described a `config.json` file that no longer exists. Sandcastle is configured via `main.ts` / `main.mts`. Removed the Config File section and updated the Config Directory listing to show the actual scaffolded files.

## Test plan

- [x] `npm run typecheck` — clean
- [x] Env vars verified against `InitService.ts` agent definitions
- [x] No `config.json` in any template under `src/templates/`