### PR TITLE
fix(createSandbox): forward bindMountHandle so session capture works in sandbox.run()

### DIFF
--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -303,6 +303,9 @@ const buildSandboxHandle = (
               hostWorktreePath: worktreePath,
               sandboxRepoPath: sandboxRepoDir,
               applyToHost,
+              bindMountHandle: providerHandle as
+                | BindMountSandboxHandle
+                | undefined,
             },
             sandbox,
           ).pipe(


### PR DESCRIPTION
## Summary

`createSandbox()` + `sandbox.run()` has always skipped session capture, which also broke context-window size reporting. Root cause: `reuseFactoryLayer` inside `buildSandboxHandle.run()` never forwarded `bindMountHandle` to the `withSandbox` callback. The Orchestrator's session-capture gate requires all four conditions — `captureSessions`, `sessionStorage`, `sessionId`, and `bindMountHandle` — so the last one being `undefined` silently disabled the whole thing.

`providerHandle` was already in the closure. One-line fix: pass it through as `bindMountHandle`.

## Test plan

- [x] `npm run typecheck` passes (no errors)
- [x] `npm test` passes (exit code 0)

Closes #717