### PR TITLE
Fix #795: use --prompt arg with OpenCode 

### DIFF
--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1238,7 +1238,7 @@ describe("opencode factory", () => {
       "opencode/big-pickle",
       "--agent",
       "build",
-      "-p",
+      "--prompt",
       "do something",
     ]);
   });

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -901,7 +901,7 @@ export const opencode = (
   buildInteractiveArgs({ prompt }: AgentCommandOptions): string[] {
     const args = ["opencode", "--model", model];
     if (options?.agent) args.push("--agent", options.agent);
-    if (prompt) args.push("-p", prompt);
+    if (prompt) args.push("--prompt", prompt);
     return args;
   },
 

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -1376,7 +1376,7 @@ describe("InitService scaffold", () => {
       { name: "pi", command: `pi "$(cat .sandcastle/SETUP_ISSUE_TRACKER.md)"` },
       {
         name: "opencode",
-        command: `opencode -p "$(cat .sandcastle/SETUP_ISSUE_TRACKER.md)"`,
+        command: `opencode --prompt "$(cat .sandcastle/SETUP_ISSUE_TRACKER.md)"`,
       },
       {
         name: "copilot",

--- a/src/InitService.test.ts
+++ b/src/InitService.test.ts
@@ -13,13 +13,8 @@ import {
   getIssueTracker,
   getSandboxProvider,
 } from "./InitService.js";
-import type {
-  AgentEntry,
-  PackageManager,
-  ScaffoldOptions,
-} from "./InitService.js";
+import type { PackageManager, ScaffoldOptions } from "./InitService.js";
 import { SANDBOX_REPO_DIR } from "./SandboxFactory.js";
-import { SKELETON_PROMPT } from "./templates.js";
 
 const makeDir = () => mkdtemp(join(tmpdir(), "init-service-"));
 

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -457,7 +457,7 @@ CURSOR_API_KEY=`,
     dockerfileTemplate: OPENCODE_DOCKERFILE,
     envExample: `# OpenCode API key
 OPENCODE_API_KEY=`,
-    setupCommand: `opencode -p "$(cat ${SETUP_ISSUE_TRACKER_PATH})"`,
+    setupCommand: `opencode --prompt "$(cat ${SETUP_ISSUE_TRACKER_PATH})"`,
   },
   {
     name: "copilot",

--- a/src/interactive.test.ts
+++ b/src/interactive.test.ts
@@ -59,19 +59,19 @@ describe("buildInteractiveArgs with prompts", () => {
     expect(args).not.toContain("");
   });
 
-  it("opencode passes prompt via -p flag", () => {
+  it("opencode passes prompt via --prompt flag", () => {
     const provider = opencode("opencode/big-pickle");
     const args = provider.buildInteractiveArgs!(interactiveOpts("fix the bug"));
     expect(args[0]).toBe("opencode");
-    const pIdx = args.indexOf("-p");
+    const pIdx = args.indexOf("--prompt");
     expect(pIdx).toBeGreaterThan(-1);
     expect(args[pIdx + 1]).toBe("fix the bug");
   });
 
-  it("opencode omits -p flag when prompt is empty", () => {
+  it("opencode omits --prompt flag when prompt is empty", () => {
     const provider = opencode("opencode/big-pickle");
     const args = provider.buildInteractiveArgs!(interactiveOpts(""));
-    expect(args).not.toContain("-p");
+    expect(args).not.toContain("--prompt");
   });
 });
 


### PR DESCRIPTION
All OpenCode launching code used -p as prompt arg, uses --prompt now. This allows to run OpenCode in interactive mode correctly.