### PR TITLE
Fix/feat: changes for observability + retry robustness on resumeSession using sessionId

### DIFF
--- a/.changeset/calm-files-divide.md
+++ b/.changeset/calm-files-divide.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Preserve Claude Code session metadata on cancelled runs when a session ID was observed before abort.

--- a/.changeset/session-carry-forward.md
+++ b/.changeset/session-carry-forward.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Carry forward captured Claude Code sessions across multi-iteration runs so later iterations resume from the previous iteration's session when supported.

--- a/.changeset/structured-agent-stream-events.md
+++ b/.changeset/structured-agent-stream-events.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Expand `onAgentStreamEvent` to emit provider-observable `result` and `sessionId` events in addition to `text` and `toolCall`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -213,5 +213,5 @@ The display mode where Sandcastle renders an interactive UI in the terminal with
 _Avoid_: "stdout mode", "interactive mode", "CLI mode" (ambiguous with the CLI itself)
 
 **Agent stream event**:
-A single item in the **agent**'s output stream -- either a `text` chunk or a `toolCall` -- surfaced to the caller of `run()` so the stream can be forwarded to an external observability system. Available only in **log-to-file mode** via the `onAgentStreamEvent` callback on the `logging` option. Each event carries its `iteration` number and a `timestamp`.
+A single provider-observable item in the **agent**'s output stream -- currently `text`, `toolCall`, `result`, or `sessionId` -- surfaced to the caller of `run()` so the stream can be forwarded to an external observability system. Available only in **log-to-file mode** via the `onAgentStreamEvent` callback on the `logging` option. Each event carries its `iteration` number and a `timestamp`.
 _Avoid_: "log event" (the log file contains more than just agent output), "display entry" (internal UI type)

--- a/README.md
+++ b/README.md
@@ -471,23 +471,23 @@ await sandbox.close();
 
 #### `WorktreeRunOptions`
 
-| Option                     | Type                   | Default | Description                                                                                                                          |
-| -------------------------- | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `agent`                    | AgentProvider          | —       | **Required.** Agent provider                                                                                                         |
-| `sandbox`                  | SandboxProvider        | —       | **Required.** Sandbox provider (AFK agents must be sandboxed)                                                                        |
-| `prompt`                   | string                 | —       | Inline prompt (mutually exclusive with `promptFile`)                                                                                 |
-| `promptFile`               | string                 | —       | Path to prompt file                                                                                                                  |
-| `maxIterations`            | number                 | 1       | Maximum iterations to run                                                                                                            |
-| `completionSignal`         | string \| string[]     | —       | Substring(s) to stop the iteration loop early                                                                                        |
-| `idleTimeoutSeconds`       | number                 | 600     | Idle timeout in seconds                                                                                                              |
-| `completionTimeoutSeconds` | number                 | 60      | Grace window after completion signal is seen but agent process hasn't exited                                                         |
-| `name`                     | string                 | —       | Optional run name                                                                                                                    |
-| `logging`                  | LoggingOption          | file    | Logging mode                                                                                                                         |
-| `hooks`                    | SandboxHooks           | —       | Lifecycle hooks (`host.*`, `sandbox.*`)                                                                                              |
-| `promptArgs`               | PromptArgs             | —       | Key-value map for `{{KEY}}` placeholder substitution                                                                                 |
-| `env`                      | Record<string, string> | —       | Environment variables to inject into the sandbox                                                                                     |
-| `resumeSession`            | string                 | —       | Resume a prior session by ID for agents that support resume. Incompatible with `maxIterations > 1`. Session file must exist on host. |
-| `signal`                   | AbortSignal            | —       | Cancel the run when aborted. Kills the in-flight agent subprocess; the worktree is preserved on disk. Rejects with `signal.reason`.  |
+| Option                     | Type                   | Default | Description                                                                                                                                                                                            |
+| -------------------------- | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `agent`                    | AgentProvider          | —       | **Required.** Agent provider                                                                                                                                                                           |
+| `sandbox`                  | SandboxProvider        | —       | **Required.** Sandbox provider (AFK agents must be sandboxed)                                                                                                                                          |
+| `prompt`                   | string                 | —       | Inline prompt (mutually exclusive with `promptFile`)                                                                                                                                                   |
+| `promptFile`               | string                 | —       | Path to prompt file                                                                                                                                                                                    |
+| `maxIterations`            | number                 | 1       | Maximum iterations to run                                                                                                                                                                              |
+| `completionSignal`         | string \| string[]     | —       | Substring(s) to stop the iteration loop early                                                                                                                                                          |
+| `idleTimeoutSeconds`       | number                 | 600     | Idle timeout in seconds                                                                                                                                                                                |
+| `completionTimeoutSeconds` | number                 | 60      | Grace window after completion signal is seen but agent process hasn't exited                                                                                                                           |
+| `name`                     | string                 | —       | Optional run name                                                                                                                                                                                      |
+| `logging`                  | LoggingOption          | file    | Logging mode                                                                                                                                                                                           |
+| `hooks`                    | SandboxHooks           | —       | Lifecycle hooks (`host.*`, `sandbox.*`)                                                                                                                                                                |
+| `promptArgs`               | PromptArgs             | —       | Key-value map for `{{KEY}}` placeholder substitution                                                                                                                                                   |
+| `env`                      | Record<string, string> | —       | Environment variables to inject into the sandbox                                                                                                                                                       |
+| `resumeSession`            | string                 | —       | Resume a prior session by ID for agents that support resume. Session file must exist on host. On multi-iteration runs, later iterations resume from the most recently captured session when supported. |
+| `signal`                   | AbortSignal            | —       | Cancel the run when aborted. Kills the in-flight agent subprocess; the worktree is preserved on disk. Rejects with `signal.reason`.                                                                    |
 
 #### `WorktreeRunResult`
 
@@ -795,7 +795,7 @@ Removes the Podman image.
 | `completionSignal`         | string \| string[] | `<promise>COMPLETE</promise>` | String or array of strings the agent emits to stop the iteration loop early                                                                                                                                                  |
 | `idleTimeoutSeconds`       | number             | `600`                         | Idle timeout in seconds — resets on each agent output event                                                                                                                                                                  |
 | `completionTimeoutSeconds` | number             | `60`                          | Grace window in seconds after the completion signal is observed but the agent process has not exited (hanging process). See [Hanging processes after the completion signal](#hanging-processes-after-the-completion-signal). |
-| `resumeSession`            | string             | —                             | Resume a prior session by ID for agents that support resume. Incompatible with `maxIterations > 1`. Session file must exist on host.                                                                                         |
+| `resumeSession`            | string             | —                             | Resume a prior session by ID for agents that support resume. Session file must exist on host. On multi-iteration runs, later iterations resume from the most recently captured session when supported.                       |
 | `signal`                   | AbortSignal        | —                             | Cancel the run when aborted. Kills the in-flight agent subprocess and cancels lifecycle hooks; the worktree is preserved on disk. Rejects with `signal.reason`.                                                              |
 | `timeouts`                 | Timeouts           | —                             | Override default timeouts for built-in lifecycle steps: `copyToWorktreeMs` (60 000), `gitSetupMs` (10 000), `commitCollectionMs` (30 000), `mergeToHostMs` (30 000).                                                         |
 | `output`                   | OutputDefinition   | —                             | Structured output definition (`Output.object(…)` or `Output.string(…)`). Requires `maxIterations === 1`. See [Structured output](#structured-output).                                                                        |
@@ -864,12 +864,37 @@ const second = await first.resume?.("Now implement the plan");
 
 Before the sandbox starts, Sandcastle validates that the session file exists on the host and transfers it into the sandbox with `cwd` fields rewritten to match the sandbox-side path. Claude Code receives `--resume <id>`; Codex receives `codex exec resume <id>` with the prompt piped over stdin; Pi receives `--session <id>`.
 
+On multi-iteration runs, Sandcastle captures the session produced by each iteration and feeds the latest captured session ID into the next iteration when the provider supports resume. This means an initial `resumeSession` seeds iteration 1, then later iterations continue from the most recently captured session instead of starting fresh.
+
 Constraints:
 
-- `resumeSession` is incompatible with `maxIterations > 1` (throws before sandbox creation).
 - The provider's host session file must exist (throws before sandbox creation).
-- Only iteration 1 receives the resume flag; subsequent iterations (if any) start fresh.
 - Providers without resume support reject `resumeSession`.
+
+### Abort metadata on cancelled runs
+
+If a run is cancelled after Sandcastle has already observed a provider session ID, the thrown abort reason is preserved exactly as `signal.reason`, but Sandcastle now attaches non-enumerable metadata describing any completed iterations plus the partial cancelled iteration.
+
+Use `getAbortMetadata(error)` to recover that information:
+
+```typescript
+import { getAbortMetadata } from "@ai-hero/sandcastle";
+
+try {
+  await run({
+    agent: claudeCode("claude-opus-4-7"),
+    sandbox: docker(),
+    prompt: "Do work",
+    signal,
+  });
+} catch (error) {
+  const metadata = getAbortMetadata(error);
+  console.log(metadata?.iterations.at(-1)?.sessionId);
+  console.log(metadata?.iterations.at(-1)?.sessionFilePath);
+}
+```
+
+This is best-effort: metadata is attached only when `signal.reason` is object-like, and partial session capture during abort is attempted but not guaranteed.
 
 ### Session fork
 

--- a/README.md
+++ b/README.md
@@ -217,15 +217,20 @@ const result = await run({
   logging: {
     type: "file",
     path: ".sandcastle/logs/my-run.log",
-    // Optional: forward the agent's output stream to your own observability system.
-    // Fires for each text chunk and tool call the agent produces. Errors thrown
-    // by the callback are swallowed so a broken forwarder cannot kill the run.
+    // Optional: forward provider-observable agent stream events to your own
+    // observability system. Currently emits `text`, `toolCall`, `result`, and
+    // `sessionId` events. Errors thrown by the callback are swallowed so a
+    // broken forwarder cannot kill the run.
     onAgentStreamEvent: (event) => {
-      // event is { type: "text" | "toolCall", iteration, timestamp, ... }
+      // event carries { type, iteration, timestamp, ... }
       myLogger.info(event);
     },
   },
   // logging: { type: "stdout" }, // OR render an interactive UI in the terminal
+
+  // Note: emitted event types are limited to what current providers expose
+  // reliably today. `result` may duplicate final assistant text, and `sessionId`
+  // is only emitted when the provider exposes a session identifier.
 
   // String (or array of strings) the agent emits to end the iteration loop early.
   // Default: "<promise>COMPLETE</promise>"

--- a/src/AbortMetadata.ts
+++ b/src/AbortMetadata.ts
@@ -1,0 +1,38 @@
+import type { IterationResult } from "./Orchestrator.js";
+
+const RUN_ABORT_METADATA = Symbol.for("@ai-hero/sandcastle/run-abort-metadata");
+
+export interface RunAbortMetadata {
+  readonly iterations: IterationResult[];
+}
+
+const isObjectLike = (value: unknown): value is Record<PropertyKey, unknown> =>
+  typeof value === "object" && value !== null;
+
+export const attachAbortMetadata = (
+  reason: unknown,
+  metadata: RunAbortMetadata,
+): void => {
+  if (!isObjectLike(reason)) return;
+  Object.defineProperty(reason, RUN_ABORT_METADATA, {
+    value: metadata,
+    configurable: true,
+    enumerable: false,
+    writable: true,
+  });
+};
+
+export const getAbortMetadata = (
+  error: unknown,
+): RunAbortMetadata | undefined => {
+  if (!isObjectLike(error)) return undefined;
+  const metadata = error[RUN_ABORT_METADATA];
+  if (
+    typeof metadata === "object" &&
+    metadata !== null &&
+    Array.isArray((metadata as RunAbortMetadata).iterations)
+  ) {
+    return metadata as RunAbortMetadata;
+  }
+  return undefined;
+};

--- a/src/AgentStreamEmitter.ts
+++ b/src/AgentStreamEmitter.ts
@@ -1,8 +1,8 @@
 import { Context, Effect, Layer } from "effect";
 
 /**
- * A single event in the agent's output stream, surfaced to callers of `run()`
- * so they can forward it to their own observability system.
+ * A single provider-observable event in the agent's output stream, surfaced to
+ * callers of `run()` so they can forward it to their own observability system.
  *
  * Emitted only in log-to-file mode when an `onAgentStreamEvent` callback is
  * provided via `logging`. See `run()`.
@@ -18,6 +18,18 @@ export type AgentStreamEvent =
       readonly type: "toolCall";
       readonly name: string;
       readonly formattedArgs: string;
+      readonly iteration: number;
+      readonly timestamp: Date;
+    }
+  | {
+      readonly type: "result";
+      readonly result: string;
+      readonly iteration: number;
+      readonly timestamp: Date;
+    }
+  | {
+      readonly type: "sessionId";
+      readonly sessionId: string;
       readonly iteration: number;
       readonly timestamp: Date;
     };

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -34,6 +34,7 @@ import {
   agentStreamEmitterLayer,
   type AgentStreamEvent,
 } from "./AgentStreamEmitter.js";
+import { getAbortMetadata } from "./AbortMetadata.js";
 import type { BindMountSandboxHandle } from "./SandboxProvider.js";
 
 const noopAgentStreamEmitterLayer = agentStreamEmitterLayer();
@@ -3057,8 +3058,15 @@ describe("Session capture integration", () => {
    */
   const makeSessionCaptureFactory = (
     hostRepoDir: string,
-    mockAgentBehavior: (sandboxRepoDir: string) => Promise<string>,
+    mockAgentBehavior: (
+      sandboxRepoDir: string,
+      command: string,
+      iterationIndex: number,
+    ) => Promise<string>,
     sessionId: string,
+    factoryOptions?: {
+      emitInitBeforeBehavior?: boolean;
+    },
   ): { factoryLayer: Layer.Layer<SandboxFactory> } => {
     const sandboxBaseDir = join(tmpdir(), `orch-session-${randomUUID()}`);
     let branchCounter = 0;
@@ -3108,10 +3116,25 @@ describe("Session capture integration", () => {
                   const onLine = options.onLine;
                   return Effect.gen(function* () {
                     const cwd = options?.cwd ?? sandboxBaseDir;
+                    const iterationIndex = branchCounter - 1;
+                    if (factoryOptions?.emitInitBeforeBehavior) {
+                      onLine(
+                        JSON.stringify({
+                          type: "system",
+                          subtype: "init",
+                          session_id: sessionId,
+                        }),
+                      );
+                    }
                     const output = yield* Effect.promise(() =>
-                      mockAgentBehavior(cwd),
+                      mockAgentBehavior(cwd, command, iterationIndex),
                     );
-                    const streamOutput = toStreamJson(output, sessionId);
+                    const streamOutput = toStreamJson(
+                      output,
+                      factoryOptions?.emitInitBeforeBehavior
+                        ? undefined
+                        : sessionId,
+                    );
                     for (const line of streamOutput.split("\n")) {
                       onLine(line);
                     }
@@ -3619,6 +3642,72 @@ describe("Session capture integration", () => {
     );
 
     expect(result.iterations[0]!.usage).toBeUndefined();
+  });
+
+  it("preserves partial session metadata when aborted after the session ID is observed", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-abort-session-host-"));
+    const hostProjectsDir = await mkdtemp(
+      join(tmpdir(), "orch-abort-session-projects-"),
+    );
+    const sandboxProjectsDir = await mkdtemp(
+      join(tmpdir(), "orch-abort-session-sb-projects-"),
+    );
+    const provider = claudeCode("test-model", {
+      sessionStorage: { hostProjectsDir, sandboxProjectsDir },
+    });
+    const mockSessionId = "abort-session-123";
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const reason = new DOMException("cancelled mid-iteration", "AbortError");
+    const ac = new AbortController();
+
+    const { factoryLayer } = makeSessionCaptureFactory(
+      hostDir,
+      async (repoDir) => {
+        const encoded = encodeProjectPath(repoDir);
+        const sessionsDir = join(sandboxProjectsDir, encoded);
+        await mkdir(sessionsDir, { recursive: true });
+        await writeFile(
+          join(sessionsDir, `${mockSessionId}.jsonl`),
+          [
+            JSON.stringify({ type: "system", cwd: repoDir }),
+            JSON.stringify({ type: "message", cwd: repoDir, text: "hello" }),
+          ].join("\n"),
+        );
+        ac.abort(reason);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return "Done.";
+      },
+      mockSessionId,
+      { emitInitBeforeBehavior: true },
+    );
+
+    await expect(
+      Effect.runPromise(
+        orchestrate({
+          provider,
+          hostRepoDir: hostDir,
+          iterations: 1,
+          prompt: "do some work",
+          signal: ac.signal,
+        }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+      ),
+    ).rejects.toThrow("cancelled mid-iteration");
+
+    expect(ac.signal.reason).toBe(reason);
+    const metadata = getAbortMetadata(reason);
+    expect(metadata?.iterations).toHaveLength(1);
+    expect(metadata?.iterations[0]!.sessionId).toBe(mockSessionId);
+    expect(metadata?.iterations[0]!.sessionFilePath).toBeDefined();
+
+    const capturedPath = metadata?.iterations[0]!.sessionFilePath!;
+    const capturedContent = await readFile(capturedPath, "utf-8");
+    const firstEntry = JSON.parse(capturedContent.split("\n")[0]!) as {
+      cwd: string;
+    };
+    expect(firstEntry.cwd).toBe(hostDir);
   });
 });
 

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -3057,8 +3057,12 @@ describe("Session capture integration", () => {
    */
   const makeSessionCaptureFactory = (
     hostRepoDir: string,
-    mockAgentBehavior: (sandboxRepoDir: string) => Promise<string>,
-    sessionId: string,
+    mockAgentBehavior: (
+      sandboxRepoDir: string,
+      command: string,
+      iterationIndex: number,
+    ) => Promise<string>,
+    sessionId: string | ((iterationIndex: number) => string),
   ): { factoryLayer: Layer.Layer<SandboxFactory> } => {
     const sandboxBaseDir = join(tmpdir(), `orch-session-${randomUUID()}`);
     let branchCounter = 0;
@@ -3108,10 +3112,18 @@ describe("Session capture integration", () => {
                   const onLine = options.onLine;
                   return Effect.gen(function* () {
                     const cwd = options?.cwd ?? sandboxBaseDir;
+                    const iterationIndex = branchCounter - 1;
                     const output = yield* Effect.promise(() =>
-                      mockAgentBehavior(cwd),
+                      mockAgentBehavior(cwd, command, iterationIndex),
                     );
-                    const streamOutput = toStreamJson(output, sessionId);
+                    const effectiveSessionId =
+                      typeof sessionId === "function"
+                        ? sessionId(iterationIndex)
+                        : sessionId;
+                    const streamOutput = toStreamJson(
+                      output,
+                      effectiveSessionId,
+                    );
                     for (const line of streamOutput.split("\n")) {
                       onLine(line);
                     }
@@ -3359,6 +3371,88 @@ describe("Session capture integration", () => {
     const capturedLines = capturedContent.split("\n");
     const entry = JSON.parse(capturedLines[0]!) as { cwd: string };
     expect(entry.cwd).toBe(hostDir);
+  });
+
+  it("carries forward the captured sessionId across iterations when the provider supports sessions", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-carry-host-"));
+    const hostProjectsDir = await mkdtemp(
+      join(tmpdir(), "orch-carry-projects-"),
+    );
+    const sandboxProjectsDir = await mkdtemp(
+      join(tmpdir(), "orch-carry-sb-projects-"),
+    );
+    const provider = claudeCode("test-model", {
+      sessionStorage: { hostProjectsDir, sandboxProjectsDir },
+    });
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const sessionIds = ["iter-1-session", "iter-2-session"] as const;
+    const seenResumeArgs: string[] = [];
+    let iteration = 0;
+
+    const { factoryLayer } = makeSessionCaptureFactory(
+      hostDir,
+      async (repoDir, command) => {
+        const expectedResume = iteration === 0 ? undefined : sessionIds[0];
+        const actualResume = command
+          .match(/--resume\s+([^\s]+)/)?.[1]
+          ?.replace(/^['"]|['"]$/g, "");
+        seenResumeArgs.push(actualResume ?? "");
+        expect(actualResume).toBe(expectedResume);
+
+        if (iteration > 0) {
+          const sbEncoded = encodeProjectPath(repoDir);
+          const resumedPath = join(
+            sandboxProjectsDir,
+            sbEncoded,
+            `${sessionIds[0]}.jsonl`,
+          );
+          const resumed = await readFile(resumedPath, "utf-8");
+          expect(resumed).toContain("first iteration work");
+        }
+
+        const sbEncoded = encodeProjectPath(repoDir);
+        const sessionsDir = join(sandboxProjectsDir, sbEncoded);
+        await mkdir(sessionsDir, { recursive: true });
+        const currentSessionId = sessionIds[iteration]!;
+        await writeFile(
+          join(sessionsDir, `${currentSessionId}.jsonl`),
+          [
+            JSON.stringify({ type: "system", cwd: repoDir }),
+            JSON.stringify({
+              type: "message",
+              cwd: repoDir,
+              text:
+                iteration === 0
+                  ? "first iteration work"
+                  : "second iteration work",
+            }),
+          ].join("\n"),
+        );
+
+        iteration++;
+        return iteration === 2
+          ? "Done. <promise>COMPLETE</promise>"
+          : "Keep going.";
+      },
+      (iterationIndex) => sessionIds[iterationIndex]!,
+    );
+
+    const result = await Effect.runPromise(
+      orchestrate({
+        provider,
+        hostRepoDir: hostDir,
+        iterations: 2,
+        prompt: "continue working",
+      }).pipe(Effect.provide(Layer.merge(factoryLayer, testDisplayLayer))),
+    );
+
+    expect(result.iterations).toHaveLength(2);
+    expect(result.iterations[0]!.sessionId).toBe(sessionIds[0]);
+    expect(result.iterations[1]!.sessionId).toBe(sessionIds[1]);
+    expect(seenResumeArgs).toEqual(["", sessionIds[0]]);
   });
 
   it("forks a session: passes --fork-session alongside --resume to claude", async () => {

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -1130,7 +1130,7 @@ describe("Orchestrator tool call display integration", () => {
 });
 
 describe("Orchestrator agent stream emitter", () => {
-  it("emits text and toolCall events with iteration index and timestamps", async () => {
+  it("emits provider-observable stream events with iteration index and timestamps", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "orch-stream-"));
     await initRepo(hostDir);
     await commitFile(hostDir, "hello.txt", "hello", "initial commit");
@@ -1198,6 +1198,8 @@ describe("Orchestrator agent stream emitter", () => {
 
     const textEvents = events.filter((e) => e.type === "text");
     const toolCallEvents = events.filter((e) => e.type === "toolCall");
+    const resultEvents = events.filter((e) => e.type === "result");
+    const sessionEvents = events.filter((e) => e.type === "sessionId");
 
     expect(textEvents.length).toBeGreaterThan(0);
     expect(textEvents[0]!.message).toContain("Working now");
@@ -1212,6 +1214,19 @@ describe("Orchestrator agent stream emitter", () => {
       iteration: 1,
     });
     expect(toolCallEvents[0]!.timestamp).toBeInstanceOf(Date);
+
+    expect(resultEvents).toHaveLength(1);
+    expect(resultEvents[0]).toMatchObject({
+      type: "result",
+      result: "<promise>COMPLETE</promise>",
+      iteration: 1,
+    });
+    expect(resultEvents[0]!.timestamp).toBeInstanceOf(Date);
+
+    // Some mock setups in this suite do not preserve the init/session event all
+    // the way through to IterationResult, so sessionId emission is asserted in
+    // the dedicated session-capture integration test below.
+    expect(sessionEvents.length).toBeGreaterThanOrEqual(0);
   });
 
   it("swallows errors thrown by the callback", async () => {
@@ -3216,6 +3231,68 @@ describe("Session capture integration", () => {
     const secondEntry = JSON.parse(lines[1]!) as { cwd: string; text: string };
     expect(secondEntry.cwd).toBe(hostDir);
     expect(secondEntry.text).toBe("hello");
+  });
+
+  it("emits a sessionId agent stream event when the provider exposes one", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "orch-stream-session-host-"));
+    const hostProjectsDir = await mkdtemp(
+      join(tmpdir(), "orch-stream-session-projects-"),
+    );
+    const sandboxProjectsDir = await mkdtemp(
+      join(tmpdir(), "orch-stream-session-sb-projects-"),
+    );
+    const provider = claudeCode("test-model", {
+      sessionStorage: { hostProjectsDir, sandboxProjectsDir },
+    });
+    const mockSessionId = "stream-session-123";
+
+    await initRepo(hostDir);
+    await commitFile(hostDir, "hello.txt", "hello", "initial commit");
+
+    const events: AgentStreamEvent[] = [];
+    const emitterLayer = agentStreamEmitterLayer((event) => {
+      events.push(event);
+    });
+
+    const { factoryLayer } = makeSessionCaptureFactory(
+      hostDir,
+      async (repoDir) => {
+        const encoded = encodeProjectPath(repoDir);
+        const sessionsDir = join(sandboxProjectsDir, encoded);
+        await mkdir(sessionsDir, { recursive: true });
+        await writeFile(
+          join(sessionsDir, `${mockSessionId}.jsonl`),
+          [
+            JSON.stringify({ type: "system", cwd: repoDir }),
+            JSON.stringify({ type: "message", cwd: repoDir, text: "hello" }),
+          ].join("\n"),
+        );
+        return "Done. <promise>COMPLETE</promise>";
+      },
+      mockSessionId,
+    );
+
+    await Effect.runPromise(
+      orchestrate({
+        provider,
+        hostRepoDir: hostDir,
+        iterations: 1,
+        prompt: "do some work",
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(factoryLayer, testDisplayLayer, emitterLayer),
+        ),
+      ),
+    );
+
+    const sessionEvents = events.filter((e) => e.type === "sessionId");
+    expect(sessionEvents).toHaveLength(1);
+    expect(sessionEvents[0]).toMatchObject({
+      type: "sessionId",
+      sessionId: mockSessionId,
+      iteration: 1,
+    });
+    expect(sessionEvents[0]!.timestamp).toBeInstanceOf(Date);
   });
 
   it("skips capture for non-Claude agents (captureSessions: false)", async () => {

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -29,6 +29,8 @@ const invokeAgent = (
   completionSignals: readonly string[],
   onText: (text: string) => void,
   onToolCall: (name: string, formattedArgs: string) => void,
+  onResult: (result: string) => void,
+  onSessionId: (sessionId: string) => void,
   onIdleWarning: (minutes: number) => void,
   onCompletionTimeout: (timeoutMs: number) => void,
   idleWarningIntervalMs: number = IDLE_WARNING_INTERVAL_MS,
@@ -152,10 +154,12 @@ const invokeAgent = (
             } else if (parsed.type === "result") {
               resultText = parsed.result;
               accumulatedOutput += parsed.result;
+              onResult(parsed.result);
             } else if (parsed.type === "tool_call") {
               onToolCall(parsed.name, parsed.args);
             } else if (parsed.type === "session_id") {
               sessionId = parsed.sessionId;
+              onSessionId(parsed.sessionId);
             } else if (parsed.type === "usage") {
               usage = parsed.usage;
             }
@@ -430,6 +434,29 @@ export const orchestrate = (
                     }),
                   );
                 };
+                const onResult = (result: string) => {
+                  textBuffer.flush();
+                  Effect.runPromise(
+                    streamEmitter.emit({
+                      type: "result",
+                      result,
+                      iteration: i,
+                      timestamp: new Date(),
+                    }),
+                  );
+                };
+                let emittedSessionId = false;
+                const onSessionId = (sessionId: string) => {
+                  emittedSessionId = true;
+                  Effect.runPromise(
+                    streamEmitter.emit({
+                      type: "sessionId",
+                      sessionId,
+                      iteration: i,
+                      timestamp: new Date(),
+                    }),
+                  );
+                };
                 const onIdleWarning = (minutes: number) => {
                   const msg =
                     minutes === 1
@@ -461,6 +488,8 @@ export const orchestrate = (
                   completionSignals,
                   onText,
                   onToolCall,
+                  onResult,
+                  onSessionId,
                   onIdleWarning,
                   onCompletionTimeout,
                   options._idleWarningIntervalMs,
@@ -471,6 +500,15 @@ export const orchestrate = (
 
                 // Flush any remaining buffered text deltas
                 textBuffer.dispose();
+
+                if (sessionId && !emittedSessionId) {
+                  yield* streamEmitter.emit({
+                    type: "sessionId",
+                    sessionId,
+                    iteration: i,
+                    timestamp: new Date(),
+                  });
+                }
 
                 yield* display.status(label("Agent stopped"), "info");
 

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -14,6 +14,7 @@ import { withSandboxLifecycle, type SandboxHooks } from "./SandboxLifecycle.js";
 import type { AgentProvider, IterationUsage } from "./AgentProvider.js";
 import type { Timeouts } from "./run.js";
 import { TextDeltaBuffer } from "./TextDeltaBuffer.js";
+import { attachAbortMetadata } from "./AbortMetadata.js";
 
 export type { ParsedStreamEvent, IterationUsage } from "./AgentProvider.js";
 
@@ -35,6 +36,7 @@ const invokeAgent = (
   resumeSession?: string,
   forkSession?: boolean,
   signal?: AbortSignal,
+  onObservedSessionId?: (sessionId: string) => void,
 ): Effect.Effect<
   { result: string; sessionId?: string; usage?: IterationUsage },
   SandboxError
@@ -156,6 +158,7 @@ const invokeAgent = (
               onToolCall(parsed.name, parsed.args);
             } else if (parsed.type === "session_id") {
               sessionId = parsed.sessionId;
+              onObservedSessionId?.(parsed.sessionId);
             } else if (parsed.type === "usage") {
               usage = parsed.usage;
             }
@@ -234,6 +237,13 @@ const invokeAgent = (
 
 const DEFAULT_COMPLETION_SIGNAL = "<promise>COMPLETE</promise>";
 const DEFAULT_IDLE_TIMEOUT_SECONDS = 10 * 60; // 600 seconds
+
+const enrichAbortReason = (
+  reason: unknown,
+  iterations: IterationResult[],
+): void => {
+  attachAbortMetadata(reason, { iterations });
+};
 const DEFAULT_COMPLETION_TIMEOUT_SECONDS = 60;
 
 export interface OrchestrateOptions {
@@ -401,6 +411,71 @@ export const orchestrate = (
 
                 yield* display.status(label("Agent started"), "success");
 
+                const captureSession = (
+                  sessionId: string,
+                  bestEffort: boolean,
+                  streamUsage?: IterationUsage,
+                ): Effect.Effect<
+                  {
+                    sessionFilePath: string | undefined;
+                    usage: IterationUsage | undefined;
+                  },
+                  SessionCaptureError
+                > =>
+                  Effect.gen(function* () {
+                    let sessionFilePath: string | undefined;
+                    let usage: IterationUsage | undefined = streamUsage;
+
+                    if (
+                      !provider.captureSessions ||
+                      !provider.sessionStorage ||
+                      !bindMountHandle
+                    ) {
+                      return { sessionFilePath, usage };
+                    }
+
+                    if (!bestEffort) {
+                      yield* display.status(label("Capturing session"), "info");
+                    }
+
+                    yield* Effect.tryPromise({
+                      try: () =>
+                        provider.sessionStorage!.captureToHost({
+                          hostCwd: hostRepoDir,
+                          sandboxCwd: ctx.sandboxRepoDir,
+                          sessionId,
+                          handle: bindMountHandle,
+                        }),
+                      catch: (e) =>
+                        new SessionCaptureError({
+                          message: `Session capture failed: ${e instanceof Error ? e.message : String(e)}`,
+                          sessionId,
+                        }),
+                    });
+                    sessionFilePath =
+                      provider.sessionStorage.hostSessionFilePath(
+                        hostRepoDir,
+                        sessionId,
+                      );
+
+                    if (provider.parseSessionUsage) {
+                      const content = yield* Effect.promise(() =>
+                        provider
+                          .sessionStorage!.readHostSession(
+                            hostRepoDir,
+                            sessionId,
+                          )
+                          .catch(() => undefined as string | undefined),
+                      );
+                      if (content) {
+                        const parsedUsage = provider.parseSessionUsage(content);
+                        if (parsedUsage) usage = parsedUsage;
+                      }
+                    }
+
+                    return { sessionFilePath, usage };
+                  });
+
                 // Invoke the agent — buffer text deltas so Pi's single-token
                 // chunks are displayed as readable multi-word lines.
                 const textBuffer = new TextDeltaBuffer((chunk) => {
@@ -430,6 +505,7 @@ export const orchestrate = (
                     }),
                   );
                 };
+                let observedSessionId: string | undefined;
                 const onIdleWarning = (minutes: number) => {
                   const msg =
                     minutes === 1
@@ -447,89 +523,86 @@ export const orchestrate = (
                     ),
                   );
                 };
-                const {
-                  result: agentOutput,
-                  sessionId,
-                  usage: streamUsage,
-                } = yield* invokeAgent(
-                  ctx.sandbox,
-                  ctx.sandboxRepoDir,
-                  fullPrompt,
-                  provider,
-                  idleTimeoutMs,
-                  completionTimeoutMs,
-                  completionSignals,
-                  onText,
-                  onToolCall,
-                  onIdleWarning,
-                  onCompletionTimeout,
-                  options._idleWarningIntervalMs,
-                  iterationResumeSession,
-                  iterationForkSession,
-                  options.signal,
-                );
-
-                // Flush any remaining buffered text deltas
-                textBuffer.dispose();
-
-                yield* display.status(label("Agent stopped"), "info");
-
-                // Capture session while sandbox is still alive. Usage from the
-                // stream (e.g. Codex's turn.completed) is the baseline; a
-                // session-parsed value below overrides it when available.
-                let sessionFilePath: string | undefined;
-                let usage: IterationUsage | undefined = streamUsage;
-                if (
-                  provider.captureSessions &&
-                  provider.sessionStorage &&
-                  sessionId &&
-                  bindMountHandle
-                ) {
-                  yield* display.status(label("Capturing session"), "info");
-                  yield* Effect.tryPromise({
-                    try: () =>
-                      provider.sessionStorage!.captureToHost({
-                        hostCwd: hostRepoDir,
-                        sandboxCwd: ctx.sandboxRepoDir,
-                        sessionId,
-                        handle: bindMountHandle,
-                      }),
-                    catch: (e) =>
-                      new SessionCaptureError({
-                        message: `Session capture failed: ${e instanceof Error ? e.message : String(e)}`,
-                        sessionId,
-                      }),
-                  });
-                  sessionFilePath = provider.sessionStorage.hostSessionFilePath(
-                    hostRepoDir,
+                const invokeAndCapture = Effect.gen(function* () {
+                  const {
+                    result: agentOutput,
                     sessionId,
+                    usage: streamUsage,
+                  } = yield* invokeAgent(
+                    ctx.sandbox,
+                    ctx.sandboxRepoDir,
+                    fullPrompt,
+                    provider,
+                    idleTimeoutMs,
+                    completionTimeoutMs,
+                    completionSignals,
+                    onText,
+                    onToolCall,
+                    onIdleWarning,
+                    onCompletionTimeout,
+                    options._idleWarningIntervalMs,
+                    iterationResumeSession,
+                    iterationForkSession,
+                    options.signal,
+                    (sessionId) => {
+                      observedSessionId = sessionId;
+                    },
                   );
 
-                  // Parse token usage from the captured session JSONL
-                  if (provider.parseSessionUsage) {
-                    const content = yield* Effect.promise(() =>
-                      provider
-                        .sessionStorage!.readHostSession(hostRepoDir, sessionId)
-                        .catch(() => undefined as string | undefined),
-                    );
-                    if (content) {
-                      const parsedUsage = provider.parseSessionUsage(content);
-                      if (parsedUsage) usage = parsedUsage;
-                    }
-                  }
-                }
+                  // Flush any remaining buffered text deltas
+                  textBuffer.dispose();
 
-                // Check completion signal
-                const matchedSignal = completionSignals.find((sig) =>
-                  agentOutput.includes(sig),
+                  yield* display.status(label("Agent stopped"), "info");
+
+                  const { sessionFilePath, usage } = sessionId
+                    ? yield* captureSession(sessionId, false, streamUsage)
+                    : { sessionFilePath: undefined, usage: streamUsage };
+
+                  // Check completion signal
+                  const matchedSignal = completionSignals.find((sig) =>
+                    agentOutput.includes(sig),
+                  );
+                  return {
+                    completionSignal: matchedSignal,
+                    stdout: agentOutput,
+                    sessionId,
+                    sessionFilePath,
+                    usage,
+                  } as const;
+                }).pipe(
+                  Effect.catchAllCause((cause) =>
+                    Effect.gen(function* () {
+                      textBuffer.dispose();
+                      if (options.signal?.aborted) {
+                        const partialSessionId = observedSessionId;
+                        const partialCapture = partialSessionId
+                          ? yield* captureSession(partialSessionId, true).pipe(
+                              Effect.catchAll(() =>
+                                Effect.succeed({
+                                  sessionFilePath: undefined,
+                                  usage: undefined,
+                                }),
+                              ),
+                            )
+                          : {
+                              sessionFilePath: undefined,
+                              usage: undefined,
+                            };
+                        enrichAbortReason(options.signal.reason, [
+                          ...allIterations,
+                          {
+                            sessionId: partialSessionId,
+                            sessionFilePath: partialCapture.sessionFilePath,
+                            usage: partialCapture.usage,
+                          },
+                        ]);
+                      }
+                      return yield* Effect.failCause(cause);
+                    }),
+                  ),
                 );
-                return {
-                  completionSignal: matchedSignal,
-                  stdout: agentOutput,
-                  sessionId,
-                  sessionFilePath,
-                  usage,
-                } as const;
+
+                return yield* invokeAndCapture;
               }),
           ),
       );

--- a/src/Orchestrator.ts
+++ b/src/Orchestrator.ts
@@ -333,6 +333,7 @@ export const orchestrate = (
     let allStdout = "";
     let resolvedBranch = "";
     let iterationPreservedPath: string | undefined;
+    let resumeSessionId = options.resumeSession;
 
     // Helper: check abort signal and bail via defect so run() can
     // re-throw the signal's reason verbatim (no Sandcastle wrapping).
@@ -362,9 +363,10 @@ export const orchestrate = (
             sandbox,
             (ctx) =>
               Effect.gen(function* () {
-                // Resume session: transfer JSONL from host to sandbox before iteration 1
-                const iterationResumeSession =
-                  i === 1 ? options.resumeSession : undefined;
+                // Resume session: transfer JSONL from host to sandbox before each
+                // iteration when a prior captured session is available. Forking
+                // remains a first-iteration-only behavior.
+                const iterationResumeSession = resumeSessionId;
                 const iterationForkSession =
                   i === 1 ? options.forkSession : undefined;
                 if (
@@ -546,6 +548,10 @@ export const orchestrate = (
         sessionFilePath: lifecycleResult.result.sessionFilePath,
         usage: lifecycleResult.result.usage,
       });
+
+      if (lifecycleResult.result.sessionId) {
+        resumeSessionId = lifecycleResult.result.sessionId;
+      }
 
       if (lifecycleResult.result.completionSignal !== undefined) {
         yield* display.status(

--- a/src/WorktreeManager.ts
+++ b/src/WorktreeManager.ts
@@ -2,6 +2,7 @@ import { Effect, Option } from "effect";
 import { FileSystem } from "@effect/platform";
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { join, normalize } from "node:path";
 import { WorktreeError, WorktreeTimeoutError, withTimeout } from "./errors.js";
 
@@ -335,8 +336,14 @@ export const create = (
       const existing = yield* listWorktrees(repoDir);
       const collision = findCollidingWorktree(existing, branch, worktreePath);
       if (collision) {
-        // Only reuse worktrees managed by sandcastle (under .sandcastle/worktrees/)
-        if (isManagedWorktreePath(collision.path, worktreesDir)) {
+        // Only reuse worktrees managed by sandcastle (under .sandcastle/worktrees/).
+        // Compare canonical paths so macOS /var ↔ /private/var aliases still match.
+        const canonicalCollisionPath = realpathSync.native(collision.path);
+        const canonicalWorktreesDir = realpathSync.native(worktreesDir);
+        const isManagedWorktree = canonicalCollisionPath.startsWith(
+          canonicalWorktreesDir,
+        );
+        if (isManagedWorktree) {
           const dirty = yield* hasUncommittedChanges(collision.path);
           if (dirty) {
             console.warn(
@@ -345,9 +352,9 @@ export const create = (
           } else {
             yield* fastForwardFromOrigin(collision.path, branch);
           }
-          // git reports forward slashes even on Windows; return a
-          // platform-native path so downstream join/fs calls stay consistent.
-          return { path: normalize(collision.path), branch };
+          // Preserve the originally requested path shape so callers see the
+          // same worktree path on initial create and on reuse.
+          return { path: worktreePath, branch };
         }
         // Branch is checked out in the main working tree or external worktree
         yield* Effect.fail(

--- a/src/createWorktree.test.ts
+++ b/src/createWorktree.test.ts
@@ -912,6 +912,32 @@ describe("worktree.run()", () => {
       signal: new AbortController().signal,
     };
   });
+
+  it("allows resumeSession with maxIterations > 1 and continues to session-file validation", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "ws-run-resume-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "init.txt", "init", "initial commit");
+
+    const ws = await createWorktree({
+      branchStrategy: { type: "branch", branch: "resume-validation-test" },
+      cwd: hostDir,
+    });
+
+    try {
+      await expect(
+        ws.run({
+          agent: claudeCode("claude-opus-4-7"),
+          sandbox: testSandbox,
+          prompt: "test",
+          resumeSession: "abc-123",
+          maxIterations: 2,
+        }),
+      ).rejects.toThrow('resumeSession "abc-123" not found');
+    } finally {
+      await ws.close();
+      await rm(hostDir, { recursive: true, force: true });
+    }
+  });
 });
 
 /** Dummy sandbox provider used to satisfy the required `sandbox` field in test mode. */

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -140,7 +140,7 @@ export interface WorktreeRunOptions {
   readonly hooks?: SandboxHooks;
   /** Environment variables to inject into the sandbox. */
   readonly env?: Record<string, string>;
-  /** Resume a prior Claude Code session by ID. The session JSONL must exist on the host. Incompatible with maxIterations > 1. */
+  /** Resume a prior Claude Code/Codex/Pi session by ID. The session JSONL must exist on the host. On multi-iteration runs, later iterations resume from the most recently captured session when supported. */
   readonly resumeSession?: string;
   /**
    * An `AbortSignal` that cancels the run when aborted.

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -481,13 +481,6 @@ export const createWorktree = async (
     const sandboxProvider = opts.sandbox;
     const maxIterations = opts.maxIterations ?? 1;
 
-    if (opts.resumeSession && maxIterations > 1) {
-      throw new Error(
-        "resumeSession cannot be combined with maxIterations > 1. " +
-          "Resume applies to iteration 1 only; multi-iteration resume semantics are not supported.",
-      );
-    }
-
     if (opts.resumeSession) {
       await assertResumeSessionExists({
         provider,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,9 @@ export type {
   IterationResult,
   IterationUsage,
   Timeouts,
+  RunAbortMetadata,
 } from "./run.js";
+export { getAbortMetadata } from "./run.js";
 export { interactive } from "./interactive.js";
 export type { InteractiveOptions, InteractiveResult } from "./interactive.js";
 export { createSandbox } from "./createSandbox.js";

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -408,7 +408,7 @@ describe("signal (AbortSignal)", () => {
 });
 
 describe("resumeSession validation", () => {
-  it("throws when resumeSession is set with maxIterations > 1", async () => {
+  it("allows resumeSession with maxIterations > 1 and continues to session-file validation", async () => {
     await expect(
       run({
         agent: claudeCode("claude-opus-4-7"),
@@ -418,9 +418,7 @@ describe("resumeSession validation", () => {
         resumeSession: "abc-123",
         maxIterations: 2,
       }),
-    ).rejects.toThrow(
-      "resumeSession cannot be combined with maxIterations > 1",
-    );
+    ).rejects.toThrow('resumeSession "abc-123" not found');
   });
 
   it("throws when resumeSession file does not exist on host", async () => {

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -12,6 +12,8 @@ import {
   printFileDisplayStartup,
   run,
   sanitizeBranchForFilename,
+  getAbortMetadata,
+  type RunAbortMetadata,
   type RunOptions,
   type RunResult,
 } from "./run.js";
@@ -146,6 +148,21 @@ describe("buildCompletionMessage", () => {
   it("reflects the correct iteration count for 1 iteration", () => {
     const result = buildCompletionMessage("<promise>COMPLETE</promise>", 1);
     expect(result.message).toContain("1 iteration(s)");
+  });
+});
+
+describe("RunAbortMetadata", () => {
+  it("is exported from run.ts", () => {
+    const metadata: RunAbortMetadata = {
+      iterations: [{ sessionId: "abc-123" }],
+    };
+
+    expect(metadata.iterations[0]!.sessionId).toBe("abc-123");
+  });
+
+  it("returns undefined for errors without Sandcastle abort metadata", () => {
+    expect(getAbortMetadata(new Error("no metadata"))).toBeUndefined();
+    expect(getAbortMetadata("cancelled")).toBeUndefined();
   });
 });
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -409,14 +409,6 @@ export async function run(
     );
   }
 
-  // Validate: resumeSession + maxIterations > 1 is not allowed
-  if (options.resumeSession && maxIterations > 1) {
-    throw new Error(
-      "resumeSession cannot be combined with maxIterations > 1. " +
-        "Resume applies to iteration 1 only; multi-iteration resume semantics are not supported.",
-    );
-  }
-
   // Validate: forkSession only makes sense alongside resumeSession.
   // It is wired internally by RunResult.fork() and never set on its own.
   if (options.forkSession && !options.resumeSession) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -266,7 +266,7 @@ export interface RunOptions<A extends AgentProvider = AgentProvider> {
   /** Branch strategy — controls how the agent's changes relate to branches.
    * Defaults to { type: "head" } for bind-mount providers and { type: "merge-to-head" } for isolated providers. */
   readonly branchStrategy?: BranchStrategy;
-  /** Resume a prior Claude Code session by ID. The session JSONL must exist on the host. Incompatible with maxIterations > 1. */
+  /** Resume a prior Claude Code/Codex/Pi session by ID. The session JSONL must exist on the host. On multi-iteration runs, later iterations resume from the most recently captured session when supported. */
   readonly resumeSession?: string;
   /**
    * When true alongside `resumeSession`, fork the session instead of mutating

--- a/src/run.ts
+++ b/src/run.ts
@@ -179,6 +179,9 @@ export const buildContextWindowLines = (
  * Use `"file"` (log-to-file mode) to write to a log file on disk, or
  * `"stdout"` (terminal mode) to render an interactive UI in the terminal.
  */
+export type { RunAbortMetadata } from "./AbortMetadata.js";
+export { getAbortMetadata } from "./AbortMetadata.js";
+
 export type LoggingOption =
   /** Write progress and agent output to a log file at the given path (log-to-file mode). */
   | {

--- a/src/run.ts
+++ b/src/run.ts
@@ -185,10 +185,11 @@ export type LoggingOption =
       readonly type: "file";
       readonly path: string;
       /**
-       * Optional callback invoked for each agent stream event (text chunk or
-       * tool call) in addition to being written to the log file. Intended for
-       * forwarding the agent's output stream to external observability
-       * systems. Errors thrown by the callback are swallowed.
+       * Optional callback invoked for each provider-observable agent stream
+       * event (`text`, `toolCall`, `result`, or `sessionId`) in addition to
+       * being written to the log file. Intended for forwarding the agent's
+       * output stream to external observability systems. Errors thrown by the
+       * callback are swallowed.
        */
       readonly onAgentStreamEvent?: (event: AgentStreamEvent) => void;
     }


### PR DESCRIPTION
- Preserves Claude session data on canceled run
- Fixes resumeSession Incompatible with `maxIterations > 1`; removed limitation entirely
- Expand `onAgentStreamEvent` to emit data to support above fixes and increase observability