### PR TITLE
feat: capture Claude subagent & workflow session logs to host

### DIFF
--- a/.changeset/capture-claude-subagent-logs.md
+++ b/.changeset/capture-claude-subagent-logs.md
@@ -1,0 +1,7 @@
+---
+"@ai-hero/sandcastle": minor
+---
+
+Capture subagent and workflow session logs from the Claude Code sandbox to the host alongside the main session transcript.
+
+Previously, logs written by `Agent`-tool subagents and `Workflow` runs were lost on sandbox teardown. They are now copied out with the same `cwd` path rewrite applied. Capture is best-effort: a corrupt or unreadable subagent log is skipped with a warning rather than aborting the rest of the capture.

--- a/README.md
+++ b/README.md
@@ -828,6 +828,8 @@ Removes the Podman image.
 
 After each resumable provider iteration, Sandcastle automatically captures the agent's session file from the sandbox to the host. Claude Code sessions are stored under `~/.claude/projects/<encoded-path>/<session-id>.jsonl`; Codex sessions are stored under `~/.codex/sessions/YYYY/MM/DD/rollout-*-<session-id>.jsonl`; Pi sessions are stored under `~/.pi/agent/sessions/--<encoded-cwd>--/<timestamp>_<session-id>.jsonl`. Any provider-specific `cwd` fields are rewritten to match the host repo root, so the provider's native resume command works.
 
+For Claude Code, transcripts written by `Agent`-tool subagents and `Workflow` runs (under `<encoded-path>/<session-id>/subagents/agent-*.jsonl`) are captured alongside the main session with the same `cwd` rewrite. Capture of these sub-session logs is best-effort: a corrupt or unreadable one is skipped with a warning rather than failing the run.
+
 Session capture is enabled by default for `claudeCode()`, `codex()`, and `pi()` and can be opted out via `captureSessions: false`. Providers without `sessionStorage` do not attempt capture. Capture failure fails the run.
 
 ### Session resume

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, posix } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   claudeCode,
   codex,
@@ -2349,6 +2349,243 @@ describe("sessionStorage", () => {
       const content = await readFile(captured!, "utf-8");
       expect(JSON.parse(content).payload.cwd).toBe("/host/repo");
     } finally {
+      await rm(hostDir, { recursive: true, force: true });
+      await rm(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  // (a) No subagents dir — only the main session is copied.
+  it("claudeCode captureToHost with no subagents dir copies only the main session", async () => {
+    const hostDir = await mkdtemp(
+      join(tmpdir(), "sandcastle-claude-sub-a-host-"),
+    );
+    const sandboxDir = await mkdtemp(
+      join(tmpdir(), "sandcastle-claude-sub-a-sbx-"),
+    );
+    try {
+      const id = "cap-sub-1";
+      const sandboxCwd = "/sandbox/repo";
+      const hostCwd = "/host/repo";
+      const sandboxMainDir = join(sandboxDir, "-sandbox-repo");
+      await mkdir(sandboxMainDir, { recursive: true });
+      await writeFile(
+        join(sandboxMainDir, `${id}.jsonl`),
+        JSON.stringify({ type: "user", cwd: sandboxCwd, sessionId: id }),
+      );
+
+      const provider = claudeCode("claude-opus-4-7", {
+        sessionStorage: {
+          hostProjectsDir: hostDir,
+          sandboxProjectsDir: sandboxDir,
+        },
+      });
+      await provider.sessionStorage!.captureToHost({
+        hostCwd,
+        sandboxCwd,
+        sessionId: id,
+        handle: fsBindMountHandle(),
+      });
+
+      const mainContent = await readFile(
+        join(hostDir, "-host-repo", `${id}.jsonl`),
+        "utf-8",
+      );
+      expect(JSON.parse(mainContent).cwd).toBe(hostCwd);
+
+      // No subagents dir should exist on the host.
+      const { access: fsAccess } = await import("node:fs/promises");
+      await expect(
+        fsAccess(join(hostDir, "-host-repo", id, "subagents")),
+      ).rejects.toThrow();
+    } finally {
+      await rm(hostDir, { recursive: true, force: true });
+      await rm(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  // (b) Two subagents are copied with cwd rewritten; non-matching files are ignored.
+  it("claudeCode captureToHost copies subagent logs with cwd rewritten and skips non-agent files", async () => {
+    const hostDir = await mkdtemp(
+      join(tmpdir(), "sandcastle-claude-sub-b-host-"),
+    );
+    const sandboxDir = await mkdtemp(
+      join(tmpdir(), "sandcastle-claude-sub-b-sbx-"),
+    );
+    try {
+      const id = "cap-sub-2";
+      const sandboxCwd = "/sandbox/repo";
+      const hostCwd = "/host/repo";
+      const sandboxMainDir = join(sandboxDir, "-sandbox-repo");
+      const sandboxSubagentsDir = join(sandboxMainDir, id, "subagents");
+      await mkdir(sandboxMainDir, { recursive: true });
+      await mkdir(sandboxSubagentsDir, { recursive: true });
+
+      await writeFile(
+        join(sandboxMainDir, `${id}.jsonl`),
+        JSON.stringify({ type: "user", cwd: sandboxCwd, sessionId: id }),
+      );
+
+      const subagentLines = (name: string) =>
+        [
+          JSON.stringify({ type: "user", cwd: sandboxCwd, sessionId: name }),
+          JSON.stringify({
+            type: "assistant",
+            cwd: sandboxCwd,
+            sessionId: name,
+          }),
+        ].join("\n");
+
+      await writeFile(
+        join(sandboxSubagentsDir, "agent-aaa.jsonl"),
+        subagentLines("agent-aaa"),
+      );
+      await writeFile(
+        join(sandboxSubagentsDir, "agent-bbb.jsonl"),
+        subagentLines("agent-bbb"),
+      );
+      await writeFile(
+        join(sandboxSubagentsDir, "notes.txt"),
+        "should not be copied",
+      );
+
+      const provider = claudeCode("claude-opus-4-7", {
+        sessionStorage: {
+          hostProjectsDir: hostDir,
+          sandboxProjectsDir: sandboxDir,
+        },
+      });
+      await provider.sessionStorage!.captureToHost({
+        hostCwd,
+        sandboxCwd,
+        sessionId: id,
+        handle: fsBindMountHandle(),
+      });
+
+      const hostSubagentsDir = join(hostDir, "-host-repo", id, "subagents");
+
+      // Both subagent logs landed with cwd rewritten on every line.
+      for (const name of ["agent-aaa.jsonl", "agent-bbb.jsonl"]) {
+        const content = await readFile(join(hostSubagentsDir, name), "utf-8");
+        for (const line of content.split("\n")) {
+          expect(JSON.parse(line).cwd).toBe(hostCwd);
+        }
+      }
+
+      // Non-matching file was not copied.
+      const { access: fsAccess } = await import("node:fs/promises");
+      await expect(
+        fsAccess(join(hostSubagentsDir, "notes.txt")),
+      ).rejects.toThrow();
+
+      // Main session also landed.
+      const mainContent = await readFile(
+        join(hostDir, "-host-repo", `${id}.jsonl`),
+        "utf-8",
+      );
+      expect(JSON.parse(mainContent).cwd).toBe(hostCwd);
+    } finally {
+      await rm(hostDir, { recursive: true, force: true });
+      await rm(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  // (c) One corrupt/unreadable subagent does not abort siblings or the main capture.
+  it("claudeCode captureToHost continues when one subagent copyFileOut throws, emitting a console.error", async () => {
+    const hostDir = await mkdtemp(
+      join(tmpdir(), "sandcastle-claude-sub-c-host-"),
+    );
+    const sandboxDir = await mkdtemp(
+      join(tmpdir(), "sandcastle-claude-sub-c-sbx-"),
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const id = "cap-sub-3";
+      const sandboxCwd = "/sandbox/repo";
+      const hostCwd = "/host/repo";
+      const sandboxMainDir = join(sandboxDir, "-sandbox-repo");
+      const sandboxSubagentsDir = join(sandboxMainDir, id, "subagents");
+      await mkdir(sandboxMainDir, { recursive: true });
+      await mkdir(sandboxSubagentsDir, { recursive: true });
+
+      await writeFile(
+        join(sandboxMainDir, `${id}.jsonl`),
+        JSON.stringify({ type: "user", cwd: sandboxCwd, sessionId: id }),
+      );
+      await writeFile(
+        join(sandboxSubagentsDir, "agent-good.jsonl"),
+        JSON.stringify({
+          type: "user",
+          cwd: sandboxCwd,
+          sessionId: "agent-good",
+        }),
+      );
+      await writeFile(
+        join(sandboxSubagentsDir, "agent-bad.jsonl"),
+        JSON.stringify({
+          type: "user",
+          cwd: sandboxCwd,
+          sessionId: "agent-bad",
+        }),
+      );
+
+      // Handle that delegates to fsBindMountHandle but throws for agent-bad.jsonl.
+      const base = fsBindMountHandle();
+      const handle: BindMountSandboxHandle = {
+        ...base,
+        copyFileOut: async (sandboxPath, hostPath) => {
+          if (sandboxPath.includes("agent-bad.jsonl")) {
+            throw new Error("simulated unreadable subagent");
+          }
+          return base.copyFileOut(sandboxPath, hostPath);
+        },
+      };
+
+      const provider = claudeCode("claude-opus-4-7", {
+        sessionStorage: {
+          hostProjectsDir: hostDir,
+          sandboxProjectsDir: sandboxDir,
+        },
+      });
+
+      // Must resolve despite the bad subagent.
+      await expect(
+        provider.sessionStorage!.captureToHost({
+          hostCwd,
+          sandboxCwd,
+          sessionId: id,
+          handle,
+        }),
+      ).resolves.toBeUndefined();
+
+      // Main session was captured.
+      const mainContent = await readFile(
+        join(hostDir, "-host-repo", `${id}.jsonl`),
+        "utf-8",
+      );
+      expect(JSON.parse(mainContent).cwd).toBe(hostCwd);
+
+      // Good sibling was captured.
+      const goodContent = await readFile(
+        join(hostDir, "-host-repo", id, "subagents", "agent-good.jsonl"),
+        "utf-8",
+      );
+      expect(JSON.parse(goodContent).cwd).toBe(hostCwd);
+
+      // Bad subagent was NOT copied.
+      const { access: fsAccess } = await import("node:fs/promises");
+      await expect(
+        fsAccess(
+          join(hostDir, "-host-repo", id, "subagents", "agent-bad.jsonl"),
+        ),
+      ).rejects.toThrow();
+
+      // console.error was called with a message referencing the failing path.
+      const errorMessages = errSpy.mock.calls.map((c) => String(c[0]));
+      expect(errorMessages.some((m) => m.includes("agent-bad.jsonl"))).toBe(
+        true,
+      );
+    } finally {
+      errSpy.mockRestore();
       await rm(hostDir, { recursive: true, force: true });
       await rm(sandboxDir, { recursive: true, force: true });
     }

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -4,10 +4,12 @@ import { tmpdir } from "node:os";
 import {
   claudeHostSessionPath,
   claudeSandboxSessionPath,
+  claudeSubagentsDirOnHost,
   encodePiSessionDir,
   findClaudeSessionOnHost,
   findCodexSessionOnHost,
   findPiSessionOnHost,
+  listClaudeSubagentSessionsInSandbox,
   locateCodexHostSession,
   locateCodexSandboxSession,
   locatePiHostSession,
@@ -319,6 +321,28 @@ const writeSandboxFile = async (
   }
 };
 
+const copyClaudeSessionFile = async (options: {
+  handle: Pick<BindMountSandboxHandle, "copyFileOut">;
+  sourcePath: string;
+  fromCwd: string;
+  toCwd: string;
+  destPath: string;
+  tag: string;
+}): Promise<void> => {
+  const jsonl = await readSandboxFile(
+    options.handle,
+    options.sourcePath,
+    options.tag,
+  );
+  const rewritten = transferClaudeSession(
+    jsonl,
+    options.fromCwd,
+    options.toCwd,
+  );
+  await mkdir(dirname(options.destPath), { recursive: true });
+  await writeFile(options.destPath, rewritten);
+};
+
 const makeClaudeSessionStorage = (
   options?: ClaudeCodeOptions,
 ): AgentSessionStorage => {
@@ -338,20 +362,49 @@ const makeClaudeSessionStorage = (
       return readFile(path, "utf-8");
     },
     captureToHost: async ({ hostCwd, sandboxCwd, sessionId, handle }) => {
-      const sandboxPath = claudeSandboxSessionPath(
+      // Main session — failure is fatal (the contract).
+      await copyClaudeSessionFile({
+        handle,
+        sourcePath: claudeSandboxSessionPath(
+          sandboxCwd,
+          sessionId,
+          sandboxProjectsDir,
+        ),
+        fromCwd: sandboxCwd,
+        toCwd: hostCwd,
+        destPath: claudeHostSessionPath(hostCwd, sessionId, hostProjectsDir),
+        tag: "claude-cap",
+      });
+
+      // Subagent / workflow logs — best-effort, supplementary. One bad file must not
+      // abort siblings or the main capture.
+      const subagentPaths = await listClaudeSubagentSessionsInSandbox(
         sandboxCwd,
         sessionId,
+        handle,
         sandboxProjectsDir,
       );
-      const jsonl = await readSandboxFile(handle, sandboxPath, "claude-cap");
-      const rewritten = transferClaudeSession(jsonl, sandboxCwd, hostCwd);
-      const hostPath = claudeHostSessionPath(
+      const hostSubagentsDir = claudeSubagentsDirOnHost(
         hostCwd,
         sessionId,
         hostProjectsDir,
       );
-      await mkdir(dirname(hostPath), { recursive: true });
-      await writeFile(hostPath, rewritten);
+      for (const sourcePath of subagentPaths) {
+        try {
+          await copyClaudeSessionFile({
+            handle,
+            sourcePath,
+            fromCwd: sandboxCwd,
+            toCwd: hostCwd,
+            destPath: join(hostSubagentsDir, posix.basename(sourcePath)),
+            tag: "claude-cap-sub",
+          });
+        } catch (error) {
+          console.error(
+            `Failed to capture subagent session log ${sourcePath}: ${String(error)}`,
+          );
+        }
+      }
     },
     resumeIntoSandbox: async ({ hostCwd, sandboxCwd, sessionId, handle }) => {
       const hostPath = claudeHostSessionPath(

--- a/src/SessionStore.test.ts
+++ b/src/SessionStore.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  claudeSubagentsDirInSandbox,
+  claudeSubagentsDirOnHost,
   encodePiSessionDir,
   encodeProjectPath,
   findClaudeSessionOnHost,
   findCodexSessionOnHost,
   findPiSessionOnHost,
+  listClaudeSubagentSessionsInSandbox,
   locateCodexHostSession,
   locatePiHostSession,
   piSessionDirPath,
@@ -12,9 +15,13 @@ import {
   transferCodexSession,
   transferPiSession,
 } from "./SessionStore.js";
+import { exec as cpExec } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix } from "node:path";
+import { promisify } from "node:util";
+
+const execAsync = promisify(cpExec);
 
 // ---------------------------------------------------------------------------
 // encodeProjectPath
@@ -128,6 +135,24 @@ describe("transferClaudeSession", () => {
     const lines = out.split("\n");
     expect(JSON.parse(lines[0]!).cwd).toBe("/host/repo");
     expect(JSON.parse(lines[1]!).cwd).toBe("/other/path");
+  });
+
+  it("tolerates malformed lines by preserving them verbatim", () => {
+    const badLine = '{"type":"broken"';
+    const jsonl = [
+      JSON.stringify({ type: "system", cwd: "/sandbox/worktree" }),
+      JSON.stringify({ type: "message", content: "hello" }),
+      badLine,
+    ].join("\n");
+
+    const out = transferClaudeSession(jsonl, "/sandbox/worktree", "/host/repo");
+    const lines = out.split("\n");
+    expect(JSON.parse(lines[0]!).cwd).toBe("/host/repo");
+    expect(JSON.parse(lines[1]!)).toEqual({
+      type: "message",
+      content: "hello",
+    });
+    expect(lines[2]).toBe(badLine);
   });
 });
 
@@ -445,6 +470,122 @@ describe("locatePiHostSession", () => {
       await expect(locatePiHostSession("missing", dir)).rejects.toThrow(
         `session missing not found in ${dir}`,
       );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claudeSubagentsDirInSandbox
+// ---------------------------------------------------------------------------
+
+describe("claudeSubagentsDirInSandbox", () => {
+  it("builds <projectsDir>/<encoded-cwd>/<sessionId>/subagents with POSIX separators", () => {
+    expect(
+      claudeSubagentsDirInSandbox(
+        "/sandbox/repo",
+        "sess-1",
+        "/home/agent/.claude/projects",
+      ),
+    ).toBe("/home/agent/.claude/projects/-sandbox-repo/sess-1/subagents");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claudeSubagentsDirOnHost
+// ---------------------------------------------------------------------------
+
+describe("claudeSubagentsDirOnHost", () => {
+  it("builds the host equivalent using node:path join", () => {
+    const projectsDir = "/tmp/claude-projects";
+    expect(claudeSubagentsDirOnHost("/host/repo", "sess-1", projectsDir)).toBe(
+      join(projectsDir, "-host-repo", "sess-1", "subagents"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listClaudeSubagentSessionsInSandbox
+// ---------------------------------------------------------------------------
+
+/** Minimal real-fs exec handle for sandbox find tests. */
+const makeFsHandle = () => ({
+  exec: async (
+    command: string,
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+    try {
+      const { stdout, stderr } = await execAsync(command);
+      return { stdout, stderr, exitCode: 0 };
+    } catch (err: unknown) {
+      const e = err as { stdout?: string; stderr?: string; code?: number };
+      return {
+        stdout: e.stdout ?? "",
+        stderr: e.stderr ?? "",
+        exitCode: e.code ?? 1,
+      };
+    }
+  },
+});
+
+describe("listClaudeSubagentSessionsInSandbox", () => {
+  it("returns [] when the subagents dir does not exist", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sandcastle-subagents-"));
+    try {
+      const result = await listClaudeSubagentSessionsInSandbox(
+        "/sandbox/repo",
+        "sess-missing",
+        makeFsHandle(),
+        dir,
+      );
+      expect(result).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns absolute paths of agent-*.jsonl files and excludes non-matching files", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sandcastle-subagents-"));
+    try {
+      const encodedCwd = encodeProjectPath("/sandbox/repo");
+      const subagentsDir = join(dir, encodedCwd, "sess-1", "subagents");
+      await mkdir(subagentsDir, { recursive: true });
+      await writeFile(join(subagentsDir, "agent-abc.jsonl"), "{}");
+      await writeFile(join(subagentsDir, "agent-def.jsonl"), "{}");
+      await writeFile(join(subagentsDir, "notes.txt"), "ignored");
+      await writeFile(join(subagentsDir, "main.jsonl"), "ignored");
+
+      const result = await listClaudeSubagentSessionsInSandbox(
+        "/sandbox/repo",
+        "sess-1",
+        makeFsHandle(),
+        dir,
+      );
+
+      expect(result.sort()).toEqual(
+        [
+          join(subagentsDir, "agent-abc.jsonl"),
+          join(subagentsDir, "agent-def.jsonl"),
+        ].sort(),
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns [] (not a throw) when the encoded-cwd dir exists but has no subagents/ subdir", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sandcastle-subagents-"));
+    try {
+      const encodedCwd = encodeProjectPath("/sandbox/repo");
+      await mkdir(join(dir, encodedCwd, "sess-1"), { recursive: true });
+
+      const result = await listClaudeSubagentSessionsInSandbox(
+        "/sandbox/repo",
+        "sess-1",
+        makeFsHandle(),
+        dir,
+      );
+      expect(result).toEqual([]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/SessionStore.ts
+++ b/src/SessionStore.ts
@@ -70,6 +70,48 @@ export const claudeSandboxSessionPath = (
   projectsDir: string,
 ): string => posix.join(projectsDir, encodeProjectPath(cwd), `${id}.jsonl`);
 
+/** Sandbox-side path to the subagents directory for a Claude session (always POSIX separators). */
+export const claudeSubagentsDirInSandbox = (
+  cwd: string,
+  sessionId: string,
+  projectsDir: string,
+): string =>
+  posix.join(projectsDir, encodeProjectPath(cwd), sessionId, "subagents");
+
+/** Host path to the subagents directory for a Claude session. */
+export const claudeSubagentsDirOnHost = (
+  cwd: string,
+  sessionId: string,
+  projectsDir?: string,
+): string => {
+  const base =
+    projectsDir ?? join(process.env.HOME ?? "~", ".claude", "projects");
+  return join(base, encodeProjectPath(cwd), sessionId, "subagents");
+};
+
+/**
+ * List all subagent session JSONL paths under a session's `subagents/` directory
+ * in the sandbox. Absent dir, empty stdout, and non-zero exit all return `[]` —
+ * a missing `subagents/` directory is the normal case for plain (non-workflow) sessions.
+ */
+export const listClaudeSubagentSessionsInSandbox = async (
+  cwd: string,
+  sessionId: string,
+  handle: Pick<BindMountSandboxHandle, "exec">,
+  sandboxProjectsDir: string,
+): Promise<string[]> => {
+  const dir = claudeSubagentsDirInSandbox(cwd, sessionId, sandboxProjectsDir);
+  const result = await handle.exec(
+    `find ${JSON.stringify(dir)} -type f -name ${JSON.stringify("agent-*.jsonl")} 2>/dev/null`,
+  );
+  if (result.exitCode !== 0 || !result.stdout.trim()) return [];
+  return result.stdout
+    .trim()
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l !== "");
+};
+
 /**
  * Locate a Claude Code session JSONL on the host by its unique id, scanning each
  * `~/.claude/projects/<encoded-cwd>/` directory rather than reconstructing the
@@ -107,20 +149,24 @@ const rewriteSessionCwd = (
     .split("\n")
     .map((line) => {
       if (line === "") return line;
-      const entry = JSON.parse(line) as Record<string, unknown>;
-      if (typeof entry.cwd === "string" && entry.cwd === fromCwd) {
-        entry.cwd = toCwd;
+      try {
+        const entry = JSON.parse(line) as Record<string, unknown>;
+        if (typeof entry.cwd === "string" && entry.cwd === fromCwd) {
+          entry.cwd = toCwd;
+        }
+        if (
+          entry.type === "session_meta" &&
+          typeof entry.payload === "object" &&
+          entry.payload !== null &&
+          typeof (entry.payload as { cwd?: unknown }).cwd === "string" &&
+          (entry.payload as { cwd: string }).cwd === fromCwd
+        ) {
+          (entry.payload as { cwd: string }).cwd = toCwd;
+        }
+        return JSON.stringify(entry);
+      } catch {
+        return line;
       }
-      if (
-        entry.type === "session_meta" &&
-        typeof entry.payload === "object" &&
-        entry.payload !== null &&
-        typeof (entry.payload as { cwd?: unknown }).cwd === "string" &&
-        (entry.payload as { cwd: string }).cwd === fromCwd
-      ) {
-        (entry.payload as { cwd: string }).cwd = toCwd;
-      }
-      return JSON.stringify(entry);
     })
     .join("\n");
 };


### PR DESCRIPTION
Closes #804.

## Summary

`captureToHost` in the Claude Code provider previously copied only the **main** session JSONL (`<sessionId>.jsonl`) from the sandbox to the host. Transcripts written by `Agent`-tool subagents and `Workflow` runs — `<sessionId>/subagents/agent-*.jsonl` — were never transferred and were lost on sandbox teardown.

This captures those subagent/workflow logs alongside the main session, applying the same sandbox→host `cwd` rewrite.

## What changed

- **`copyClaudeSessionFile`** — extracted the single-file copy sequence (read → `transferClaudeSession` → ensure dest dir → write) into a reusable primitive; the main-session capture now goes through it (behavior unchanged).
- **`captureToHost`** — after the main copy (which stays **fatal** on failure), enumerates subagents via `listClaudeSubagentSessionsInSandbox` and copies each to the host `subagents/` dir. Each subagent copy is **best-effort**: wrapped in its own `try/catch` → `console.error` + continue, so one corrupt/unreadable log never aborts siblings or the main capture.
- **`SessionStore`** — new `claudeSubagentsDirInSandbox` / `claudeSubagentsDirOnHost` path builders and `listClaudeSubagentSessionsInSandbox` (absent dir / empty / non-zero `find` exit all → `[]`, never throws — a missing `subagents/` dir is the normal case). Also hardened `rewriteSessionCwd` with per-line `try/catch` so a partially-written/corrupt JSONL line is preserved verbatim instead of aborting the whole capture.
- **Docs** — the README "Session capture" section now notes that Claude Code subagent/workflow transcripts are captured alongside the main session.

The **resume** direction (host → sandbox) is intentionally **out of scope** — it's unconfirmed whether `claude --resume <id>` reads `<id>/subagents/`, so subagent seeding on resume is deferred pending evidence it's needed.

## Notes

- These files (`src/SessionStore.ts`, `src/AgentProvider.ts`) are intentionally Effect-free, matching the existing style guarded by `scripts/check-public-types-effect-free.mjs`; this change keeps them that way.
- Verified against a real `agent-*.jsonl`: every line carries a top-level `cwd` field, so the rewrite is genuinely load-bearing on subagent logs (not a no-op).

## Testing

- `npm run typecheck` — clean
- `SessionStore.test.ts` + `AgentProvider.test.ts` — 257 passed, 0 failed
- New `captureToHost` tests cover: no `subagents/` dir (main only), N subagents copied with `cwd` rewritten + non-`agent-*` files filtered out, and one I/O-failing subagent (main + good sibling still captured, warning emitted).

A `minor` changeset is included (`@ai-hero/sandcastle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
