### PR TITLE
Added Devin Agent Provider

### DIFF
--- a/.changeset/devin-agent-provider.md
+++ b/.changeset/devin-agent-provider.md
@@ -7,3 +7,5 @@ Add Devin agent provider.
 Exports a `devin(model, options?)` factory that runs the Devin CLI (`devin -p`) inside a sandbox container. Follows the cursor/copilot pattern: `captureSessions: false`, plain-text stdout streaming, no session storage.
 
 The accompanying Dockerfile installs the Devin CLI binary directly from the release tarball (bypassing the interactive install script) and writes `credentials.toml` from `DEVIN_API_KEY` at runtime before each invocation.
+
+Fix: the prompt is now delivered via stdin and `--prompt-file` instead of as an inline shell argument, preventing `E2BIG` ("argument list too long") crashes when the prompt exceeds the OS ARG_MAX limit.

--- a/.changeset/devin-agent-provider.md
+++ b/.changeset/devin-agent-provider.md
@@ -1,0 +1,9 @@
+---
+"@ai-hero/sandcastle": minor
+---
+
+Add Devin agent provider.
+
+Exports a `devin(model, options?)` factory that runs the Devin CLI (`devin -p`) inside a sandbox container. Follows the cursor/copilot pattern: `captureSessions: false`, plain-text stdout streaming, no session storage.
+
+The accompanying Dockerfile installs the Devin CLI binary directly from the release tarball (bypassing the interactive install script) and writes `credentials.toml` from `DEVIN_API_KEY` at runtime before each invocation.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,75 @@
+## Add Devin agent provider
+
+Adds support for the [Devin CLI](https://cli.devin.ai) as a new agent provider, following the same pattern as the existing `cursor` and `copilot` providers.
+
+### What's changed
+
+**`src/AgentProvider.ts`**
+
+- New `devin(model, options?)` factory and `DevinOptions` interface
+- `buildPrintCommand`: writes `credentials.toml` from `$DEVIN_SESSION_TOKEN` before each invocation (the Devin CLI authenticates via an OAuth session token, not an API key), then runs `devin -p <prompt> --model <model> --permission-mode dangerous`
+- `parseStreamLine`: plain-text passthrough — Devin's `-p` mode streams plain text to stdout, no structured JSON
+- `captureSessions: false`, no `sessionStorage` — resume is not supported (the `-p` stdout stream does not emit a session ID)
+
+**`src/InitService.ts`**
+
+- New `DEVIN_DOCKERFILE` — based on `node:22-bookworm`, installs the Devin CLI binary directly from the release tarball via the manifest JSON rather than the install script (the install script ends with an interactive `devin setup` wizard that would hang a Docker `RUN` layer)
+- New `AGENT_REGISTRY` entry: `name: "devin"`, `defaultModel: "adaptive"`
+
+**`src/index.ts`**
+
+- Exports `devin` and `DevinOptions`
+
+**`src/AgentProvider.test.ts`**
+
+- 17 new tests covering `buildPrintCommand`, `parseStreamLine`, `buildInteractiveArgs`, `captureSessions`, `env`, and `sessionStorage`
+
+---
+
+### Why the install script is bypassed
+
+The official install script (`curl -fsSL https://cli.devin.ai/install.sh | bash`) ends with `devin setup`, an interactive onboarding wizard that blocks a Docker build. Instead, the Dockerfile fetches the versioned tarball URL from the manifest JSON and extracts the binary directly:
+
+```dockerfile
+RUN MANIFEST=$(curl -fsSL https://static.devin.ai/cli/current/manifest.json) && \
+    BUNDLE_URL=$(echo "$MANIFEST" | jq -r '.platforms["x86_64-unknown-linux"].url') && \
+    curl -fsSL "$BUNDLE_URL" | tar xz -C /usr/local && \
+    chmod +x /usr/local/bin/devin
+```
+
+---
+
+### Why `DEVIN_SESSION_TOKEN` instead of an API key
+
+The Devin CLI authenticates via an OAuth session token stored in `~/.local/share/devin/credentials.toml`, not a static API key. `buildPrintCommand` writes this file from `$DEVIN_SESSION_TOKEN` at runtime using `printf` so the token value (which contains `$` characters) is passed through the environment rather than shell-interpolated.
+
+---
+
+### Usage
+
+```ts
+import { run, devin } from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+
+await run({
+  agent: devin("adaptive"), // or "swe-1-6-fast", "claude-sonnet-4", etc.
+  sandbox: docker(),
+  promptFile: ".sandcastle/prompt.md",
+});
+```
+
+**`.sandcastle/.env`**
+
+```bash
+# windsurf_api_key value from ~/.local/share/devin/credentials.toml on the host
+# Use single quotes to preserve the $ characters in the token value
+DEVIN_SESSION_TOKEN='devin-session-token$eyJ...'
+```
+
+---
+
+### Known limitations
+
+- **No resume support** — the `-p` stdout stream does not emit a session ID, so interrupted runs start fresh rather than continuing where they left off. This matches the `cursor` and `copilot` providers.
+- **Session token expiry** — `DEVIN_SESSION_TOKEN` is an OAuth JWT that expires when you log out or the session times out. Re-run `devin auth login` on the host and update `.sandcastle/.env` to refresh it.
+- **x86_64 Linux only** — the Dockerfile targets `x86_64-unknown-linux`. ARM (`aarch64`) support can be added by making the platform detection dynamic in the `RUN` layer.

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -2002,7 +2002,9 @@ describe("devin factory", () => {
       opts("do something"),
     );
     expect(result.stdin).toBe("do something");
+    expect(result.command).toContain("mktemp");
     expect(result.command).toContain("--prompt-file");
+    expect(result.command).toContain("trap");
     expect(result.command).not.toContain("do something");
   });
 

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -7,6 +7,7 @@ import {
   codex,
   copilot,
   cursor,
+  devin,
   opencode,
   pi,
 } from "./AgentProvider.js";
@@ -1954,6 +1955,112 @@ describe("copilot factory", () => {
     expect(provider1.buildPrintCommand(opts("test")).command).not.toContain(
       "model-b",
     );
+  });
+});
+
+describe("devin factory", () => {
+  const opts = (prompt: string): AgentCommandOptions => ({
+    prompt,
+    dangerouslySkipPermissions: false,
+  });
+
+  it("returns a provider with name 'devin'", () => {
+    expect(devin("swe-1-6-fast").name).toBe("devin");
+  });
+
+  it("captureSessions is false", () => {
+    expect(devin("swe-1-6-fast").captureSessions).toBe(false);
+  });
+
+  it("defaults env to empty object", () => {
+    expect(devin("swe-1-6-fast").env).toEqual({});
+  });
+
+  it("accepts env option and exposes it", () => {
+    expect(
+      devin("swe-1-6-fast", { env: { DEVIN_API_KEY: "cog_test" } }).env,
+    ).toEqual({ DEVIN_API_KEY: "cog_test" });
+  });
+
+  it("buildPrintCommand includes -p flag", () => {
+    const { command } = devin("swe-1-6-fast").buildPrintCommand(opts("hello"));
+    expect(command).toContain("-p");
+  });
+
+  it("buildPrintCommand includes the model", () => {
+    const { command } = devin("swe-1-6-fast").buildPrintCommand(opts("hello"));
+    expect(command).toContain("swe-1-6-fast");
+  });
+
+  it("buildPrintCommand shell-escapes the model", () => {
+    const { command } = devin("swe-1-6-fast").buildPrintCommand(opts("hello"));
+    expect(command).toContain("--model 'swe-1-6-fast'");
+  });
+
+  it("buildPrintCommand delivers prompt after -- separator", () => {
+    const { command } = devin("swe-1-6-fast").buildPrintCommand(
+      opts("do something"),
+    );
+    expect(command).toContain("-- 'do something'");
+  });
+
+  it("buildPrintCommand includes credentials.toml setup from DEVIN_API_KEY", () => {
+    const { command } = devin("swe-1-6-fast").buildPrintCommand(opts("hello"));
+    expect(command).toContain("credentials.toml");
+    expect(command).toContain("DEVIN_API_KEY");
+    expect(command).toContain("~/.local/share/devin");
+  });
+
+  it("buildPrintCommand includes --permission-mode bypass when dangerouslySkipPermissions", () => {
+    const { command } = devin("swe-1-6-fast").buildPrintCommand({
+      prompt: "test",
+      dangerouslySkipPermissions: true,
+    });
+    expect(command).toContain("--permission-mode bypass");
+  });
+
+  it("buildPrintCommand omits --permission-mode bypass when not set", () => {
+    const { command } = devin("swe-1-6-fast").buildPrintCommand({
+      prompt: "test",
+      dangerouslySkipPermissions: false,
+    });
+    expect(command).not.toContain("--permission-mode bypass");
+  });
+
+  it("parseStreamLine returns text event for non-empty line", () => {
+    expect(devin("swe-1-6-fast").parseStreamLine("Hello world")).toEqual([
+      { type: "text", text: "Hello world" },
+    ]);
+  });
+
+  it("parseStreamLine returns empty array for blank line", () => {
+    expect(devin("swe-1-6-fast").parseStreamLine("")).toEqual([]);
+  });
+
+  it("parseStreamLine returns empty array for whitespace-only line", () => {
+    expect(devin("swe-1-6-fast").parseStreamLine("   ")).toEqual([]);
+  });
+
+  it("buildInteractiveArgs includes binary, model, and prompt", () => {
+    expect(
+      devin("swe-1-6-fast").buildInteractiveArgs!({
+        prompt: "do something",
+        dangerouslySkipPermissions: true,
+      }),
+    ).toEqual(["devin", "--model", "swe-1-6-fast", "--", "do something"]);
+  });
+
+  it("buildInteractiveArgs omits -- and prompt when prompt is empty", () => {
+    expect(
+      devin("swe-1-6-fast").buildInteractiveArgs!({
+        prompt: "",
+        dangerouslySkipPermissions: false,
+      }),
+    ).toEqual(["devin", "--model", "swe-1-6-fast"]);
+  });
+
+  it("has no sessionStorage", () => {
+    expect(devin("swe-1-6-fast").sessionStorage).toBeUndefined();
   });
 });
 

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1997,12 +1997,13 @@ describe("devin factory", () => {
     expect(command).toContain("--model 'swe-1-6-fast'");
   });
 
-  it("buildPrintCommand delivers prompt as inline -p argument", () => {
-    const { command } = devin("swe-1-6-fast").buildPrintCommand(
+  it("buildPrintCommand delivers prompt via stdin and --prompt-file (not inline argv)", () => {
+    const result = devin("swe-1-6-fast").buildPrintCommand(
       opts("do something"),
     );
-    expect(command).toContain("-p 'do something'");
-    expect(command).not.toContain("-- 'do something'");
+    expect(result.stdin).toBe("do something");
+    expect(result.command).toContain("--prompt-file");
+    expect(result.command).not.toContain("do something");
   });
 
   it("buildPrintCommand includes credentials.toml setup from DEVIN_API_KEY", () => {

--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -1997,17 +1997,18 @@ describe("devin factory", () => {
     expect(command).toContain("--model 'swe-1-6-fast'");
   });
 
-  it("buildPrintCommand delivers prompt after -- separator", () => {
+  it("buildPrintCommand delivers prompt as inline -p argument", () => {
     const { command } = devin("swe-1-6-fast").buildPrintCommand(
       opts("do something"),
     );
-    expect(command).toContain("-- 'do something'");
+    expect(command).toContain("-p 'do something'");
+    expect(command).not.toContain("-- 'do something'");
   });
 
   it("buildPrintCommand includes credentials.toml setup from DEVIN_API_KEY", () => {
     const { command } = devin("swe-1-6-fast").buildPrintCommand(opts("hello"));
     expect(command).toContain("credentials.toml");
-    expect(command).toContain("DEVIN_API_KEY");
+    expect(command).toContain("DEVIN_SESSION_TOKEN");
     expect(command).toContain("~/.local/share/devin");
   });
 
@@ -2016,7 +2017,7 @@ describe("devin factory", () => {
       prompt: "test",
       dangerouslySkipPermissions: true,
     });
-    expect(command).toContain("--permission-mode bypass");
+    expect(command).toContain("--permission-mode dangerous");
   });
 
   it("buildPrintCommand omits --permission-mode bypass when not set", () => {
@@ -2024,7 +2025,7 @@ describe("devin factory", () => {
       prompt: "test",
       dangerouslySkipPermissions: false,
     });
-    expect(command).not.toContain("--permission-mode bypass");
+    expect(command).not.toContain("--permission-mode dangerous");
   });
 
   it("parseStreamLine returns text event for non-empty line", () => {

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -1149,6 +1149,78 @@ export const copilot = (
 });
 
 // ---------------------------------------------------------------------------
+// Devin agent provider
+// ---------------------------------------------------------------------------
+
+/**
+ * Devin's `-p` mode emits plain text to stdout; there is no structured JSON
+ * stream. Every non-empty line is surfaced as a `text` event for live display.
+ * Tool calls and session IDs are not available in the stdout stream.
+ */
+const parseDevinStreamLine = (line: string): ParsedStreamEvent[] => {
+  if (line.trim()) {
+    return [{ type: "text", text: line }];
+  }
+  return [];
+};
+
+/** Options for the Devin agent provider. */
+export interface DevinOptions {
+  /** Environment variables injected by this agent provider. */
+  readonly env?: Record<string, string>;
+}
+
+/**
+ * Agent provider for the Devin CLI (`devin -p`).
+ *
+ * Auth: Devin authenticates via `~/.local/share/devin/credentials.toml`.
+ * `buildPrintCommand` writes this file from `DEVIN_API_KEY` before each
+ * invocation so the agent can authenticate inside the sandbox without
+ * interactive login. The install script is not used (it ends with an
+ * interactive `devin setup` wizard); the binary is installed directly from
+ * the release tarball in the Dockerfile instead.
+ *
+ * Resume: Devin's `-p` stdout stream does not emit a session ID, so session
+ * capture and resume are not supported. `captureSessions` is false, matching
+ * the cursor and copilot providers.
+ */
+export const devin = (
+  model: string,
+  options?: DevinOptions,
+): AgentProvider => ({
+  name: "devin",
+  env: options?.env ?? {},
+  captureSessions: false,
+
+  buildPrintCommand({
+    prompt,
+    dangerouslySkipPermissions,
+  }: AgentCommandOptions): PrintCommand {
+    const bypassFlag = dangerouslySkipPermissions
+      ? " --permission-mode bypass"
+      : "";
+    // Write credentials.toml from DEVIN_API_KEY before each invocation.
+    // Devin authenticates via this file; no interactive login is required.
+    const setupCredentials =
+      `mkdir -p ~/.local/share/devin && ` +
+      `printf 'windsurf_api_key = "%s"\\napi_server_url = "https://server.codeium.com"\\ndevin_webapp_host = "app.devin.ai"\\ndevin_api_url = "https://api.devin.ai"\\n' "$DEVIN_API_KEY" > ~/.local/share/devin/credentials.toml`;
+    return {
+      command: `${setupCredentials} && devin -p --model ${shellEscape(model)}${bypassFlag} -- ${shellEscape(prompt)}`,
+    };
+  },
+
+  buildInteractiveArgs({ prompt }: AgentCommandOptions): string[] {
+    const args = ["devin", "--model", model];
+    if (prompt) args.push("--", prompt);
+    return args;
+  },
+
+  parseStreamLine(line: string): ParsedStreamEvent[] {
+    return parseDevinStreamLine(line);
+  },
+});
+
+// ---------------------------------------------------------------------------
 // Claude Code agent provider
 // ---------------------------------------------------------------------------
 

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -1197,15 +1197,19 @@ export const devin = (
     dangerouslySkipPermissions,
   }: AgentCommandOptions): PrintCommand {
     const bypassFlag = dangerouslySkipPermissions
-      ? " --permission-mode bypass"
+      ? " --permission-mode dangerous"
       : "";
-    // Write credentials.toml from DEVIN_API_KEY before each invocation.
-    // Devin authenticates via this file; no interactive login is required.
+    // Write credentials.toml from DEVIN_SESSION_TOKEN before each invocation.
+    // DEVIN_SESSION_TOKEN is the windsurf_api_key value from the host's
+    // ~/.local/share/devin/credentials.toml — the CLI uses OAuth session tokens,
+    // not API keys. No interactive login is required inside the sandbox.
+    // Note: \\n in the printf format string must be 4 backslashes in TS source so
+    // the template literal emits the two-character sequence \n that printf interprets.
     const setupCredentials =
       `mkdir -p ~/.local/share/devin && ` +
-      `printf 'windsurf_api_key = "%s"\\napi_server_url = "https://server.codeium.com"\\ndevin_webapp_host = "app.devin.ai"\\ndevin_api_url = "https://api.devin.ai"\\n' "$DEVIN_API_KEY" > ~/.local/share/devin/credentials.toml`;
+      `printf 'windsurf_api_key = "%s"\\napi_server_url = "https://server.codeium.com"\\ndevin_webapp_host = "app.devin.ai"\\ndevin_api_url = "https://api.devin.ai"\\n' "$DEVIN_SESSION_TOKEN" > ~/.local/share/devin/credentials.toml`;
     return {
-      command: `${setupCredentials} && devin -p --model ${shellEscape(model)}${bypassFlag} -- ${shellEscape(prompt)}`,
+      command: `${setupCredentials} && devin -p ${shellEscape(prompt)} --model ${shellEscape(model)}${bypassFlag}`,
     };
   },
 

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -1214,12 +1214,17 @@ export const devin = (
     const setupCredentials =
       `mkdir -p ~/.local/share/devin && ` +
       `printf 'windsurf_api_key = "%s"\\napi_server_url = "https://server.codeium.com"\\ndevin_webapp_host = "app.devin.ai"\\ndevin_api_url = "https://api.devin.ai"\\n' "$DEVIN_SESSION_TOKEN" > ~/.local/share/devin/credentials.toml`;
-    // Write the prompt to a temp file via stdin to avoid the Linux ARG_MAX
-    // limit (E2BIG) that fires when a large prompt is inlined as a shell
-    // argument. `cat` reads stdin into the file; devin-wrapper then reads the
-    // prompt from the file via --prompt-file instead of from argv.
+    // Write the prompt to a unique temp file via stdin to avoid the Linux
+    // ARG_MAX limit (E2BIG) when a large prompt is inlined as a shell argument.
+    // mktemp gives each concurrent run its own file; the trap cleans it up even
+    // on failure. devin -p panics when given no inline prompt and stdin is not a
+    // tty, so --prompt-file is the only supported path for non-argv delivery.
     return {
-      command: `${setupCredentials} && cat > /tmp/sandcastle-devin-prompt && devin-wrapper -p --prompt-file /tmp/sandcastle-devin-prompt --model ${shellEscape(model)}${bypassFlag}`,
+      command:
+        `${setupCredentials} && ` +
+        `PROMPT_FILE=$(mktemp) && trap 'rm -f "$PROMPT_FILE"' EXIT && ` +
+        `cat > "$PROMPT_FILE" && ` +
+        `devin-wrapper -p --prompt-file "$PROMPT_FILE" --model ${shellEscape(model)}${bypassFlag}`,
       stdin: prompt,
     };
   },

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -1156,12 +1156,18 @@ export const copilot = (
  * Devin's `-p` mode emits plain text to stdout; there is no structured JSON
  * stream. Every non-empty line is surfaced as a `text` event for live display.
  * Tool calls and session IDs are not available in the stdout stream.
+ *
+ * Lines prefixed with "[log] " are forwarded by devin-wrapper from the Devin
+ * log file to keep the idle timer alive during silent tool-use phases. They
+ * are surfaced as `tool_call` events (so they appear in the display but are
+ * not included in the final text output) rather than `text` events.
  */
 const parseDevinStreamLine = (line: string): ParsedStreamEvent[] => {
-  if (line.trim()) {
-    return [{ type: "text", text: line }];
+  if (!line.trim()) return [];
+  if (line.startsWith("[log] ")) {
+    return [{ type: "tool_call", name: "log", args: line.slice(6) }];
   }
-  return [];
+  return [{ type: "text", text: line }];
 };
 
 /** Options for the Devin agent provider. */
@@ -1208,8 +1214,13 @@ export const devin = (
     const setupCredentials =
       `mkdir -p ~/.local/share/devin && ` +
       `printf 'windsurf_api_key = "%s"\\napi_server_url = "https://server.codeium.com"\\ndevin_webapp_host = "app.devin.ai"\\ndevin_api_url = "https://api.devin.ai"\\n' "$DEVIN_SESSION_TOKEN" > ~/.local/share/devin/credentials.toml`;
+    // Write the prompt to a temp file via stdin to avoid the Linux ARG_MAX
+    // limit (E2BIG) that fires when a large prompt is inlined as a shell
+    // argument. `cat` reads stdin into the file; devin-wrapper then reads the
+    // prompt from the file via --prompt-file instead of from argv.
     return {
-      command: `${setupCredentials} && devin -p ${shellEscape(prompt)} --model ${shellEscape(model)}${bypassFlag}`,
+      command: `${setupCredentials} && cat > /tmp/sandcastle-devin-prompt && devin-wrapper -p --prompt-file /tmp/sandcastle-devin-prompt --model ${shellEscape(model)}${bypassFlag}`,
+      stdin: prompt,
     };
   },
 

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -406,7 +406,7 @@ WORKDIR /home/agent
 ENTRYPOINT ["sleep", "infinity"]
 `;
 
-const DEVIN_DOCKERFILE = `FROM debian:bookworm-slim
+const DEVIN_DOCKERFILE = `FROM node:22-bookworm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -424,8 +424,8 @@ RUN apt-get update && apt-get install -y \
 ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 
-RUN groupadd -g $AGENT_GID agent && \
-    useradd -u $AGENT_UID -g $AGENT_GID -m -d /home/agent agent
+# Rename the base image's "node" user to "agent" and align UID/GID.
+RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
 
 # Install the Devin CLI binary directly from the release tarball.
 # We bypass the install script (which ends with an interactive \`devin setup\`

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -436,6 +436,52 @@ RUN MANIFEST=\$(curl -fsSL https://static.devin.ai/cli/current/manifest.json) &&
     curl -fsSL "\$BUNDLE_URL" | tar xz -C /usr/local && \\
     chmod +x /usr/local/bin/devin
 
+# Install the devin-wrapper that runs devin in the background and forwards the
+# Devin log file to stdout as "[log] ..." lines. This keeps Sandcastle's idle
+# timer alive during silent tool-use phases.
+RUN cat <<'WRAPPER' > /usr/local/bin/devin-wrapper
+#!/usr/bin/env bash
+set -uo pipefail
+
+mkdir -p "\${HOME}/.local/share/devin/cli/logs"
+
+devin "\$@" &
+devin_pid=$!
+
+log_dir="\${HOME}/.local/share/devin/cli/logs"
+log_file=""
+max_wait=50
+
+for _ in \$(seq 1 \${max_wait}); do
+  log_file=\$(ls -t "\${log_dir}"/devin_*_"\${devin_pid}".log 2>/dev/null | head -n 1 || true)
+  if [[ -n "\${log_file}" && -f "\${log_file}" ]]; then
+    break
+  fi
+  sleep 0.1
+done
+
+if [[ -z "\${log_file}" ]]; then
+  log_file=\$(ls -t "\${log_dir}"/devin_*.log 2>/dev/null | head -n 1 || true)
+fi
+
+if [[ -n "\${log_file}" && -f "\${log_file}" ]]; then
+  tail -f -s 0.1 -n +1 --pid="\${devin_pid}" "\${log_file}" | sed -u 's/^/[log] /' &
+  log_tail_pid=$!
+else
+  log_tail_pid=""
+fi
+
+wait "\${devin_pid}"
+exit_code=$?
+
+if [[ -n "\${log_tail_pid}" ]]; then
+  wait "\${log_tail_pid}" 2>/dev/null || true
+fi
+
+exit "\${exit_code}"
+WRAPPER
+RUN chmod +x /usr/local/bin/devin-wrapper
+
 USER \${AGENT_UID}:\${AGENT_GID}
 
 WORKDIR /home/agent

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -519,8 +519,8 @@ GITHUB_TOKEN=`,
     defaultModel: "adaptive",
     factoryImport: "devin",
     dockerfileTemplate: DEVIN_DOCKERFILE,
-    envExample: `# Devin service-user API key (starts with cog_)
-DEVIN_API_KEY=`,
+    envExample: `# Devin session token — the windsurf_api_key value from ~/.local/share/devin/credentials.toml on your host
+DEVIN_SESSION_TOKEN=`,
     setupCommand: `devin -p -- "$(cat ${SETUP_ISSUE_TRACKER_PATH})"`,
   },
 ];

--- a/src/InitService.ts
+++ b/src/InitService.ts
@@ -406,6 +406,46 @@ WORKDIR /home/agent
 ENTRYPOINT ["sleep", "infinity"]
 `;
 
+const DEVIN_DOCKERFILE = `FROM debian:bookworm-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+  git \
+  curl \
+  jq \
+  ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+{{ISSUE_TRACKER_TOOLS}}
+
+# Build-args for UID/GID alignment: sandcastle docker build-image
+# defaults these to the host user's UID/GID so image-built files
+# and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+RUN groupadd -g $AGENT_GID agent && \
+    useradd -u $AGENT_UID -g $AGENT_GID -m -d /home/agent agent
+
+# Install the Devin CLI binary directly from the release tarball.
+# We bypass the install script (which ends with an interactive \`devin setup\`
+# wizard) by fetching the tarball and extracting only the binary.
+# Auth is handled at runtime via credentials.toml written from DEVIN_API_KEY.
+RUN MANIFEST=\$(curl -fsSL https://static.devin.ai/cli/current/manifest.json) && \\
+    BUNDLE_URL=\$(echo "\$MANIFEST" | jq -r '.platforms["x86_64-unknown-linux"].url') && \\
+    curl -fsSL "\$BUNDLE_URL" | tar xz -C /usr/local && \\
+    chmod +x /usr/local/bin/devin
+
+USER \${AGENT_UID}:\${AGENT_GID}
+
+WORKDIR /home/agent
+
+# In worktree sandbox mode, Sandcastle bind-mounts the git worktree at \${SANDBOX_REPO_DIR}
+# and overrides the working directory to \${SANDBOX_REPO_DIR} at container start.
+# Structure your Dockerfile so that \${SANDBOX_REPO_DIR} can serve as the project root.
+ENTRYPOINT ["sleep", "infinity"]
+`;
+
 const AGENT_REGISTRY: AgentEntry[] = [
   {
     name: "claude-code",
@@ -472,6 +512,16 @@ OPENCODE_API_KEY=`,
 # COPILOT_GITHUB_TOKEN takes precedence over GH_TOKEN and GITHUB_TOKEN.
 GITHUB_TOKEN=`,
     setupCommand: `copilot -i "$(cat ${SETUP_ISSUE_TRACKER_PATH})"`,
+  },
+  {
+    name: "devin",
+    label: "Devin",
+    defaultModel: "adaptive",
+    factoryImport: "devin",
+    dockerfileTemplate: DEVIN_DOCKERFILE,
+    envExample: `# Devin service-user API key (starts with cog_)
+DEVIN_API_KEY=`,
+    setupCommand: `devin -p -- "$(cat ${SETUP_ISSUE_TRACKER_PATH})"`,
   },
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export type {
 export { CwdError } from "./CwdError.js";
 export {
   claudeCode,
+  devin,
   codex,
   copilot,
   cursor,
@@ -63,6 +64,7 @@ export type {
   AgentCommandOptions,
   PrintCommand,
   ClaudeCodeOptions,
+  DevinOptions,
   CodexOptions,
   CopilotOptions,
   CursorOptions,


### PR DESCRIPTION
## Add Devin agent provider

Adds support for the [Devin CLI](https://cli.devin.ai) as a new agent provider, following the same pattern as the existing `cursor` and `copilot` providers.

### What's changed

**`src/AgentProvider.ts`**
- New `devin(model, options?)` factory and `DevinOptions` interface
- `buildPrintCommand`: writes `credentials.toml` from `$DEVIN_SESSION_TOKEN` before each invocation (the Devin CLI authenticates via an OAuth session token, not an API key), then runs `devin -p <prompt> --model <model> --permission-mode dangerous`
- `parseStreamLine`: plain-text passthrough — Devin's `-p` mode streams plain text to stdout, no structured JSON
- `captureSessions: false`, no `sessionStorage` — resume is not supported (the `-p` stdout stream does not emit a session ID)

**`src/InitService.ts`**
- New `DEVIN_DOCKERFILE` — based on `node:22-bookworm`, installs the Devin CLI binary directly from the release tarball via the manifest JSON rather than the install script (the install script ends with an interactive `devin setup` wizard that would hang a Docker `RUN` layer)
- New `AGENT_REGISTRY` entry: `name: "devin"`, `defaultModel: "adaptive"`

**`src/index.ts`**
- Exports `devin` and `DevinOptions`

**`src/AgentProvider.test.ts`**
- 17 new tests covering `buildPrintCommand`, `parseStreamLine`, `buildInteractiveArgs`, `captureSessions`, `env`, and `sessionStorage`

---

### Why the install script is bypassed

The official install script (`curl -fsSL https://cli.devin.ai/install.sh | bash`) ends with `devin setup`, an interactive onboarding wizard that blocks a Docker build. Instead, the Dockerfile fetches the versioned tarball URL from the manifest JSON and extracts the binary directly:

```dockerfile
RUN MANIFEST=$(curl -fsSL https://static.devin.ai/cli/current/manifest.json) && \
    BUNDLE_URL=$(echo "$MANIFEST" | jq -r '.platforms["x86_64-unknown-linux"].url') && \
    curl -fsSL "$BUNDLE_URL" | tar xz -C /usr/local && \
    chmod +x /usr/local/bin/devin
```

---

### Why `DEVIN_SESSION_TOKEN` instead of an API key

The Devin CLI authenticates via an OAuth session token stored in `~/.local/share/devin/credentials.toml`, not a static API key. `buildPrintCommand` writes this file from `$DEVIN_SESSION_TOKEN` at runtime using `printf` so the token value (which contains `$` characters) is passed through the environment rather than shell-interpolated.

---

### Usage

```ts
import { run, devin } from "@ai-hero/sandcastle";
import { docker } from "@ai-hero/sandcastle/sandboxes/docker";

await run({
  agent: devin("adaptive"),  // or "swe-1-6-fast", "claude-sonnet-4", etc.
  sandbox: docker(),
  promptFile: ".sandcastle/prompt.md",
});
```

**`.sandcastle/.env`**

```bash
# windsurf_api_key value from ~/.local/share/devin/credentials.toml on the host
# Use single quotes to preserve the $ characters in the token value
DEVIN_SESSION_TOKEN='devin-session-token$eyJ...'
```

---

### Known limitations

- **No resume support** — the `-p` stdout stream does not emit a session ID, so interrupted runs start fresh rather than continuing where they left off. This matches the `cursor` and `copilot` providers.
- **Session token expiry** — `DEVIN_SESSION_TOKEN` is an OAuth JWT that expires when you log out or the session times out. Re-run `devin auth login` on the host and update `.sandcastle/.env` to refresh it.
- **x86_64 Linux only** — the Dockerfile targets `x86_64-unknown-linux`. ARM (`aarch64`) support can be added by making the platform detection dynamic in the `RUN` layer.
