### PR TITLE
fix(build): replace Unix-only postbuild commands with a Node script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "postbuild": "rm -rf dist/templates && cp -r src/templates dist/templates && node scripts/check-public-types-effect-free.mjs",
+    "postbuild": "node scripts/copy-templates.mjs && node scripts/check-public-types-effect-free.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsgo --noEmit",

--- a/scripts/copy-templates.mjs
+++ b/scripts/copy-templates.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+/**
+ * Copy the template scaffolds from `src/templates` to `dist/templates`
+ * after the build, replacing any existing copy.
+ *
+ * Uses Node.js fs APIs rather than `rm -rf` / `cp -r` so the build works
+ * on Windows hosts (PowerShell has no `rm -rf`/`cp -r`) as well as on
+ * macOS/Linux.
+ */
+import { cpSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const src = join(here, "..", "src", "templates");
+const dest = join(here, "..", "dist", "templates");
+
+rmSync(dest, { recursive: true, force: true });
+cpSync(src, dest, { recursive: true });
+
+console.log("✓ Templates copied to dist/templates");


### PR DESCRIPTION
## Problem

The `postbuild` npm script uses Unix-only shell commands:

```
"postbuild": "rm -rf dist/templates && cp -r src/templates dist/templates && node scripts/check-public-types-effect-free.mjs"
```

`rm -rf` and `cp -r` do not exist in Windows PowerShell/cmd, so `npm run build` fails on Windows hosts, blocking contributors on Windows.

## Fix

Replace the two shell commands with `scripts/copy-templates.mjs`, a small Node script using `node:fs` `rmSync`/`cpSync` (Node 16+ built-ins — **no new dependencies**). It mirrors the style of the existing `scripts/check-public-types-effect-free.mjs`.

```diff
- "postbuild": "rm -rf dist/templates && cp -r src/templates dist/templates && node scripts/check-public-types-effect-free.mjs",
+ "postbuild": "node scripts/copy-templates.mjs && node scripts/check-public-types-effect-free.mjs",
```

Behavior is identical on macOS/Linux: `dist/templates` is wiped and recopied recursively before the existing effect-free type check runs.

## Testing

Verified on macOS:
- Confirmed `package.json` `postbuild` now invokes `node scripts/copy-templates.mjs`.
- Compared `dist/templates` produced by the old `rm`/`cp` flow vs. the new script using `diff -qr` and SHA-256 checksums — no differences.
- `npm run build` succeeds; `postbuild` copies the templates and then runs the public-type effect-free check.

Also verified on Windows: `npm run build` now completes (previously died at `rm -rf`).

## Changeset

None — build-tooling change only; the published package (`files: ["dist"]`) is unaffected. Happy to add an empty changeset if CI requires one.