### PR TITLE
fix: locate Claude session by id on capture

### DIFF
--- a/src/AgentProvider.test.ts
+++ b/src/AgentProvider.test.ts
@@ -2396,6 +2396,65 @@ describe("sessionStorage", () => {
     }
   });
 
+  it("claudeCode captureToHost locates the session by id when the sandbox dir name does not match encodeProjectPath (Claude collapses '.' → '-')", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-claude-locate-"));
+    const sandboxDir = await mkdtemp(
+      join(tmpdir(), "sandcastle-claude-locate-sbx-"),
+    );
+    try {
+      const id = "session-dotted-cwd";
+      const hostCwd = "/host/repo";
+      // A cwd with a dot segment. encodeProjectPath() keeps the dot
+      // ("-sandbox-.work-repo"), but Claude Code writes the project dir with the
+      // dot collapsed to a dash. Capture must follow Claude's real dir, not the
+      // reconstructed one — otherwise `find`/`docker cp` misses the file.
+      const sandboxCwd = "/sandbox/.work/repo";
+      const claudeActualDir = join(sandboxDir, "-sandbox--work-repo");
+      await mkdir(claudeActualDir, { recursive: true });
+      const sandboxSubagentsDir = join(claudeActualDir, id, "subagents");
+      await mkdir(sandboxSubagentsDir, { recursive: true });
+      await writeFile(
+        join(claudeActualDir, `${id}.jsonl`),
+        JSON.stringify({ type: "system", cwd: sandboxCwd }),
+      );
+      await writeFile(
+        join(sandboxSubagentsDir, "agent-alpha.jsonl"),
+        JSON.stringify({ type: "system", cwd: sandboxCwd, agent: "alpha" }),
+      );
+
+      const provider = claudeCode("claude-opus-4-7", {
+        sessionStorage: {
+          hostProjectsDir: hostDir,
+          sandboxProjectsDir: sandboxDir,
+        },
+      });
+
+      await provider.sessionStorage!.captureToHost({
+        hostCwd,
+        sandboxCwd,
+        sessionId: id,
+        handle: fsBindMountHandle(),
+      });
+
+      // Main session captured with cwd rewritten, despite the dir mismatch.
+      const main = await readFile(
+        join(hostDir, "-host-repo", `${id}.jsonl`),
+        "utf-8",
+      );
+      expect(JSON.parse(main).cwd).toBe(hostCwd);
+
+      // Subagent transcript, derived from the located dir, also captured.
+      const alpha = await readFile(
+        join(hostDir, "-host-repo", id, "subagents", "agent-alpha.jsonl"),
+        "utf-8",
+      );
+      expect(JSON.parse(alpha).cwd).toBe(hostCwd);
+    } finally {
+      await rm(hostDir, { recursive: true, force: true });
+      await rm(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
   it("claudeCode captureToHost copies subagent/workflow logs alongside the main session with cwd rewritten", async () => {
     const hostDir = await mkdtemp(
       join(tmpdir(), "sandcastle-claude-sub-many-"),

--- a/src/AgentProvider.ts
+++ b/src/AgentProvider.ts
@@ -9,7 +9,8 @@ import {
   findClaudeSessionOnHost,
   findCodexSessionOnHost,
   findPiSessionOnHost,
-  listClaudeSubagentSessionsInSandbox,
+  listClaudeSubagentSessionsInDir,
+  locateClaudeSandboxSession,
   locateCodexHostSession,
   locateCodexSandboxSession,
   locatePiHostSession,
@@ -368,14 +369,22 @@ const makeClaudeSessionStorage = (
       return readFile(path, "utf-8");
     },
     captureToHost: async ({ hostCwd, sandboxCwd, sessionId, handle }) => {
+      // Locate the session by id instead of reconstructing
+      // `<projectsDir>/<encoded-cwd>/` via encodeProjectPath. Claude Code
+      // derives that directory from its own cwd-encoding (which collapses more
+      // than path separators, e.g. `.` → `-`), so reconstructing it on the host
+      // drifts whenever Claude's encoding changes — the cause of "session not
+      // found in container" capture failures. The id is globally unique.
+      const mainSandboxPath = await locateClaudeSandboxSession(
+        sessionId,
+        handle,
+        sandboxProjectsDir,
+      );
+
       // Main session: failure is fatal — the user expects their session.
       await copyClaudeSessionFile({
         handle,
-        sourcePath: claudeSandboxSessionPath(
-          sandboxCwd,
-          sessionId,
-          sandboxProjectsDir,
-        ),
+        sourcePath: mainSandboxPath,
         fromCwd: sandboxCwd,
         toCwd: hostCwd,
         destPath: claudeHostSessionPath(hostCwd, sessionId, hostProjectsDir),
@@ -385,12 +394,11 @@ const makeClaudeSessionStorage = (
       // Subagent / workflow transcripts: best-effort. A missing `subagents/`
       // dir is the normal case (no Agent-tool / Workflow usage this run);
       // an individual subagent failing to copy must not abort siblings or
-      // the (already-successful) main capture.
-      const subagentSandboxPaths = await listClaudeSubagentSessionsInSandbox(
-        sandboxCwd,
-        sessionId,
+      // the (already-successful) main capture. Derive the directory from the
+      // located main-session path so it tracks Claude's real encoding too.
+      const subagentSandboxPaths = await listClaudeSubagentSessionsInDir(
+        posix.join(posix.dirname(mainSandboxPath), sessionId, "subagents"),
         handle,
-        sandboxProjectsDir,
       );
       const hostSubagentsDir = claudeSubagentsDirOnHost(
         hostCwd,

--- a/src/Orchestrator.test.ts
+++ b/src/Orchestrator.test.ts
@@ -3180,7 +3180,27 @@ describe("Session capture integration", () => {
             // Create a bind-mount handle backed by filesystem copy
             const handle: BindMountSandboxHandle = {
               worktreePath: sandboxBaseDir,
-              exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+              // This handle is filesystem-backed ("the sandbox IS the
+              // filesystem"), so run commands for real — captureToHost locates
+              // the session JSONL via `find`, which must see the files written
+              // under sandboxProjectsDir.
+              exec: async (command) => {
+                try {
+                  const { stdout, stderr } = await execAsync(command);
+                  return { stdout, stderr, exitCode: 0 };
+                } catch (err) {
+                  const e = err as {
+                    stdout?: string;
+                    stderr?: string;
+                    code?: number;
+                  };
+                  return {
+                    stdout: e.stdout ?? "",
+                    stderr: e.stderr ?? "",
+                    exitCode: typeof e.code === "number" ? e.code : 1,
+                  };
+                }
+              },
               copyFileIn: async (hostPath, sandboxPath) => {
                 await mkdir(join(sandboxPath, ".."), { recursive: true });
                 await copyFile(hostPath, sandboxPath);
@@ -3508,7 +3528,27 @@ describe("Session capture integration", () => {
           () => {
             const handle: BindMountSandboxHandle = {
               worktreePath: sandboxBaseDir,
-              exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+              // This handle is filesystem-backed ("the sandbox IS the
+              // filesystem"), so run commands for real — captureToHost locates
+              // the session JSONL via `find`, which must see the files written
+              // under sandboxProjectsDir.
+              exec: async (command) => {
+                try {
+                  const { stdout, stderr } = await execAsync(command);
+                  return { stdout, stderr, exitCode: 0 };
+                } catch (err) {
+                  const e = err as {
+                    stdout?: string;
+                    stderr?: string;
+                    code?: number;
+                  };
+                  return {
+                    stdout: e.stdout ?? "",
+                    stderr: e.stderr ?? "",
+                    exitCode: typeof e.code === "number" ? e.code : 1,
+                  };
+                }
+              },
               copyFileIn: async (hostPath, sandboxPath) => {
                 await mkdir(join(sandboxPath, ".."), { recursive: true });
                 await copyFile(hostPath, sandboxPath);

--- a/src/SessionStore.ts
+++ b/src/SessionStore.ts
@@ -98,29 +98,70 @@ export const claudeSubagentsDirOnHost = (
 };
 
 /**
- * Enumerate Claude Code subagent / workflow transcripts living under
- * `<projectsDir>/<encoded-cwd>/<sessionId>/subagents/` inside the sandbox.
- * Returns the absolute sandbox-side paths of every `agent-*.jsonl` file
- * (matched at any depth so future per-workflow subdirs still surface).
+ * Enumerate Claude Code subagent / workflow transcripts (`agent-*.jsonl`,
+ * matched at any depth so future per-workflow subdirs still surface) under a
+ * known `subagents/` directory inside the sandbox.
  *
  * Never throws — a missing `subagents/` directory is the normal case for a
  * session that didn't spawn any subagents, and `find` over an absent path
  * also exits non-zero. Both collapse to `[]`.
+ */
+export const listClaudeSubagentSessionsInDir = async (
+  subagentsDir: string,
+  handle: Pick<BindMountSandboxHandle, "exec">,
+): Promise<string[]> => {
+  const result = await handle.exec(
+    `find ${JSON.stringify(subagentsDir)} -type f -name ${JSON.stringify("agent-*.jsonl")} 2>/dev/null`,
+  );
+  if (result.exitCode !== 0) return [];
+  const stdout = result.stdout.trim();
+  if (stdout === "") return [];
+  return stdout.split("\n").filter((line) => line !== "");
+};
+
+/**
+ * Enumerate Claude Code subagent / workflow transcripts for a session whose
+ * `subagents/` directory is reconstructed from `(cwd, id)`. Prefer
+ * {@link listClaudeSubagentSessionsInDir} with a directory derived from the
+ * located main-session path when available, since that sidesteps cwd-encoding
+ * drift.
  */
 export const listClaudeSubagentSessionsInSandbox = async (
   cwd: string,
   id: string,
   handle: Pick<BindMountSandboxHandle, "exec">,
   sandboxProjectsDir: string,
-): Promise<string[]> => {
-  const dir = claudeSubagentsDirInSandbox(cwd, id, sandboxProjectsDir);
-  const result = await handle.exec(
-    `find ${JSON.stringify(dir)} -type f -name ${JSON.stringify("agent-*.jsonl")} 2>/dev/null`,
+): Promise<string[]> =>
+  listClaudeSubagentSessionsInDir(
+    claudeSubagentsDirInSandbox(cwd, id, sandboxProjectsDir),
+    handle,
   );
-  if (result.exitCode !== 0) return [];
-  const stdout = result.stdout.trim();
-  if (stdout === "") return [];
-  return stdout.split("\n").filter((line) => line !== "");
+
+/**
+ * Locate a Claude Code session JSONL inside the sandbox by its unique id,
+ * scanning `<sandboxProjectsDir>/` rather than reconstructing the
+ * `<encoded-cwd>` directory via {@link encodeProjectPath}. Claude Code derives
+ * that directory from its own cwd-encoding rules, which collapse more than path
+ * separators (e.g. `.` → `-`); reconstructing it on the host drifts whenever
+ * Claude's encoding changes and produces "session not found in container"
+ * capture failures. The session id is globally unique, so the first match wins.
+ *
+ * Throws when no match exists — the main session file is expected to be present
+ * once the agent has produced a session id.
+ */
+export const locateClaudeSandboxSession = async (
+  id: string,
+  handle: Pick<BindMountSandboxHandle, "exec">,
+  sandboxProjectsDir: string,
+): Promise<string> => {
+  const result = await handle.exec(
+    `find ${JSON.stringify(sandboxProjectsDir)} -type f -name ${JSON.stringify(`${id}.jsonl`)} -print -quit`,
+  );
+  const path = result.stdout.trim().split("\n")[0];
+  if (result.exitCode !== 0 || !path) {
+    throw new Error(`session ${id} not found under ${sandboxProjectsDir}`);
+  }
+  return path;
 };
 
 /**


### PR DESCRIPTION
This appears to be an issue following a bump to claude code in the container as it was not pinned.

- `captureToHost` reconstructs the sandbox project dir via `encodeProjectPath`, which replaces only path separators (`/`, `\`)
- Current Claude Code also collapses `.` → `-` in its project-dir encoding (e.g. `/repo/.work` → `-repo--work`), so the reconstructed path misses the real dir

**Result:** `docker cp` fails with `Could not find the file …<id>.jsonl in container` on an otherwise-successful run; the session capture throws and surfaces as a crash even though the agent completed

The codex and pi providers already avoid this by locating the session file by its globally-unique id; only the Claude provider reconstructs the path

**Fix:** add `locateClaudeSandboxSession` (`find <projectsDir> -name <id>.jsonl`), use it in `captureToHost`, and derive the subagents dir from the located path — sidesteps cwd-encoding drift entirely

- `listClaudeSubagentSessionsInSandbox` kept as a thin back-compat wrapper over the new dir-based `listClaudeSubagentSessionsInDir`

Adds a regression test placing the session under a dir name `encodeProjectPath` would not produce; updates the Orchestrator capture harness handle to run `find` for real

**Verified:** `tsgo --noEmit` clean; SessionStore + AgentProvider + Orchestrator suites pass (343 tests)