### PR TITLE
Template Fix: parallel templates - no hooks on non-sandbox runs

### DIFF
--- a/src/templates/parallel-planner-with-review/main.mts
+++ b/src/templates/parallel-planner-with-review/main.mts
@@ -205,7 +205,6 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   // uses to know which branches to merge and which issues to close.
   // -------------------------------------------------------------------------
   await sandcastle.run({
-    hooks,
     sandbox: docker(),
     name: "merger",
     maxIterations: 1,

--- a/src/templates/parallel-planner-with-review/main.mts
+++ b/src/templates/parallel-planner-with-review/main.mts
@@ -71,7 +71,6 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   // It outputs a <plan> JSON block — Output.object parses and validates it.
   // -------------------------------------------------------------------------
   const plan = await sandcastle.run({
-    hooks,
     sandbox: docker(),
     name: "planner",
     // One iteration is enough: the planner just needs to read and reason,

--- a/src/templates/parallel-planner/main.mts
+++ b/src/templates/parallel-planner/main.mts
@@ -66,7 +66,6 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   // It outputs a <plan> JSON block — Output.object parses and validates it.
   // -------------------------------------------------------------------------
   const plan = await sandcastle.run({
-    hooks,
     sandbox: docker(),
     name: "planner",
     // One iteration is enough: the planner just needs to read and reason,
@@ -183,7 +182,6 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   // uses to know which branches to merge and which issues to close.
   // -------------------------------------------------------------------------
   await sandcastle.run({
-    hooks,
     sandbox: docker(),
     name: "merger",
     maxIterations: 1,


### PR DESCRIPTION
I tried to use the parrallel-planner-with-review template and it was erroring out on the planner sandcastle.run call on 'npm install'. npm install was erroring because the planner was not ( and does not need to ) spinning up the full sandbox. I removed the hooks from that run call and everything ran correctly.

This PR remove the hooks from the planner and merger sandcastle.run calls to fix the problem in both the parallel-planner and parallel-planner-with-review templates so others dont run into the same issue. small fix but hopefully saves people some headaches.