### PR TITLE
Run head branch strategy in worktrees

### DIFF
--- a/src/SandboxFactory.test.ts
+++ b/src/SandboxFactory.test.ts
@@ -543,19 +543,25 @@ describe("WorktreeDockerSandboxFactory", () => {
       displayRef = Ref.unsafeMake<ReadonlyArray<DisplayEntry>>([]),
     ) => makeLayer(displayRef, { type: "head" });
 
-    it("does not create a worktree", async () => {
+    it("runs head mode in a temporary worktree and cleans it up", async () => {
+      let receivedInfo: { hostWorktreePath?: string } | undefined;
       await Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
-          yield* factory.withSandbox(() => Effect.void);
+          yield* factory.withSandbox((info) => {
+            receivedInfo = info;
+            return Effect.void;
+          });
         }).pipe(Effect.provide(makeHeadLayer())),
       );
 
       const worktree = await findCreatedWorktree(hostRepoDir);
+      expect(receivedInfo?.hostWorktreePath).not.toBe(hostRepoDir);
+      expect(receivedInfo?.hostWorktreePath).toContain(".sandcastle");
       expect(worktree).toBeUndefined();
     });
 
-    it("passes host repo dir and git mounts to provider", async () => {
+    it("passes worktree dir and git mounts to provider", async () => {
       await Effect.runPromise(
         Effect.gen(function* () {
           const factory = yield* SandboxFactory;
@@ -565,13 +571,21 @@ describe("WorktreeDockerSandboxFactory", () => {
 
       expect(mockProvider.createCalls).toHaveLength(1);
       const opts = mockProvider.createCalls[0];
+      expect(opts.mounts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            hostPath: expect.stringContaining(".sandcastle"),
+            sandboxPath: SANDBOX_REPO_DIR,
+          }),
+        ]),
+      );
       expect(opts.mounts).toContainEqual({
-        hostPath: hostRepoDir,
-        sandboxPath: SANDBOX_REPO_DIR,
-      });
-      expect(opts.mounts).toContainEqual({
-        hostPath: `${hostRepoDir}/.git`,
-        sandboxPath: `${hostRepoDir}/.git`,
+        hostPath: expect.stringContaining(
+          `${hostRepoDir.replaceAll("\\", "/")}/.git`,
+        ),
+        sandboxPath: expect.stringContaining(
+          `${hostRepoDir.replaceAll("\\", "/")}/.git`,
+        ),
       });
     });
 
@@ -587,7 +601,7 @@ describe("WorktreeDockerSandboxFactory", () => {
       expect(result.value).toBe("done");
     });
 
-    it("passes hostWorktreePath pointing to host repo dir", async () => {
+    it("passes hostWorktreePath pointing to the temporary worktree", async () => {
       let receivedInfo: { hostWorktreePath?: string } | undefined;
       await Effect.runPromise(
         Effect.gen(function* () {
@@ -599,7 +613,8 @@ describe("WorktreeDockerSandboxFactory", () => {
         }).pipe(Effect.provide(makeHeadLayer())),
       );
 
-      expect(receivedInfo?.hostWorktreePath).toBe(hostRepoDir);
+      expect(receivedInfo?.hostWorktreePath).not.toBe(hostRepoDir);
+      expect(receivedInfo?.hostWorktreePath).toContain(".sandcastle");
     });
   });
 
@@ -991,7 +1006,7 @@ describe("WorktreeDockerSandboxFactory — no-sandbox provider", () => {
     tempDirs.length = 0;
   });
 
-  it("head mode: does not create a worktree and runs in hostRepoDir", async () => {
+  it("head mode: creates a worktree, runs in it, and cleans up on success", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandcastle-test-"));
     tempDirs.push(hostDir);
     await initRepoWithCommit(hostDir);
@@ -1005,7 +1020,9 @@ describe("WorktreeDockerSandboxFactory — no-sandbox provider", () => {
         yield* factory.withSandbox((info, sandbox) => {
           receivedInfo = info;
           return Effect.gen(function* () {
-            const r = yield* sandbox.exec("cat hello.txt");
+            const r = yield* sandbox.exec(
+              `node -e "process.stdout.write(require('fs').readFileSync('hello.txt','utf8'))"`,
+            );
             execOut = r.stdout.trim();
           });
         });
@@ -1014,7 +1031,8 @@ describe("WorktreeDockerSandboxFactory — no-sandbox provider", () => {
 
     const worktree = await findCreatedWorktree(hostDir);
     expect(worktree).toBeUndefined();
-    expect(receivedInfo?.hostWorktreePath).toBe(hostDir);
+    expect(receivedInfo?.hostWorktreePath).not.toBe(hostDir);
+    expect(receivedInfo?.hostWorktreePath).toContain(".sandcastle");
     expect(execOut).toBe("hi");
   });
 

--- a/src/SandboxFactory.ts
+++ b/src/SandboxFactory.ts
@@ -303,7 +303,6 @@ export const WorktreeDockerSandboxFactory = {
         timeouts,
       } = yield* SandboxConfig;
 
-      const isHeadMode = branchStrategy.type === "head";
       const branch =
         branchStrategy.type === "branch" ? branchStrategy.branch : undefined;
       const baseBranch =
@@ -343,49 +342,7 @@ export const WorktreeDockerSandboxFactory = {
           if (sandboxProvider.tag === "none") {
             let preservedPath: string | undefined;
 
-            // Head mode: use hostRepoDir directly, no worktree.
-            if (isHeadMode) {
-              return (
-                hooks?.host?.onWorktreeReady?.length
-                  ? runHostHooks(
-                      hooks.host.onWorktreeReady,
-                      hostRepoDir,
-                      signal,
-                    )
-                  : Effect.void
-              ).pipe(
-                Effect.andThen(
-                  Effect.acquireUseRelease(
-                    startSandbox({
-                      provider: sandboxProvider,
-                      hostRepoDir,
-                      env,
-                      worktreeOrRepoPath: hostRepoDir,
-                    }),
-                    ({ sandbox, worktreePath }) =>
-                      makeEffect(
-                        {
-                          hostWorktreePath: hostRepoDir,
-                          sandboxRepoPath: worktreePath,
-                        },
-                        sandbox,
-                      ) as Effect.Effect<A, E | SandboxError, R>,
-                    ({ handle }) =>
-                      Effect.tryPromise({
-                        try: () => handle.close(),
-                        catch: () => undefined,
-                      }).pipe(Effect.orDie),
-                  ).pipe(
-                    Effect.map((value) => ({
-                      value,
-                      preservedWorktreePath: undefined,
-                    })),
-                  ),
-                ),
-              );
-            }
-
-            // Worktree mode (merge-to-head or explicit branch).
+            // Worktree mode (head, merge-to-head, or explicit branch).
             // Nested so the worktree is always cleaned up (outer release) even
             // when copying, hooks, or sandbox start fail. The provider handle is
             // closed by the inner release, which only runs once it exists.
@@ -522,67 +479,7 @@ export const WorktreeDockerSandboxFactory = {
             );
           }
 
-          if (isHeadMode) {
-            // Head mode: bind-mount host directory directly, no worktree
-            const gitPath = join(hostRepoDir, ".git");
-            return (
-              hooks?.host?.onWorktreeReady?.length
-                ? runHostHooks(hooks.host.onWorktreeReady, hostRepoDir, signal)
-                : Effect.void
-            ).pipe(
-              Effect.andThen(resolveGitMounts(gitPath)),
-              Effect.provideService(FileSystem.FileSystem, fileSystem),
-              Effect.mapError(
-                (e) =>
-                  new WorktreeError({
-                    message: `Failed to resolve git mounts: ${e}`,
-                  }) as E | SandboxError,
-              ),
-              Effect.flatMap((gitMounts) =>
-                // Patch git mounts for Windows worktree compatibility (ADR-0006)
-                patchGitMountsForWindows(
-                  gitMounts,
-                  hostRepoDir,
-                  SANDBOX_REPO_DIR,
-                ),
-              ),
-              Effect.flatMap((gitMounts) =>
-                Effect.acquireUseRelease(
-                  startSandbox({
-                    provider: sandboxProvider,
-                    hostRepoDir,
-                    env,
-                    worktreeOrRepoPath: hostRepoDir,
-                    gitMounts,
-                    repoDir: SANDBOX_REPO_DIR,
-                  }),
-                  // Use
-                  ({ sandbox, worktreePath, handle }) =>
-                    makeEffect(
-                      {
-                        hostWorktreePath: hostRepoDir,
-                        sandboxRepoPath: worktreePath,
-                        bindMountHandle: handle as BindMountSandboxHandle,
-                      },
-                      sandbox,
-                    ) as Effect.Effect<A, E | SandboxError, R>,
-                  // Release
-                  ({ handle }) =>
-                    Effect.tryPromise({
-                      try: () => handle.close(),
-                      catch: () => undefined,
-                    }).pipe(Effect.orDie),
-                ).pipe(
-                  Effect.map((value) => ({
-                    value,
-                    preservedWorktreePath: undefined,
-                  })),
-                ),
-              ),
-            );
-          }
-
-          // Worktree mode (merge-to-head or explicit branch)
+          // Worktree mode (head, merge-to-head, or explicit branch)
           // Populated by the release phase when a worktree is preserved on failure,
           // so we can attach the path to recognized error types before they propagate.
           let preservedWorktreePath: string | undefined;

--- a/src/SandboxProvider.ts
+++ b/src/SandboxProvider.ts
@@ -242,7 +242,7 @@ export interface NoSandboxProvider {
 
 // ---------- Branch strategy types ----------
 
-/** Head strategy: agent writes directly to host working directory. Bind-mount only. */
+/** Head strategy: temporary worktree forked from the host working directory's current HEAD. */
 export interface HeadBranchStrategy {
   readonly type: "head";
 }

--- a/src/createWorktree.ts
+++ b/src/createWorktree.ts
@@ -209,8 +209,8 @@ export interface Worktree {
  * Creates a git worktree as an independent, first-class worktree.
  * Returns a Worktree handle with close() and [Symbol.asyncDispose]().
  *
- * Only accepts 'branch' and 'merge-to-head' strategies — 'head' is a
- * compile-time type error since head means no worktree.
+ * Only accepts 'branch' and 'merge-to-head' strategies. Top-level 'head'
+ * strategy creates its own temporary worktree, so it is not valid here.
  */
 export const createWorktree = async (
   options: CreateWorktreeOptions,

--- a/src/interactive-windowsMounts.test.ts
+++ b/src/interactive-windowsMounts.test.ts
@@ -109,11 +109,13 @@ describe("interactive() Windows mount patching", () => {
     const worktreePath = call[1];
     const sandboxRepoDir = call[2];
     expect(Array.isArray(gitMounts)).toBe(true);
-    expect(worktreePath).toContain(".sandcastle/worktrees");
+    expect(worktreePath.replaceAll("\\", "/")).toContain(
+      ".sandcastle/worktrees",
+    );
     expect(sandboxRepoDir).toBe(SANDBOX_REPO_DIR);
-  });
+  }, 10_000);
 
-  it("calls patchGitMountsForWindows with hostRepoDir as worktreeHostPath in head mode", async () => {
+  it("calls patchGitMountsForWindows with worktreePath in head mode", async () => {
     hostDir = await mkdtemp(join(tmpdir(), "wm-test-interactive-head-"));
     await initRepo(hostDir);
     await commitFile(hostDir, "init.txt", "init", "initial commit");
@@ -132,7 +134,7 @@ describe("interactive() Windows mount patching", () => {
     const call = mockPatchGitMountsForWindows.mock.calls[0]!;
     const worktreePath = call[1];
     const sandboxRepoDir = call[2];
-    expect(worktreePath).toBe(hostDir);
+    expect(worktreePath.replaceAll("\\", "/")).toContain(".sandcastle");
     expect(sandboxRepoDir).toBe(SANDBOX_REPO_DIR);
   });
 });

--- a/src/interactive.test.ts
+++ b/src/interactive.test.ts
@@ -477,7 +477,7 @@ describe("interactive()", () => {
 
   // --- Branch strategy tests ---
 
-  it("head strategy: commits land on current branch directly", async () => {
+  it("head strategy: commits merge back to the current branch", async () => {
     const provider = makeTestProvider(async (_args, opts) => {
       const cwd = opts.cwd!;
       execSync('echo "head change" > headfile.txt', { cwd });
@@ -500,7 +500,13 @@ describe("interactive()", () => {
 
     expect(result.branch).toBe(currentBranch);
     expect(result.commits.length).toBe(1);
-  });
+
+    const log = execSync("git log --oneline -1", {
+      cwd: hostDir,
+      encoding: "utf-8",
+    });
+    expect(log).toContain("head commit");
+  }, 10_000);
 
   it("merge-to-head strategy: commits merge back to head", async () => {
     const provider = makeTestProvider(async (_args, opts) => {
@@ -616,18 +622,22 @@ describe("interactive()", () => {
 
   // --- copyToWorktree tests ---
 
-  it("throws when copyToWorktree used with head strategy", async () => {
-    const provider = makeTestProvider(async () => ({ exitCode: 0 }));
+  it("runs head strategy interactive sessions in a worktree", async () => {
+    let interactiveCwd = "";
 
-    await expect(
-      interactive({
-        agent: claudeCode("claude-opus-4-8"),
-        sandbox: provider,
-        prompt: "test",
-        branchStrategy: { type: "head" },
-        copyToWorktree: ["node_modules"],
-      }),
-    ).rejects.toThrow("copyToWorktree is not supported with head");
+    const provider = makeTestProvider(async (_args, opts) => {
+      interactiveCwd = opts.cwd ?? "";
+      return { exitCode: 0 };
+    });
+
+    await interactive({
+      agent: claudeCode("claude-opus-4-8"),
+      sandbox: provider,
+      prompt: "test",
+      branchStrategy: { type: "head" },
+    });
+
+    expect(interactiveCwd.replaceAll("\\", "/")).toContain(".sandcastle");
   });
 
   // --- AbortSignal tests ---

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -135,18 +135,6 @@ export const interactive = async (
     );
   }
 
-  // Validate: copyToWorktree is incompatible with head strategy
-  if (
-    branchStrategy.type === "head" &&
-    options.copyToWorktree &&
-    options.copyToWorktree.length > 0
-  ) {
-    throw new Error(
-      "copyToWorktree is not supported with head branch strategy. " +
-        "In head mode the host working directory is bind-mounted directly.",
-    );
-  }
-
   // Validate buildInteractiveArgs is available
   if (!provider.buildInteractiveArgs) {
     throw new Error(
@@ -157,7 +145,6 @@ export const interactive = async (
   const branch: string | undefined =
     branchStrategy.type === "branch" ? branchStrategy.branch : undefined;
 
-  const isHeadMode = branchStrategy.type === "head";
   const sandboxProvider = resolvedSandbox;
 
   const inner = Effect.gen(function* () {
@@ -234,8 +221,7 @@ export const interactive = async (
       yield* validateNoArgsWithInlinePrompt(userArgs);
     }
 
-    // In head mode, pass the host branch so SandboxLifecycle skips the merge step.
-    const lifecycleBranch = isHeadMode ? currentHostBranch : branch;
+    const lifecycleBranch = branch;
 
     // Display intro and summary
     yield* d.intro(options.name ?? "sandcastle interactive");
@@ -245,21 +231,17 @@ export const interactive = async (
       Branch: resolvedBranch,
     });
 
-    // 5. Create worktree (unless head mode)
-    let worktreeInfo: WorktreeManager.WorktreeInfo | undefined;
-
-    if (!isHeadMode) {
-      worktreeInfo = yield* d.taskLog("Creating worktree", () =>
-        WorktreeManager.pruneStale(hostRepoDir).pipe(
-          Effect.catchAll(() => Effect.void),
-          Effect.andThen(
-            branch
-              ? WorktreeManager.create(hostRepoDir, { branch })
-              : WorktreeManager.create(hostRepoDir, { name: options.name }),
-          ),
+    // 5. Create worktree.
+    const worktreeInfo = yield* d.taskLog("Creating worktree", () =>
+      WorktreeManager.pruneStale(hostRepoDir).pipe(
+        Effect.catchAll(() => Effect.void),
+        Effect.andThen(
+          branch
+            ? WorktreeManager.create(hostRepoDir, { branch })
+            : WorktreeManager.create(hostRepoDir, { name: options.name }),
         ),
-      );
-    }
+      ),
+    );
 
     // 6. Prepare the worktree and start the sandbox. If any step fails after the
     // worktree exists (copying, hooks, or sandbox start), remove the worktree so
@@ -268,37 +250,30 @@ export const interactive = async (
       | BindMountSandboxHandle
       | IsolatedSandboxHandle
       | NoSandboxHandle = yield* Effect.gen(function* () {
-      if (!isHeadMode) {
-        // Copy files to worktree (bind-mount and no-sandbox, non-head)
-        if (
-          (sandboxProvider.tag === "bind-mount" ||
-            sandboxProvider.tag === "none") &&
-          options.copyToWorktree &&
-          options.copyToWorktree.length > 0
-        ) {
-          yield* d.taskLog("Copying files to worktree", () =>
-            copyToWorktree(
-              options.copyToWorktree!,
-              hostRepoDir,
-              worktreeInfo!.path,
-              options.timeouts?.copyToWorktreeMs,
-            ),
-          );
-        }
+      if (
+        (sandboxProvider.tag === "bind-mount" ||
+          sandboxProvider.tag === "none") &&
+        options.copyToWorktree &&
+        options.copyToWorktree.length > 0
+      ) {
+        yield* d.taskLog("Copying files to worktree", () =>
+          copyToWorktree(
+            options.copyToWorktree!,
+            hostRepoDir,
+            worktreeInfo.path,
+            options.timeouts?.copyToWorktreeMs,
+          ),
+        );
+      }
 
-        // Run host.onWorktreeReady hooks
-        if (hooks?.host?.onWorktreeReady?.length) {
-          yield* runHostHooks(hooks.host.onWorktreeReady, worktreeInfo!.path);
-        }
-      } else if (hooks?.host?.onWorktreeReady?.length) {
-        // Head strategy: cwd is the host repo root
-        yield* runHostHooks(hooks.host.onWorktreeReady, hostRepoDir);
+      if (hooks?.host?.onWorktreeReady?.length) {
+        yield* runHostHooks(hooks.host.onWorktreeReady, worktreeInfo.path);
       }
 
       // Start sandbox
       if (sandboxProvider.tag === "none") {
-        // No-sandbox: run directly on the host, no container
-        const worktreePath = isHeadMode ? hostRepoDir : worktreeInfo!.path;
+        // No-sandbox: run directly in the worktree, no container
+        const worktreePath = worktreeInfo.path;
         return yield* Effect.promise(() =>
           sandboxProvider.create({
             worktreePath,
@@ -309,7 +284,7 @@ export const interactive = async (
         const startResult = yield* d.taskLog("Starting sandbox", () =>
           startSandbox({
             provider: sandboxProvider,
-            hostRepoDir: worktreeInfo!.path,
+            hostRepoDir: worktreeInfo.path,
             env: effectiveEnv,
             copyPaths: options.copyToWorktree,
           }),
@@ -318,9 +293,7 @@ export const interactive = async (
       } else {
         const gitPath = join(hostRepoDir, ".git");
         const rawGitMounts = yield* resolveGitMounts(gitPath);
-        const worktreeOrRepoPath = isHeadMode
-          ? hostRepoDir
-          : worktreeInfo!.path;
+        const worktreeOrRepoPath = worktreeInfo.path;
         const gitMounts = yield* patchGitMountsForWindows(
           rawGitMounts,
           worktreeOrRepoPath,
@@ -374,7 +347,7 @@ export const interactive = async (
           sandboxRepoDir: worktreePath,
           hooks,
           branch: lifecycleBranch,
-          hostWorktreePath: isHeadMode ? hostRepoDir : worktreeInfo?.path,
+          hostWorktreePath: worktreeInfo.path,
           applyToHost,
           timeouts: options.timeouts,
         },
@@ -420,17 +393,15 @@ export const interactive = async (
 
       // Check for uncommitted changes (worktree mode only)
       let preservedWorktreePath: string | undefined;
-      if (worktreeInfo) {
-        const hasUncommitted = yield* WorktreeManager.hasUncommittedChanges(
-          worktreeInfo.path,
-        ).pipe(Effect.catchAll(() => Effect.succeed(false)));
-        if (hasUncommitted) {
-          preservedWorktreePath = worktreeInfo.path;
-        }
+      const hasUncommitted = yield* WorktreeManager.hasUncommittedChanges(
+        worktreeInfo.path,
+      ).pipe(Effect.catchAll(() => Effect.succeed(false)));
+      if (hasUncommitted) {
+        preservedWorktreePath = worktreeInfo.path;
       }
 
       // Clean up worktree if not preserved
-      if (worktreeInfo && !preservedWorktreePath) {
+      if (!preservedWorktreePath) {
         yield* WorktreeManager.remove(worktreeInfo.path).pipe(
           Effect.catchAll(() => Effect.void),
         );
@@ -455,11 +426,9 @@ export const interactive = async (
     }).pipe(
       // On error, always clean up worktree (on success, handled above with preserve check)
       Effect.tapError(() =>
-        worktreeInfo
-          ? WorktreeManager.remove(worktreeInfo.path).pipe(
-              Effect.catchAll(() => Effect.void),
-            )
-          : Effect.void,
+        WorktreeManager.remove(worktreeInfo.path).pipe(
+          Effect.catchAll(() => Effect.void),
+        ),
       ),
       // Always close sandbox handle
       Effect.ensuring(Effect.promise(() => handle.close().catch(() => {}))),

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -475,22 +475,6 @@ describe("forkSession validation", () => {
   });
 });
 
-describe("copyToWorktree with head branch strategy", () => {
-  it("throws a runtime error when copyToWorktree is provided with head strategy", async () => {
-    await expect(
-      run({
-        agent: claudeCode("claude-opus-4-8"),
-        sandbox: testSandbox,
-        prompt: "test",
-        branchStrategy: { type: "head" },
-        copyToWorktree: [".env"],
-      }),
-    ).rejects.toThrow(
-      "copyToWorktree is not supported with head branch strategy",
-    );
-  });
-});
-
 describe("branchStrategy on RunOptions", () => {
   it("throws when head strategy is used with an isolated provider", async () => {
     const isolatedSandbox = sandcastle.createIsolatedSandboxProvider({

--- a/src/run.ts
+++ b/src/run.ts
@@ -519,18 +519,6 @@ export async function run(
     );
   }
 
-  // Validate: copyToWorktree is incompatible with head strategy
-  if (
-    effectiveBranchType === "head" &&
-    options.copyToWorktree &&
-    options.copyToWorktree.length > 0
-  ) {
-    throw new Error(
-      "copyToWorktree is not supported with head branch strategy. " +
-        "In head mode the host working directory is bind-mounted directly.",
-    );
-  }
-
   // Validate: resumeSession + maxIterations > 1 is not allowed
   if (options.resumeSession && maxIterations > 1) {
     throw new Error(
@@ -631,8 +619,8 @@ export async function run(
     getCurrentBranch(hostRepoDir),
   );
 
-  // When in merge-to-head mode, generate a temporary branch name.
-  // In head mode, use the host's current branch directly (no worktree).
+  // Head mode preserves the public branch label while the factory runs the
+  // agent in a temporary worktree forked from the current HEAD.
   const resolvedBranch =
     effectiveBranchType === "head"
       ? currentHostBranch
@@ -733,17 +721,12 @@ export async function run(
       );
     }
 
-    // In head mode, pass the host branch so SandboxLifecycle skips the merge step.
-    // In merge-to-head mode, branch is undefined (triggers merge). In branch mode, it's the explicit branch.
-    const orchestrateBranch =
-      effectiveBranchType === "head" ? currentHostBranch : branch;
-
     const orchestrateResult = yield* orchestrate({
       hostRepoDir,
       iterations: maxIterations,
       hooks,
       prompt: resolvedPrompt,
-      branch: orchestrateBranch,
+      branch,
       provider,
       completionSignal: options.completionSignal,
       idleTimeoutSeconds: options.idleTimeoutSeconds,

--- a/src/startSandbox.ts
+++ b/src/startSandbox.ts
@@ -52,7 +52,7 @@ export interface StartSandboxNoSandboxOptions {
   provider: NoSandboxProvider;
   hostRepoDir: string;
   env: Record<string, string>;
-  /** Host-side worktree path the agent will run in. Equal to hostRepoDir in head mode. */
+  /** Host-side worktree path the agent will run in. */
   worktreeOrRepoPath: string;
   gitMounts?: undefined;
   repoDir?: undefined;

--- a/src/templates/simple-loop/main.mts
+++ b/src/templates/simple-loop/main.mts
@@ -26,10 +26,10 @@ await run({
   // per run, or set it to 1 for a single-shot mode.
   maxIterations: 3,
 
-  // Branch strategy — merge-to-head creates a temporary branch for the agent
+  // Branch strategy - merge-to-head creates a temporary branch for the agent
   // to work on, then merges the result back to HEAD when the run completes.
-  // This is required when using copyToWorktree, since head mode bind-mounts
-  // the host directory directly (no worktree to copy into).
+  // Head mode also uses a temporary worktree, but this template keeps
+  // merge-to-head explicit.
   branchStrategy: { type: "merge-to-head" },
 
   // Copy node_modules from the host into the worktree before the sandbox


### PR DESCRIPTION
## Summary
- route head branch strategy through temporary worktrees instead of the host checkout
- let head mode merge completed commits back to the current branch through the existing lifecycle path
- update run, interactive, factory, and docs/tests to reflect the new head semantics

## Verification
- npm run typecheck
- npm test -- src/SandboxFactory.test.ts src/interactive.test.ts src/interactive-windowsMounts.test.ts -t head
- npx prettier --check src/SandboxFactory.ts src/run.ts src/interactive.ts src/SandboxFactory.test.ts src/run.test.ts src/interactive.test.ts src/interactive-windowsMounts.test.ts src/createWorktree.ts src/SandboxProvider.ts src/startSandbox.ts src/templates/simple-loop/main.mts

Note: full focused file run on Windows hit pre-existing Windows fragility outside this change: POSIX cp usage in copyToWorktree tests and isolated sandbox copy path assumptions.