### PR TITLE
feat(sandboxes): add optional memory/memorySwap limits to docker() and podman()

### DIFF
--- a/.changeset/sandbox-memory-limits.md
+++ b/.changeset/sandbox-memory-limits.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": minor
+---
+
+Add optional `memory` and `memorySwap` options to the `docker()` and `podman()` sandbox providers. They are thin pass-throughs to the `--memory` and `--memory-swap` flags on `docker run` / `podman run`, letting callers bound per-container memory (e.g. `memory: "512m"`, `memorySwap: "2g"`) so several concurrent sandboxes fit within a memory-constrained VM's budget. When omitted, no flag is added and the container stays unconstrained.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ const result = await run({
     devices: ["/dev/kvm"],
     // Optional: limit CPU resources via --cpus. Fractional values allowed (e.g. 1.5).
     // cpus: 2,
+    // Optional: limit memory via --memory (e.g. "512m", "2g").
+    // memory: "2g",
+    // Optional: limit memory + swap via --memory-swap. Only meaningful alongside memory.
+    // memorySwap: "2g",
   }),
 
   // Host repo directory — replaces process.cwd() as the anchor for

--- a/src/DockerLifecycle.ts
+++ b/src/DockerLifecycle.ts
@@ -85,6 +85,10 @@ export interface StartContainerOptions {
   readonly devices?: readonly string[];
   /** Limit CPU resources via `--cpus` (e.g. `1.5`). Fractional values allowed. */
   readonly cpus?: number;
+  /** Limit memory via `--memory` (e.g. `"512m"`, `"2g"`). */
+  readonly memory?: string;
+  /** Limit memory + swap via `--memory-swap` (e.g. `"2g"`). Only meaningful alongside `memory`. */
+  readonly memorySwap?: string;
   /**
    * SELinux volume label suffix applied to bind mounts (default `"z"`).
    *
@@ -152,6 +156,12 @@ export const startContainer = (
     ]);
     const cpusFlags =
       options?.cpus !== undefined ? ["--cpus", String(options.cpus)] : [];
+    const memoryFlags =
+      options?.memory !== undefined ? ["--memory", options.memory] : [];
+    const memorySwapFlags =
+      options?.memorySwap !== undefined
+        ? ["--memory-swap", options.memorySwap]
+        : [];
 
     yield* dockerExec([
       "run",
@@ -166,6 +176,8 @@ export const startContainer = (
       ...groupAddFlags,
       ...deviceFlags,
       ...cpusFlags,
+      ...memoryFlags,
+      ...memorySwapFlags,
       imageName,
     ]);
   });

--- a/src/sandboxes/docker.test.ts
+++ b/src/sandboxes/docker.test.ts
@@ -306,6 +306,65 @@ describe("docker()", () => {
     await handle.close();
   });
 
+  it("passes --memory and --memory-swap flags to docker run when set", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = docker({ memory: "512m", memorySwap: "1g" });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1] as string[];
+
+    const memoryIdx = runArgs.indexOf("--memory");
+    expect(memoryIdx).toBeGreaterThan(-1);
+    expect(runArgs[memoryIdx + 1]).toBe("512m");
+
+    const memorySwapIdx = runArgs.indexOf("--memory-swap");
+    expect(memorySwapIdx).toBeGreaterThan(-1);
+    expect(runArgs[memorySwapIdx + 1]).toBe("1g");
+
+    await handle.close();
+  });
+
+  it("does not pass --memory or --memory-swap to docker run when omitted", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = docker();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1] as string[];
+
+    expect(runArgs).not.toContain("--memory");
+    expect(runArgs).not.toContain("--memory-swap");
+
+    await handle.close();
+  });
+
   it("runs pre-flight docker image inspect before docker run", async () => {
     const callOrder: string[] = [];
     mockExecFile.mockImplementation((_command, args, ...rest: any[]) => {

--- a/src/sandboxes/docker.ts
+++ b/src/sandboxes/docker.ts
@@ -121,6 +121,29 @@ export interface DockerOptions {
    * When omitted, no `--cpus` flag is added and the container is unconstrained.
    */
   readonly cpus?: number;
+  /**
+   * Limit the memory available to the container, via `--memory`.
+   *
+   * Maps directly to `docker run --memory`. Accepts Docker's human-readable
+   * byte units:
+   *
+   * - `"512m"` → `--memory 512m`
+   * - `"2g"` → `--memory 2g`
+   *
+   * When omitted, no `--memory` flag is added and the container is unconstrained.
+   */
+  readonly memory?: string;
+  /**
+   * Limit the memory plus swap available to the container, via `--memory-swap`.
+   *
+   * Maps directly to `docker run --memory-swap`. Only meaningful when `memory`
+   * is also set:
+   *
+   * - `"2g"` → `--memory-swap 2g`
+   *
+   * When omitted, no `--memory-swap` flag is added.
+   */
+  readonly memorySwap?: string;
 }
 
 /**
@@ -193,6 +216,8 @@ export const docker = (options?: DockerOptions): SandboxProvider => {
             groups: options?.groups,
             devices: options?.devices,
             cpus: options?.cpus,
+            memory: options?.memory,
+            memorySwap: options?.memorySwap,
             selinuxLabel,
           },
         ),

--- a/src/sandboxes/podman.test.ts
+++ b/src/sandboxes/podman.test.ts
@@ -633,6 +633,65 @@ describe("podman()", () => {
     await handle.close();
   });
 
+  it("passes --memory and --memory-swap flags to podman run when set", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman({ memory: "512m", memorySwap: "1g" });
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1] as string[];
+
+    const memoryIdx = runArgs.indexOf("--memory");
+    expect(memoryIdx).toBeGreaterThan(-1);
+    expect(runArgs[memoryIdx + 1]).toBe("512m");
+
+    const memorySwapIdx = runArgs.indexOf("--memory-swap");
+    expect(memorySwapIdx).toBeGreaterThan(-1);
+    expect(runArgs[memorySwapIdx + 1]).toBe("1g");
+
+    await handle.close();
+  });
+
+  it("does not pass --memory or --memory-swap flag when omitted", async () => {
+    mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
+      const callback = rest[rest.length - 1];
+      callback(null, "", "");
+      return undefined as any;
+    });
+
+    const provider = podman();
+    const handle = await provider.create({
+      worktreePath: "/tmp/worktree",
+      hostRepoPath: "/tmp/repo",
+      mounts: [
+        { hostPath: "/tmp/worktree", sandboxPath: "/home/agent/workspace" },
+      ],
+      env: {},
+    });
+
+    const runArgs = mockExecFile.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "run",
+    )?.[1] as string[];
+
+    expect(runArgs).not.toContain("--memory");
+    expect(runArgs).not.toContain("--memory-swap");
+
+    await handle.close();
+  });
+
   it("does not pass --network flag when network is omitted", async () => {
     mockExecFile.mockImplementation((_command, _args, ...rest: any[]) => {
       const callback = rest[rest.length - 1];

--- a/src/sandboxes/podman.ts
+++ b/src/sandboxes/podman.ts
@@ -132,6 +132,29 @@ export interface PodmanOptions {
    * When omitted, no `--cpus` flag is added and the container is unconstrained.
    */
   readonly cpus?: number;
+  /**
+   * Limit the memory available to the container, via `--memory`.
+   *
+   * Maps directly to `podman run --memory`. Accepts Podman's human-readable
+   * byte units:
+   *
+   * - `"512m"` → `--memory 512m`
+   * - `"2g"` → `--memory 2g`
+   *
+   * When omitted, no `--memory` flag is added and the container is unconstrained.
+   */
+  readonly memory?: string;
+  /**
+   * Limit the memory plus swap available to the container, via `--memory-swap`.
+   *
+   * Maps directly to `podman run --memory-swap`. Only meaningful when `memory`
+   * is also set:
+   *
+   * - `"2g"` → `--memory-swap 2g`
+   *
+   * When omitted, no `--memory-swap` flag is added.
+   */
+  readonly memorySwap?: string;
 }
 
 /**
@@ -218,6 +241,12 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
       ]);
       const cpusArgs =
         options?.cpus !== undefined ? ["--cpus", String(options.cpus)] : [];
+      const memoryArgs =
+        options?.memory !== undefined ? ["--memory", options.memory] : [];
+      const memorySwapArgs =
+        options?.memorySwap !== undefined
+          ? ["--memory-swap", options.memorySwap]
+          : [];
 
       // Start container via podman run
       await new Promise<void>((resolve, reject) => {
@@ -234,6 +263,8 @@ export const podman = (options?: PodmanOptions): SandboxProvider => {
             ...groupArgs,
             ...deviceArgs,
             ...cpusArgs,
+            ...memoryArgs,
+            ...memorySwapArgs,
             "-w",
             worktreePath,
             ...envArgs,


### PR DESCRIPTION
Adds optional `memory` / `memorySwap` limits to `docker()` and `podman()`, so callers can bound per-container memory and fit several concurrent sandboxes within a memory-constrained VM's budget.

Both are optional string fields, thin pass-throughs to `docker run` / `podman run` (not validated), mirroring the existing `cpus` option:

- `memory?: string` → `--memory` (e.g. `"512m"`, `"2g"`)
- `memorySwap?: string` → `--memory-swap` (only meaningful alongside `memory`)

Non-breaking: when omitted, no flag is added and the `run` args are byte-identical. Tests cover flags-present-when-set and flags-absent-when-omitted for both providers.
