### PR TITLE
fix: stream reusable sandbox terminal output

### DIFF
--- a/.changeset/bright-candles-stream.md
+++ b/.changeset/bright-candles-stream.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Fix terminal-mode streaming for reusable sandboxes so `sandbox.run()` displays parsed agent text, tool calls, and run status instead of silently buffering them.

--- a/src/createSandbox.test.ts
+++ b/src/createSandbox.test.ts
@@ -1,3 +1,4 @@
+import * as clack from "@clack/prompts";
 import { exec } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, writeFileSync } from "node:fs";
 import {
@@ -12,7 +13,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { Effect, Layer } from "effect";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { claudeCode, codex, pi } from "./AgentProvider.js";
 import { createSandbox, type CreateSandboxOptions } from "./createSandbox.js";
 import type { SandboxService } from "./SandboxFactory.js";
@@ -296,6 +297,85 @@ describe("createSandbox", () => {
       expect(typeof result.stdout).toBe("string");
       expect(Array.isArray(result.commits)).toBe(true);
     } finally {
+      await sandbox.close();
+      await rm(hostDir, { recursive: true, force: true });
+    }
+  });
+
+  it("sandbox.run() streams parsed agent text and tool calls in terminal mode", async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), "sandbox-stdout-"));
+    await initRepo(hostDir);
+    await commitFile(hostDir, "init.txt", "init", "initial commit");
+
+    const textLine = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "streamed agent text" }],
+      },
+    });
+    const toolLine = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "tool_use", name: "Bash", input: { command: "npm test" } },
+        ],
+      },
+    });
+    const resultLine = JSON.stringify({
+      type: "result",
+      result: "streamed agent text",
+    });
+
+    const messageSpy = vi
+      .spyOn(clack.log, "message")
+      .mockImplementation(() => {});
+    const stepSpy = vi.spyOn(clack.log, "step").mockImplementation(() => {});
+
+    const sandbox = await createSandbox({
+      branch: "stdout-streaming-branch",
+      sandbox: testSandbox,
+      cwd: hostDir,
+      _test: {
+        buildSandbox: (sandboxDir) => {
+          const real = makeLocalSandbox(sandboxDir);
+          return {
+            exec: (command, options) => {
+              if (command.startsWith("claude ") && options?.onLine) {
+                const onLine = options.onLine;
+                return Effect.sync(() => {
+                  for (const line of [textLine, toolLine, resultLine]) {
+                    onLine(line);
+                  }
+                  return {
+                    stdout: [textLine, toolLine, resultLine].join("\n"),
+                    stderr: "",
+                    exitCode: 0,
+                  };
+                });
+              }
+              return real.exec(command, options);
+            },
+            copyIn: real.copyIn,
+            copyFileOut: real.copyFileOut,
+          };
+        },
+      },
+    });
+
+    try {
+      await sandbox.run({
+        agent: testProvider,
+        prompt: "do something",
+        maxIterations: 1,
+        logging: { type: "stdout" },
+      });
+
+      expect(messageSpy).toHaveBeenCalledWith("streamed agent text");
+      expect(stepSpy).toHaveBeenCalledWith(expect.stringContaining("Bash"));
+      expect(stepSpy).toHaveBeenCalledWith(expect.stringContaining("npm test"));
+    } finally {
+      messageSpy.mockRestore();
+      stepSpy.mockRestore();
       await sandbox.close();
       await rm(hostDir, { recursive: true, force: true });
     }

--- a/src/createSandbox.test.ts
+++ b/src/createSandbox.test.ts
@@ -330,6 +330,10 @@ describe("createSandbox", () => {
       .spyOn(clack.log, "message")
       .mockImplementation(() => {});
     const stepSpy = vi.spyOn(clack.log, "step").mockImplementation(() => {});
+    vi.spyOn(clack.log, "info").mockImplementation(() => {});
+    vi.spyOn(clack.log, "success").mockImplementation(() => {});
+    vi.spyOn(clack.log, "warning").mockImplementation(() => {});
+    vi.spyOn(clack.log, "error").mockImplementation(() => {});
 
     const sandbox = await createSandbox({
       branch: "stdout-streaming-branch",
@@ -374,10 +378,9 @@ describe("createSandbox", () => {
       expect(stepSpy).toHaveBeenCalledWith(expect.stringContaining("Bash"));
       expect(stepSpy).toHaveBeenCalledWith(expect.stringContaining("npm test"));
     } finally {
-      messageSpy.mockRestore();
-      stepSpy.mockRestore();
       await sandbox.close();
       await rm(hostDir, { recursive: true, force: true });
+      vi.restoreAllMocks();
     }
   });
 

--- a/src/createSandbox.test.ts
+++ b/src/createSandbox.test.ts
@@ -302,87 +302,107 @@ describe("createSandbox", () => {
     }
   });
 
-  it("sandbox.run() streams parsed agent text and tool calls in terminal mode", async () => {
-    const hostDir = await mkdtemp(join(tmpdir(), "sandbox-stdout-"));
-    await initRepo(hostDir);
-    await commitFile(hostDir, "init.txt", "init", "initial commit");
+  it.each([
+    { label: "without verbose raw output", verbose: false },
+    { label: "with verbose raw output", verbose: true },
+  ])(
+    "sandbox.run() streams parsed agent text and tool calls in terminal mode $label",
+    async ({ verbose }) => {
+      const hostDir = await mkdtemp(join(tmpdir(), "sandbox-terminal-"));
+      await initRepo(hostDir);
+      await commitFile(hostDir, "init.txt", "init", "initial commit");
 
-    const textLine = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [{ type: "text", text: "streamed agent text" }],
-      },
-    });
-    const toolLine = JSON.stringify({
-      type: "assistant",
-      message: {
-        content: [
-          { type: "tool_use", name: "Bash", input: { command: "npm test" } },
-        ],
-      },
-    });
-    const resultLine = JSON.stringify({
-      type: "result",
-      result: "streamed agent text",
-    });
-
-    const messageSpy = vi
-      .spyOn(clack.log, "message")
-      .mockImplementation(() => {});
-    const stepSpy = vi.spyOn(clack.log, "step").mockImplementation(() => {});
-    vi.spyOn(clack.log, "info").mockImplementation(() => {});
-    vi.spyOn(clack.log, "success").mockImplementation(() => {});
-    vi.spyOn(clack.log, "warning").mockImplementation(() => {});
-    vi.spyOn(clack.log, "error").mockImplementation(() => {});
-
-    const sandbox = await createSandbox({
-      branch: "stdout-streaming-branch",
-      sandbox: testSandbox,
-      cwd: hostDir,
-      _test: {
-        buildSandbox: (sandboxDir) => {
-          const real = makeLocalSandbox(sandboxDir);
-          return {
-            exec: (command, options) => {
-              if (command.startsWith("claude ") && options?.onLine) {
-                const onLine = options.onLine;
-                return Effect.sync(() => {
-                  for (const line of [textLine, toolLine, resultLine]) {
-                    onLine(line);
-                  }
-                  return {
-                    stdout: [textLine, toolLine, resultLine].join("\n"),
-                    stderr: "",
-                    exitCode: 0,
-                  };
-                });
-              }
-              return real.exec(command, options);
-            },
-            copyIn: real.copyIn,
-            copyFileOut: real.copyFileOut,
-          };
+      const textLine = JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "streamed agent text" }],
         },
-      },
-    });
-
-    try {
-      await sandbox.run({
-        agent: testProvider,
-        prompt: "do something",
-        maxIterations: 1,
-        logging: { type: "stdout" },
+      });
+      const toolLine = JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", name: "Bash", input: { command: "npm test" } },
+          ],
+        },
+      });
+      const resultLine = JSON.stringify({
+        type: "result",
+        result: "streamed agent text",
       });
 
-      expect(messageSpy).toHaveBeenCalledWith("streamed agent text");
-      expect(stepSpy).toHaveBeenCalledWith(expect.stringContaining("Bash"));
-      expect(stepSpy).toHaveBeenCalledWith(expect.stringContaining("npm test"));
-    } finally {
-      await sandbox.close();
-      await rm(hostDir, { recursive: true, force: true });
-      vi.restoreAllMocks();
-    }
-  });
+      const messageSpy = vi
+        .spyOn(clack.log, "message")
+        .mockImplementation(() => {});
+      const stepSpy = vi.spyOn(clack.log, "step").mockImplementation(() => {});
+      const stdoutWriteSpy = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+      vi.spyOn(clack.log, "info").mockImplementation(() => {});
+      vi.spyOn(clack.log, "success").mockImplementation(() => {});
+      vi.spyOn(clack.log, "warning").mockImplementation(() => {});
+      vi.spyOn(clack.log, "error").mockImplementation(() => {});
+
+      const sandbox = await createSandbox({
+        branch: "terminal-streaming-branch",
+        sandbox: testSandbox,
+        cwd: hostDir,
+        _test: {
+          buildSandbox: (sandboxDir) => {
+            const real = makeLocalSandbox(sandboxDir);
+            return {
+              exec: (command, options) => {
+                if (command.startsWith("claude ") && options?.onLine) {
+                  const onLine = options.onLine;
+                  return Effect.sync(() => {
+                    for (const line of [textLine, toolLine, resultLine]) {
+                      onLine(line);
+                    }
+                    return {
+                      stdout: [textLine, toolLine, resultLine].join("\n"),
+                      stderr: "",
+                      exitCode: 0,
+                    };
+                  });
+                }
+                return real.exec(command, options);
+              },
+              copyIn: real.copyIn,
+              copyFileOut: real.copyFileOut,
+            };
+          },
+        },
+      });
+
+      try {
+        await sandbox.run({
+          agent: testProvider,
+          prompt: "do something",
+          maxIterations: 1,
+          logging: verbose
+            ? { type: "stdout", verbose: true }
+            : { type: "stdout" },
+        });
+
+        expect(messageSpy).toHaveBeenCalledWith("streamed agent text");
+        expect(stepSpy).toHaveBeenCalledWith(expect.stringContaining("Bash"));
+        expect(stepSpy).toHaveBeenCalledWith(
+          expect.stringContaining("npm test"),
+        );
+        for (const line of [textLine, toolLine, resultLine]) {
+          if (verbose) {
+            expect(stdoutWriteSpy).toHaveBeenCalledWith(`${line}\n`);
+          } else {
+            expect(stdoutWriteSpy).not.toHaveBeenCalledWith(`${line}\n`);
+          }
+        }
+      } finally {
+        await sandbox.close();
+        await rm(hostDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+      }
+    },
+  );
 
   it("sandbox.run() emits 'Context window: NNNk' line when an iteration has usage", async () => {
     const hostDir = await mkdtemp(join(tmpdir(), "sandbox-test-"));

--- a/src/createSandbox.ts
+++ b/src/createSandbox.ts
@@ -424,7 +424,7 @@ const buildSandboxHandle = (
                 NodeFileSystem.layer,
               );
             })()
-          : silentDisplayLayer;
+          : ClackDisplay.layer;
 
       const reuseFactoryLayer = Layer.succeed(SandboxFactory, {
         withSandbox: (makeEffect) =>


### PR DESCRIPTION
Fixes #966.

## Summary

- render reusable `createSandbox().run()` terminal output through `ClackDisplay`
- keep preliminary prompt-template substitution silent and leave file logging unchanged
- add public-API regression coverage for parsed agent text and tool calls
- add a patch changeset

## Why

`createSandbox().run({ logging: { type: "stdout" } })` currently routes its runtime display through `SilentDisplay`. The agent still runs and its provider stream is parsed, but normal terminal mode hides the parsed text, tool calls, and lifecycle status. Only `verbose: true` appears to work because it writes raw provider JSON directly to stdout.

The sibling top-level `run()` and `createWorktree().run()` paths already use `ClackDisplay` for terminal mode. This change makes the reusable-sandbox path consistent with them while retaining `SilentDisplay` for the separate prompt-substitution step.

## Verification

- `npm run typecheck`
- `npm test` — 1,448 passed, 2 skipped
- `npm run build`
- copied the built `dist` into a real consumer's installed package and ran its reusable-sandbox smoke test in normal stdout mode; agent text, a Bash tool call, a file-read tool call, completion output, and lifecycle statuses all rendered cleanly
