### PR TITLE
fix: forward stdin in isolated sandbox providers

### DIFF
--- a/.changeset/forward-isolated-sandbox-stdin.md
+++ b/.changeset/forward-isolated-sandbox-stdin.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": minor
 ---
 
-Forward agent prompt stdin through temporary files in the Vercel and Daytona isolated sandbox providers instead of silently discarding it. Support Vercel Sandbox SDK 2.x and 3.x filesystem layouts.
+Ensure the Vercel and Daytona sandbox providers deliver prompts supplied over stdin, so stdin-based agents no longer receive empty prompts. The Vercel provider now supports `@vercel/sandbox` 2.x and 3.x; 1.x is excluded because early releases can lose streamed output.

--- a/.changeset/forward-isolated-sandbox-stdin.md
+++ b/.changeset/forward-isolated-sandbox-stdin.md
@@ -2,4 +2,4 @@
 "@ai-hero/sandcastle": minor
 ---
 
-Forward agent prompt stdin through temporary files in the Vercel and Daytona isolated sandbox providers instead of silently discarding it. Support both Vercel Sandbox SDK 2.9 and 3.x filesystem layouts.
+Forward agent prompt stdin through temporary files in the Vercel and Daytona isolated sandbox providers instead of silently discarding it. Support Vercel Sandbox SDK 2.x and 3.x filesystem layouts.

--- a/.changeset/forward-isolated-sandbox-stdin.md
+++ b/.changeset/forward-isolated-sandbox-stdin.md
@@ -1,5 +1,5 @@
 ---
-"@ai-hero/sandcastle": patch
+"@ai-hero/sandcastle": minor
 ---
 
-Forward agent prompt stdin through temporary files in the Vercel and Daytona isolated sandbox providers instead of silently discarding it.
+Forward agent prompt stdin through temporary files in the Vercel and Daytona isolated sandbox providers instead of silently discarding it. Support both Vercel Sandbox SDK 2.9 and 3.x filesystem layouts.

--- a/.changeset/forward-isolated-sandbox-stdin.md
+++ b/.changeset/forward-isolated-sandbox-stdin.md
@@ -1,0 +1,5 @@
+---
+"@ai-hero/sandcastle": patch
+---
+
+Forward agent prompt stdin through temporary files in the Vercel and Daytona isolated sandbox providers instead of silently discarding it.

--- a/docs/adr/0021-support-vercel-sandbox-sdk-2-and-3.md
+++ b/docs/adr/0021-support-vercel-sandbox-sdk-2-and-3.md
@@ -1,0 +1,13 @@
+# Support Vercel Sandbox SDK 2.x and 3.x, but not 1.x
+
+Sandcastle supports `@vercel/sandbox` versions `>=2.0.0 <4`. The Vercel sandbox provider discovers the sandbox's default working directory at runtime because SDK 2.x starts in `/vercel/sandbox` while SDK 3.x starts in `/vercel`; this keeps the provider independent of either filesystem layout.
+
+## Considered options
+
+- **Keep the previous `>=1.0.0` range.** Rejected because real-provider tests found unreliable streaming in early 1.x releases: 1.0.2 lost output from both single and concurrent commands, and 1.1.0 lost output from concurrent commands. Although 1.10.2 passed, there is no documented compatibility boundary within 1.x, and an SDK-specific buffered or serialized fallback would weaken the provider's streaming and concurrency behavior.
+- **Require 2.9.2 or newer.** Rejected because 2.0.0 passed the same real-provider harness, including a 200 KB stdin payload, streaming output, empty stdin, concurrent execution, non-zero exits, and temporary-file cleanup.
+- **Allow 4.x and newer.** Rejected until a future major version is tested because Vercel has already changed its default filesystem layout across major versions.
+
+## Consequences
+
+The optional peer dependency range is narrower than Sandcastle's previous declaration, so this change receives a minor release while Sandcastle is pre-1.0. Supporting a future Vercel SDK major requires verifying the real provider behavior and deliberately widening the range.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       },
       "peerDependencies": {
         "@daytona/sdk": "^0.164.0",
-        "@vercel/sandbox": ">=2.9.2 <4"
+        "@vercel/sandbox": ">=2.0.0 <4"
       },
       "peerDependenciesMeta": {
         "@daytona/sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       },
       "peerDependencies": {
         "@daytona/sdk": "^0.164.0",
-        "@vercel/sandbox": ">=1.0.0"
+        "@vercel/sandbox": ">=2.9.2 <4"
       },
       "peerDependenciesMeta": {
         "@daytona/sdk": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "peerDependencies": {
     "@daytona/sdk": "^0.164.0",
-    "@vercel/sandbox": ">=1.0.0"
+    "@vercel/sandbox": ">=2.9.2 <4"
   },
   "peerDependenciesMeta": {
     "@vercel/sandbox": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "peerDependencies": {
     "@daytona/sdk": "^0.164.0",
-    "@vercel/sandbox": ">=2.9.2 <4"
+    "@vercel/sandbox": ">=2.0.0 <4"
   },
   "peerDependenciesMeta": {
     "@vercel/sandbox": {

--- a/src/sandboxes/daytona.test.ts
+++ b/src/sandboxes/daytona.test.ts
@@ -49,7 +49,7 @@ describe("daytona()", () => {
     );
     expect(executeCommand).toHaveBeenNthCalledWith(
       1,
-      `chmod 600 '${path}' && exec sh -c 'claude --print -p -' < '${path}'`,
+      `chmod 600 '${path}' && sh -c 'claude --print -p -' < '${path}'`,
       "/home/daytona/workspace",
     );
     expect(executeCommand).toHaveBeenNthCalledWith(
@@ -94,7 +94,7 @@ describe("daytona()", () => {
 
     const stdinPath = uploadFile.mock.calls[0]![1];
     expect(executeSessionCommand).toHaveBeenCalledWith(expect.any(String), {
-      command: `cd /home/daytona/workspace && chmod 600 '${stdinPath}' && exec sh -c 'claude --model '\\''claude-opus'\\'' --print -p -' < '${stdinPath}'`,
+      command: `cd /home/daytona/workspace && chmod 600 '${stdinPath}' && sh -c 'claude --model '\\''claude-opus'\\'' --print -p -' < '${stdinPath}'`,
       async: true,
     });
     expect(deleteSession).toHaveBeenCalledOnce();

--- a/src/sandboxes/daytona.test.ts
+++ b/src/sandboxes/daytona.test.ts
@@ -52,11 +52,7 @@ describe("daytona()", () => {
       `chmod 600 '${path}' && sh -c 'claude --print -p -' < '${path}'`,
       "/home/daytona/workspace",
     );
-    expect(executeCommand).toHaveBeenNthCalledWith(
-      2,
-      `rm -f -- '${path}'`,
-      "/home/daytona/workspace",
-    );
+    expect(executeCommand).toHaveBeenNthCalledWith(2, `rm -f -- '${path}'`);
     expect(result).toEqual({
       stdout: "agent output",
       stderr: "",
@@ -98,9 +94,38 @@ describe("daytona()", () => {
       async: true,
     });
     expect(deleteSession).toHaveBeenCalledOnce();
-    expect(executeCommand).toHaveBeenCalledWith(
-      `rm -f -- '${stdinPath}'`,
-      "/home/daytona/workspace",
-    );
+    expect(executeCommand).toHaveBeenCalledWith(`rm -f -- '${stdinPath}'`);
+  });
+
+  it("cleans up stdin when the requested working directory is invalid", async () => {
+    const uploadedFiles = new Set<string>();
+    const invalidCwd = "/missing/worktree";
+    const executeCommand = vi.fn(async (command: string, cwd?: string) => {
+      if (cwd === invalidCwd) {
+        return { result: "", exitCode: 1 };
+      }
+
+      const removedPath = command.match(/^rm -f -- '([^']+)'$/)?.[1];
+      if (removedPath) uploadedFiles.delete(removedPath);
+      return { result: "", exitCode: 0 };
+    });
+    const uploadFile = vi.fn(async (_content: Buffer, path: string) => {
+      uploadedFiles.add(path);
+    });
+    sdk.create.mockResolvedValue({
+      getWorkDir: vi.fn(async () => "/home/daytona/workspace"),
+      getUserHomeDir: vi.fn(async () => "/home/daytona"),
+      process: { executeCommand },
+      fs: { uploadFile },
+    });
+
+    const handle = await daytona().create({ env: {} });
+    const result = await handle.exec("agent --prompt -", {
+      cwd: invalidCwd,
+      stdin: "prompt",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(uploadedFiles).toEqual(new Set());
   });
 });

--- a/src/sandboxes/daytona.test.ts
+++ b/src/sandboxes/daytona.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const sdk = vi.hoisted(() => ({
+  create: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock("@daytona/sdk", () => ({
+  Daytona: class {
+    create = sdk.create;
+    delete = sdk.delete;
+  },
+}));
+
+import { daytona } from "./daytona.js";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("daytona()", () => {
+  it("delivers exec stdin through a temporary sandbox file", async () => {
+    const executeCommand = vi
+      .fn()
+      .mockResolvedValueOnce({
+        result: "agent output",
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({ result: "", exitCode: 0 });
+    const uploadFile = vi.fn(
+      async (_content: Buffer, _path: string): Promise<void> => {},
+    );
+    sdk.create.mockResolvedValue({
+      getWorkDir: vi.fn(async () => "/home/daytona/workspace"),
+      getUserHomeDir: vi.fn(async () => "/home/daytona"),
+      process: { executeCommand },
+      fs: { uploadFile },
+    });
+
+    const handle = await daytona().create({ env: {} });
+    const result = await handle.exec("claude --print -p -", {
+      stdin: "prompt with 'quotes'\nand a trailing newline\n",
+    });
+
+    const [content, path] = uploadFile.mock.calls[0]!;
+    expect(path).toMatch(/^\/tmp\/sandcastle-stdin-[\da-f-]+$/);
+    expect(content.toString()).toBe(
+      "prompt with 'quotes'\nand a trailing newline\n",
+    );
+    expect(executeCommand).toHaveBeenNthCalledWith(
+      1,
+      `chmod 600 '${path}' && exec sh -c 'claude --print -p -' < '${path}'`,
+      "/home/daytona/workspace",
+    );
+    expect(executeCommand).toHaveBeenNthCalledWith(
+      2,
+      `rm -f -- '${path}'`,
+      "/home/daytona/workspace",
+    );
+    expect(result).toEqual({
+      stdout: "agent output",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("delivers stdin while streaming output and cleans up after failure", async () => {
+    const executionError = new Error("remote command failed");
+    const executeSessionCommand = vi.fn().mockRejectedValue(executionError);
+    const deleteSession = vi.fn(async () => {});
+    const executeCommand = vi.fn(async () => ({ result: "", exitCode: 0 }));
+    const uploadFile = vi.fn(
+      async (_content: Buffer, _path: string): Promise<void> => {},
+    );
+    sdk.create.mockResolvedValue({
+      getWorkDir: vi.fn(async () => "/home/daytona/workspace"),
+      getUserHomeDir: vi.fn(async () => "/home/daytona"),
+      process: {
+        createSession: vi.fn(async () => {}),
+        executeSessionCommand,
+        deleteSession,
+        executeCommand,
+      },
+      fs: { uploadFile },
+    });
+
+    const handle = await daytona().create({ env: {} });
+    await expect(
+      handle.exec("claude --model 'claude-opus' --print -p -", {
+        stdin: "prompt",
+        onLine: vi.fn(),
+      }),
+    ).rejects.toBe(executionError);
+
+    const stdinPath = uploadFile.mock.calls[0]![1];
+    expect(executeSessionCommand).toHaveBeenCalledWith(expect.any(String), {
+      command: `cd /home/daytona/workspace && chmod 600 '${stdinPath}' && exec sh -c 'claude --model '\\''claude-opus'\\'' --print -p -' < '${stdinPath}'`,
+      async: true,
+    });
+    expect(deleteSession).toHaveBeenCalledOnce();
+    expect(executeCommand).toHaveBeenCalledWith(
+      `rm -f -- '${stdinPath}'`,
+      "/home/daytona/workspace",
+    );
+  });
+});

--- a/src/sandboxes/daytona.ts
+++ b/src/sandboxes/daytona.ts
@@ -15,9 +15,9 @@ import {
 } from "../SandboxProvider.js";
 import { BoundedTail, MAX_TAIL_CHARS } from "../boundedTail.js";
 import {
-  createStdinFilePath,
   redirectCommandStdinFromFile,
   removeStdinFileCommand,
+  withStdinFile,
 } from "./stdin-file.js";
 
 import type {
@@ -52,8 +52,7 @@ export interface DaytonaOptions {
    * Supports both image-based and snapshot-based creation.
    */
   readonly create?:
-    | CreateSandboxFromImageParams
-    | CreateSandboxFromSnapshotParams;
+    CreateSandboxFromImageParams | CreateSandboxFromSnapshotParams;
 
   /** Environment variables injected by this provider. Merged at launch time with env resolver and agent provider env. */
   readonly env?: Record<string, string>;
@@ -118,90 +117,91 @@ export const daytona = (options?: DaytonaOptions): IsolatedSandboxProvider =>
         ): Promise<ExecResult> => {
           const effectiveCommand = opts?.sudo ? `sudo ${command}` : command;
           const stdin = opts?.stdin;
-          const stdinPath =
-            stdin !== undefined ? createStdinFilePath() : undefined;
           const cwd = opts?.cwd ?? worktreePath;
 
-          try {
-            if (stdinPath !== undefined && stdin !== undefined) {
-              await sandbox.fs.uploadFile(Buffer.from(stdin), stdinPath);
-            }
-
-            const commandToRun = stdinPath
-              ? redirectCommandStdinFromFile(effectiveCommand, stdinPath)
-              : effectiveCommand;
-
-            if (opts?.onLine) {
-              const onLine = opts.onLine;
-              const sessionId = `sandcastle-${crypto.randomUUID()}`;
-              await sandbox.process.createSession(sessionId);
-
-              try {
-                const execResponse =
-                  await sandbox.process.executeSessionCommand(sessionId, {
-                    command: `cd ${cwd} && ${commandToRun}`,
-                    async: true,
-                  });
-
-                const cmdId = execResponse.cmdId!;
-
-                const stdoutTail = new BoundedTail(maxOutputTailChars, "\n");
-                const stderrTail = new BoundedTail(maxOutputTailChars, "");
-                let partial = "";
-
-                await sandbox.process.getSessionCommandLogs(
-                  sessionId,
-                  cmdId,
-                  (chunk: string) => {
-                    const text = partial + chunk;
-                    const lines = text.split("\n");
-                    partial = lines.pop() ?? "";
-                    for (const line of lines) {
-                      stdoutTail.push(line);
-                      onLine(line);
-                    }
-                  },
-                  (chunk: string) => {
-                    stderrTail.push(chunk);
-                  },
+          return withStdinFile(
+            stdin,
+            {
+              upload: (path, content) => sandbox.fs.uploadFile(content, path),
+              remove: async (path) => {
+                await sandbox.process.executeCommand(
+                  removeStdinFileCommand(path),
                 );
+              },
+            },
+            async (stdinPath) => {
+              const commandToRun = stdinPath
+                ? redirectCommandStdinFromFile(effectiveCommand, stdinPath)
+                : effectiveCommand;
 
-                if (partial) {
-                  stdoutTail.push(partial);
-                  onLine(partial);
+              if (opts?.onLine) {
+                const onLine = opts.onLine;
+                const sessionId = `sandcastle-${crypto.randomUUID()}`;
+                await sandbox.process.createSession(sessionId);
+
+                try {
+                  const execResponse =
+                    await sandbox.process.executeSessionCommand(sessionId, {
+                      command: `cd ${cwd} && ${commandToRun}`,
+                      async: true,
+                    });
+
+                  const cmdId = execResponse.cmdId!;
+
+                  const stdoutTail = new BoundedTail(maxOutputTailChars, "\n");
+                  const stderrTail = new BoundedTail(maxOutputTailChars, "");
+                  let partial = "";
+
+                  await sandbox.process.getSessionCommandLogs(
+                    sessionId,
+                    cmdId,
+                    (chunk: string) => {
+                      const text = partial + chunk;
+                      const lines = text.split("\n");
+                      partial = lines.pop() ?? "";
+                      for (const line of lines) {
+                        stdoutTail.push(line);
+                        onLine(line);
+                      }
+                    },
+                    (chunk: string) => {
+                      stderrTail.push(chunk);
+                    },
+                  );
+
+                  if (partial) {
+                    stdoutTail.push(partial);
+                    onLine(partial);
+                  }
+
+                  const cmdInfo = await sandbox.process.getSessionCommand(
+                    sessionId,
+                    cmdId,
+                  );
+
+                  return {
+                    stdout: stdoutTail.toString(),
+                    stderr: stderrTail.toString(),
+                    exitCode: cmdInfo.exitCode ?? 0,
+                  };
+                } finally {
+                  await sandbox.process
+                    .deleteSession(sessionId)
+                    .catch(() => {});
                 }
-
-                const cmdInfo = await sandbox.process.getSessionCommand(
-                  sessionId,
-                  cmdId,
-                );
-
-                return {
-                  stdout: stdoutTail.toString(),
-                  stderr: stderrTail.toString(),
-                  exitCode: cmdInfo.exitCode ?? 0,
-                };
-              } finally {
-                await sandbox.process.deleteSession(sessionId).catch(() => {});
               }
-            }
 
-            const response = await sandbox.process.executeCommand(
-              commandToRun,
-              cwd,
-            );
-            return {
-              stdout: response.result,
-              stderr: "",
-              exitCode: response.exitCode,
-            };
-          } finally {
-            if (stdinPath !== undefined) {
-              await sandbox.process
-                .executeCommand(removeStdinFileCommand(stdinPath), cwd)
-                .catch(() => {});
-            }
-          }
+              const response = await sandbox.process.executeCommand(
+                commandToRun,
+                cwd,
+              );
+              return {
+                stdout: response.result,
+                stderr: "",
+                exitCode: response.exitCode,
+              };
+            },
+          );
         },
 
         copyIn: async (

--- a/src/sandboxes/daytona.ts
+++ b/src/sandboxes/daytona.ts
@@ -14,6 +14,11 @@ import {
   type IsolatedSandboxProvider,
 } from "../SandboxProvider.js";
 import { BoundedTail, MAX_TAIL_CHARS } from "../boundedTail.js";
+import {
+  createStdinFilePath,
+  redirectCommandStdinFromFile,
+  removeStdinFileCommand,
+} from "./stdin-file.js";
 
 import type {
   Daytona as DaytonaClient,
@@ -108,75 +113,95 @@ export const daytona = (options?: DaytonaOptions): IsolatedSandboxProvider =>
             onLine?: (line: string) => void;
             cwd?: string;
             sudo?: boolean;
+            stdin?: string;
           },
         ): Promise<ExecResult> => {
           const effectiveCommand = opts?.sudo ? `sudo ${command}` : command;
-          if (opts?.onLine) {
-            const onLine = opts.onLine;
-            const sessionId = `sandcastle-${crypto.randomUUID()}`;
-            await sandbox.process.createSession(sessionId);
+          const stdin = opts?.stdin;
+          const stdinPath =
+            stdin !== undefined ? createStdinFilePath() : undefined;
+          const cwd = opts?.cwd ?? worktreePath;
 
-            try {
-              const execResponse = await sandbox.process.executeSessionCommand(
-                sessionId,
-                {
-                  command: `cd ${opts?.cwd ?? worktreePath} && ${effectiveCommand}`,
-                  async: true,
-                },
-              );
+          try {
+            if (stdinPath !== undefined && stdin !== undefined) {
+              await sandbox.fs.uploadFile(Buffer.from(stdin), stdinPath);
+            }
 
-              const cmdId = execResponse.cmdId!;
+            const commandToRun = stdinPath
+              ? redirectCommandStdinFromFile(effectiveCommand, stdinPath)
+              : effectiveCommand;
 
-              const stdoutTail = new BoundedTail(maxOutputTailChars, "\n");
-              const stderrTail = new BoundedTail(maxOutputTailChars, "");
-              let partial = "";
+            if (opts?.onLine) {
+              const onLine = opts.onLine;
+              const sessionId = `sandcastle-${crypto.randomUUID()}`;
+              await sandbox.process.createSession(sessionId);
 
-              await sandbox.process.getSessionCommandLogs(
-                sessionId,
-                cmdId,
-                (chunk: string) => {
-                  const text = partial + chunk;
-                  const lines = text.split("\n");
-                  partial = lines.pop() ?? "";
-                  for (const line of lines) {
-                    stdoutTail.push(line);
-                    onLine(line);
-                  }
-                },
-                (chunk: string) => {
-                  stderrTail.push(chunk);
-                },
-              );
+              try {
+                const execResponse =
+                  await sandbox.process.executeSessionCommand(sessionId, {
+                    command: `cd ${cwd} && ${commandToRun}`,
+                    async: true,
+                  });
 
-              if (partial) {
-                stdoutTail.push(partial);
-                onLine(partial);
+                const cmdId = execResponse.cmdId!;
+
+                const stdoutTail = new BoundedTail(maxOutputTailChars, "\n");
+                const stderrTail = new BoundedTail(maxOutputTailChars, "");
+                let partial = "";
+
+                await sandbox.process.getSessionCommandLogs(
+                  sessionId,
+                  cmdId,
+                  (chunk: string) => {
+                    const text = partial + chunk;
+                    const lines = text.split("\n");
+                    partial = lines.pop() ?? "";
+                    for (const line of lines) {
+                      stdoutTail.push(line);
+                      onLine(line);
+                    }
+                  },
+                  (chunk: string) => {
+                    stderrTail.push(chunk);
+                  },
+                );
+
+                if (partial) {
+                  stdoutTail.push(partial);
+                  onLine(partial);
+                }
+
+                const cmdInfo = await sandbox.process.getSessionCommand(
+                  sessionId,
+                  cmdId,
+                );
+
+                return {
+                  stdout: stdoutTail.toString(),
+                  stderr: stderrTail.toString(),
+                  exitCode: cmdInfo.exitCode ?? 0,
+                };
+              } finally {
+                await sandbox.process.deleteSession(sessionId).catch(() => {});
               }
+            }
 
-              const cmdInfo = await sandbox.process.getSessionCommand(
-                sessionId,
-                cmdId,
-              );
-
-              return {
-                stdout: stdoutTail.toString(),
-                stderr: stderrTail.toString(),
-                exitCode: cmdInfo.exitCode ?? 0,
-              };
-            } finally {
-              await sandbox.process.deleteSession(sessionId).catch(() => {});
+            const response = await sandbox.process.executeCommand(
+              commandToRun,
+              cwd,
+            );
+            return {
+              stdout: response.result,
+              stderr: "",
+              exitCode: response.exitCode,
+            };
+          } finally {
+            if (stdinPath !== undefined) {
+              await sandbox.process
+                .executeCommand(removeStdinFileCommand(stdinPath), cwd)
+                .catch(() => {});
             }
           }
-
-          const response = await sandbox.process.executeCommand(
-            effectiveCommand,
-            opts?.cwd ?? worktreePath,
-          );
-          return {
-            stdout: response.result,
-            stderr: "",
-            exitCode: response.exitCode,
-          };
         },
 
         copyIn: async (

--- a/src/sandboxes/stdin-file.ts
+++ b/src/sandboxes/stdin-file.ts
@@ -1,0 +1,16 @@
+import { randomUUID } from "node:crypto";
+
+export const createStdinFilePath = (): string =>
+  `/tmp/sandcastle-stdin-${randomUUID()}`;
+
+const shellEscape = (value: string): string =>
+  `'${value.replace(/'/g, `'\\''`)}'`;
+
+export const redirectCommandStdinFromFile = (
+  command: string,
+  stdinPath: string,
+): string =>
+  `chmod 600 ${shellEscape(stdinPath)} && exec sh -c ${shellEscape(command)} < ${shellEscape(stdinPath)}`;
+
+export const removeStdinFileCommand = (stdinPath: string): string =>
+  `rm -f -- ${shellEscape(stdinPath)}`;

--- a/src/sandboxes/stdin-file.ts
+++ b/src/sandboxes/stdin-file.ts
@@ -3,6 +3,27 @@ import { randomUUID } from "node:crypto";
 export const createStdinFilePath = (): string =>
   `/tmp/sandcastle-stdin-${randomUUID()}`;
 
+interface StdinFileOperations {
+  readonly upload: (path: string, content: Buffer) => Promise<void>;
+  readonly remove: (path: string) => Promise<void>;
+}
+
+export const withStdinFile = async <T>(
+  stdin: string | undefined,
+  operations: StdinFileOperations,
+  run: (stdinPath: string | undefined) => Promise<T>,
+): Promise<T> => {
+  if (stdin === undefined) return run(undefined);
+
+  const stdinPath = createStdinFilePath();
+  try {
+    await operations.upload(stdinPath, Buffer.from(stdin));
+    return await run(stdinPath);
+  } finally {
+    await operations.remove(stdinPath).catch(() => {});
+  }
+};
+
 const shellEscape = (value: string): string =>
   `'${value.replace(/'/g, `'\\''`)}'`;
 

--- a/src/sandboxes/stdin-file.ts
+++ b/src/sandboxes/stdin-file.ts
@@ -10,7 +10,7 @@ export const redirectCommandStdinFromFile = (
   command: string,
   stdinPath: string,
 ): string =>
-  `chmod 600 ${shellEscape(stdinPath)} && exec sh -c ${shellEscape(command)} < ${shellEscape(stdinPath)}`;
+  `chmod 600 ${shellEscape(stdinPath)} && sh -c ${shellEscape(command)} < ${shellEscape(stdinPath)}`;
 
 export const removeStdinFileCommand = (stdinPath: string): string =>
   `rm -f -- ${shellEscape(stdinPath)}`;

--- a/src/sandboxes/vercel.test.ts
+++ b/src/sandboxes/vercel.test.ts
@@ -77,7 +77,7 @@ describe("vercel()", () => {
       cmd: "sh",
       args: [
         "-c",
-        `chmod 600 '${path}' && exec sh -c 'claude --print -p -' < '${path}'`,
+        `chmod 600 '${path}' && sh -c 'claude --print -p -' < '${path}'`,
       ],
       cwd: "/vercel/sandbox/workspace",
     });
@@ -130,7 +130,7 @@ describe("vercel()", () => {
         cmd: "sh",
         args: [
           "-c",
-          `chmod 600 '${stdinPath}' && exec sh -c 'claude --model '\\''claude-opus'\\'' --print -p -' < '${stdinPath}'`,
+          `chmod 600 '${stdinPath}' && sh -c 'claude --model '\\''claude-opus'\\'' --print -p -' < '${stdinPath}'`,
         ],
       }),
     );

--- a/src/sandboxes/vercel.test.ts
+++ b/src/sandboxes/vercel.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setVercelSandboxCreate } from "../test-fixtures/vercel-sandbox.js";
 import { vercel } from "./vercel.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("vercel()", () => {
   it("returns a SandboxProvider with tag 'isolated' and name 'vercel'", () => {
@@ -37,5 +42,101 @@ describe("vercel()", () => {
   it("defaults env to empty object when not provided", () => {
     const provider = vercel();
     expect(provider.env).toEqual({});
+  });
+
+  it("delivers exec stdin through a temporary sandbox file", async () => {
+    const runCommand = vi.fn(async (options: { cmd: string }) => ({
+      exitCode: 0,
+      stdout: async () => (options.cmd === "rm" ? "" : "agent output"),
+      stderr: async () => "",
+    }));
+    const writeFiles = vi.fn(
+      async (
+        _files: Array<{ path: string; content: string | Buffer }>,
+      ): Promise<void> => {},
+    );
+    setVercelSandboxCreate(async () => ({
+      mkDir: vi.fn(async () => {}),
+      runCommand,
+      writeFiles,
+      readFileToBuffer: vi.fn(),
+      stop: vi.fn(async () => {}),
+    }));
+
+    const handle = await vercel().create({ env: {} });
+    const result = await handle.exec("claude --print -p -", {
+      stdin: "prompt with 'quotes'\nand a trailing newline\n",
+    });
+
+    const { path, content } = writeFiles.mock.calls[0]![0]![0]!;
+    expect(path).toMatch(/^\/tmp\/sandcastle-stdin-[\da-f-]+$/);
+    expect(content.toString()).toBe(
+      "prompt with 'quotes'\nand a trailing newline\n",
+    );
+    expect(runCommand).toHaveBeenNthCalledWith(1, {
+      cmd: "sh",
+      args: [
+        "-c",
+        `chmod 600 '${path}' && exec sh -c 'claude --print -p -' < '${path}'`,
+      ],
+      cwd: "/vercel/sandbox/workspace",
+    });
+    expect(runCommand).toHaveBeenNthCalledWith(2, {
+      cmd: "rm",
+      args: ["-f", "--", path],
+    });
+    expect(result).toEqual({
+      stdout: "agent output",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("delivers stdin while streaming output and cleans up after failure", async () => {
+    const executionError = new Error("remote command failed");
+    const runCommand = vi
+      .fn()
+      .mockRejectedValueOnce(executionError)
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: async () => "",
+        stderr: async () => "",
+      });
+    const writeFiles = vi.fn(
+      async (
+        _files: Array<{ path: string; content: string | Buffer }>,
+      ): Promise<void> => {},
+    );
+    setVercelSandboxCreate(async () => ({
+      mkDir: vi.fn(async () => {}),
+      runCommand,
+      writeFiles,
+      readFileToBuffer: vi.fn(),
+      stop: vi.fn(async () => {}),
+    }));
+
+    const handle = await vercel().create({ env: {} });
+    await expect(
+      handle.exec("claude --model 'claude-opus' --print -p -", {
+        stdin: "prompt",
+        onLine: vi.fn(),
+      }),
+    ).rejects.toBe(executionError);
+
+    const stdinPath = writeFiles.mock.calls[0]![0]![0]!.path;
+    expect(runCommand).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        cmd: "sh",
+        args: [
+          "-c",
+          `chmod 600 '${stdinPath}' && exec sh -c 'claude --model '\\''claude-opus'\\'' --print -p -' < '${stdinPath}'`,
+        ],
+      }),
+    );
+    expect(runCommand).toHaveBeenNthCalledWith(2, {
+      cmd: "rm",
+      args: ["-f", "--", stdinPath],
+    });
   });
 });

--- a/src/sandboxes/vercel.test.ts
+++ b/src/sandboxes/vercel.test.ts
@@ -18,6 +18,36 @@ describe("vercel()", () => {
     expect(typeof provider.create).toBe("function");
   });
 
+  it.each([
+    ["2.9", "/vercel/sandbox", "/vercel/sandbox/workspace"],
+    ["3.2", "/vercel", "/vercel/workspace"],
+  ])(
+    "discovers the worktree path for Vercel SDK %s",
+    async (_version, defaultCwd, expectedWorktreePath) => {
+      const runCommand = vi.fn(async (options: { cmd: string }) => ({
+        exitCode: 0,
+        stdout: async () => (options.cmd === "pwd" ? `${defaultCwd}\n` : ""),
+        stderr: async () => "",
+      }));
+      setVercelSandboxCreate(async () => ({
+        mkDir: vi.fn(async () => {}),
+        runCommand,
+        writeFiles: vi.fn(async () => {}),
+        readFileToBuffer: vi.fn(),
+        stop: vi.fn(async () => {}),
+      }));
+
+      const handle = await vercel().create({ env: {} });
+
+      expect(handle.worktreePath).toBe(expectedWorktreePath);
+      expect(runCommand).toHaveBeenNthCalledWith(1, { cmd: "pwd" });
+      expect(runCommand).toHaveBeenNthCalledWith(2, {
+        cmd: "mkdir",
+        args: ["-p", expectedWorktreePath],
+      });
+    },
+  );
+
   it("accepts a token option", () => {
     // Should not throw
     const provider = vercel({ token: "my-token" });
@@ -47,7 +77,12 @@ describe("vercel()", () => {
   it("delivers exec stdin through a temporary sandbox file", async () => {
     const runCommand = vi.fn(async (options: { cmd: string }) => ({
       exitCode: 0,
-      stdout: async () => (options.cmd === "rm" ? "" : "agent output"),
+      stdout: async () =>
+        options.cmd === "pwd"
+          ? "/vercel/sandbox\n"
+          : options.cmd === "sh"
+            ? "agent output"
+            : "",
       stderr: async () => "",
     }));
     const writeFiles = vi.fn(
@@ -73,7 +108,7 @@ describe("vercel()", () => {
     expect(content.toString()).toBe(
       "prompt with 'quotes'\nand a trailing newline\n",
     );
-    expect(runCommand).toHaveBeenNthCalledWith(1, {
+    expect(runCommand).toHaveBeenNthCalledWith(3, {
       cmd: "sh",
       args: [
         "-c",
@@ -81,7 +116,7 @@ describe("vercel()", () => {
       ],
       cwd: "/vercel/sandbox/workspace",
     });
-    expect(runCommand).toHaveBeenNthCalledWith(2, {
+    expect(runCommand).toHaveBeenNthCalledWith(4, {
       cmd: "rm",
       args: ["-f", "--", path],
     });
@@ -94,14 +129,14 @@ describe("vercel()", () => {
 
   it("delivers stdin while streaming output and cleans up after failure", async () => {
     const executionError = new Error("remote command failed");
-    const runCommand = vi
-      .fn()
-      .mockRejectedValueOnce(executionError)
-      .mockResolvedValueOnce({
+    const runCommand = vi.fn(async (options: { cmd: string }) => {
+      if (options.cmd === "sh") throw executionError;
+      return {
         exitCode: 0,
-        stdout: async () => "",
+        stdout: async () => (options.cmd === "pwd" ? "/vercel/sandbox\n" : ""),
         stderr: async () => "",
-      });
+      };
+    });
     const writeFiles = vi.fn(
       async (
         _files: Array<{ path: string; content: string | Buffer }>,
@@ -125,7 +160,7 @@ describe("vercel()", () => {
 
     const stdinPath = writeFiles.mock.calls[0]![0]![0]!.path;
     expect(runCommand).toHaveBeenNthCalledWith(
-      1,
+      3,
       expect.objectContaining({
         cmd: "sh",
         args: [
@@ -134,7 +169,7 @@ describe("vercel()", () => {
         ],
       }),
     );
-    expect(runCommand).toHaveBeenNthCalledWith(2, {
+    expect(runCommand).toHaveBeenNthCalledWith(4, {
       cmd: "rm",
       args: ["-f", "--", stdinPath],
     });

--- a/src/sandboxes/vercel.test.ts
+++ b/src/sandboxes/vercel.test.ts
@@ -2,6 +2,28 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { setVercelSandboxCreate } from "../test-fixtures/vercel-sandbox.js";
 import { vercel } from "./vercel.js";
 
+type RunCommand = (options: { cmd: string }) => Promise<{
+  exitCode: number;
+  stdout: () => Promise<string>;
+  stderr: () => Promise<string>;
+}>;
+
+type WriteFiles = (
+  files: Array<{ path: string; content: string | Buffer }>,
+) => Promise<void>;
+
+const configureVercelSandbox = (
+  runCommand: RunCommand,
+  writeFiles: WriteFiles = vi.fn(async () => {}),
+): void => {
+  setVercelSandboxCreate(async () => ({
+    runCommand,
+    writeFiles,
+    readFileToBuffer: vi.fn(),
+    stop: vi.fn(async () => {}),
+  }));
+};
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -29,13 +51,7 @@ describe("vercel()", () => {
         stdout: async () => (options.cmd === "pwd" ? `${defaultCwd}\n` : ""),
         stderr: async () => "",
       }));
-      setVercelSandboxCreate(async () => ({
-        mkDir: vi.fn(async () => {}),
-        runCommand,
-        writeFiles: vi.fn(async () => {}),
-        readFileToBuffer: vi.fn(),
-        stop: vi.fn(async () => {}),
-      }));
+      configureVercelSandbox(runCommand);
 
       const handle = await vercel().create({ env: {} });
 
@@ -90,13 +106,7 @@ describe("vercel()", () => {
         _files: Array<{ path: string; content: string | Buffer }>,
       ): Promise<void> => {},
     );
-    setVercelSandboxCreate(async () => ({
-      mkDir: vi.fn(async () => {}),
-      runCommand,
-      writeFiles,
-      readFileToBuffer: vi.fn(),
-      stop: vi.fn(async () => {}),
-    }));
+    configureVercelSandbox(runCommand, writeFiles);
 
     const handle = await vercel().create({ env: {} });
     const result = await handle.exec("claude --print -p -", {
@@ -142,13 +152,7 @@ describe("vercel()", () => {
         _files: Array<{ path: string; content: string | Buffer }>,
       ): Promise<void> => {},
     );
-    setVercelSandboxCreate(async () => ({
-      mkDir: vi.fn(async () => {}),
-      runCommand,
-      writeFiles,
-      readFileToBuffer: vi.fn(),
-      stop: vi.fn(async () => {}),
-    }));
+    configureVercelSandbox(runCommand, writeFiles);
 
     const handle = await vercel().create({ env: {} });
     await expect(

--- a/src/sandboxes/vercel.ts
+++ b/src/sandboxes/vercel.ts
@@ -18,6 +18,10 @@ import {
   type IsolatedSandboxProvider,
 } from "../SandboxProvider.js";
 import { BoundedTail, MAX_TAIL_CHARS } from "../boundedTail.js";
+import {
+  createStdinFilePath,
+  redirectCommandStdinFromFile,
+} from "./stdin-file.js";
 
 /** Worktree path inside the Vercel sandbox. */
 const VERCEL_REPO_PATH = "/vercel/sandbox/workspace";
@@ -180,73 +184,99 @@ export const vercel = (options?: VercelOptions): IsolatedSandboxProvider =>
             onLine?: (line: string) => void;
             cwd?: string;
             sudo?: boolean;
+            stdin?: string;
           },
         ): Promise<ExecResult> => {
-          if (opts?.onLine) {
-            const onLine = opts.onLine;
-            const stdoutTail = new BoundedTail(maxOutputTailChars, "\n");
-            const stderrTail = new BoundedTail(maxOutputTailChars, "");
-            let partial = "";
+          const stdin = opts?.stdin;
+          const stdinPath =
+            stdin !== undefined ? createStdinFilePath() : undefined;
 
-            const stdoutWritable = new Writable({
-              write(chunk, _encoding, callback) {
-                const text = partial + chunk.toString();
-                const lines = text.split("\n");
-                partial = lines.pop() ?? "";
-                for (const line of lines) {
-                  stdoutTail.push(line);
-                  onLine(line);
-                }
-                callback();
-              },
-              final(callback) {
-                if (partial) {
-                  stdoutTail.push(partial);
-                  onLine(partial);
-                  partial = "";
-                }
-                callback();
-              },
-            });
+          try {
+            if (stdinPath !== undefined && stdin !== undefined) {
+              await sandbox.writeFiles([
+                { path: stdinPath, content: Buffer.from(stdin) },
+              ]);
+            }
 
-            const stderrWritable = new Writable({
-              write(chunk, _encoding, callback) {
-                stderrTail.push(chunk.toString());
-                callback();
-              },
-            });
+            const commandToRun = stdinPath
+              ? redirectCommandStdinFromFile(command, stdinPath)
+              : command;
+
+            if (opts?.onLine) {
+              const onLine = opts.onLine;
+              const stdoutTail = new BoundedTail(maxOutputTailChars, "\n");
+              const stderrTail = new BoundedTail(maxOutputTailChars, "");
+              let partial = "";
+
+              const stdoutWritable = new Writable({
+                write(chunk, _encoding, callback) {
+                  const text = partial + chunk.toString();
+                  const lines = text.split("\n");
+                  partial = lines.pop() ?? "";
+                  for (const line of lines) {
+                    stdoutTail.push(line);
+                    onLine(line);
+                  }
+                  callback();
+                },
+                final(callback) {
+                  if (partial) {
+                    stdoutTail.push(partial);
+                    onLine(partial);
+                    partial = "";
+                  }
+                  callback();
+                },
+              });
+
+              const stderrWritable = new Writable({
+                write(chunk, _encoding, callback) {
+                  stderrTail.push(chunk.toString());
+                  callback();
+                },
+              });
+
+              const result = await sandbox.runCommand({
+                cmd: "sh",
+                args: ["-c", commandToRun],
+                cwd: opts?.cwd ?? VERCEL_REPO_PATH,
+                stdout: stdoutWritable,
+                stderr: stderrWritable,
+                ...(opts?.sudo ? { sudo: true } : {}),
+              });
+
+              return {
+                stdout: stdoutTail.toString(),
+                stderr: stderrTail.toString(),
+                exitCode: result.exitCode,
+              };
+            }
 
             const result = await sandbox.runCommand({
               cmd: "sh",
-              args: ["-c", command],
+              args: ["-c", commandToRun],
               cwd: opts?.cwd ?? VERCEL_REPO_PATH,
-              stdout: stdoutWritable,
-              stderr: stderrWritable,
               ...(opts?.sudo ? { sudo: true } : {}),
             });
 
+            const stdout = await result.stdout();
+            const stderr = await result.stderr();
+
             return {
-              stdout: stdoutTail.toString(),
-              stderr: stderrTail.toString(),
+              stdout,
+              stderr,
               exitCode: result.exitCode,
             };
+          } finally {
+            if (stdinPath !== undefined) {
+              await sandbox
+                .runCommand({
+                  cmd: "rm",
+                  args: ["-f", "--", stdinPath],
+                })
+                .catch(() => {});
+            }
           }
-
-          const result = await sandbox.runCommand({
-            cmd: "sh",
-            args: ["-c", command],
-            cwd: opts?.cwd ?? VERCEL_REPO_PATH,
-            ...(opts?.sudo ? { sudo: true } : {}),
-          });
-
-          const stdout = await result.stdout();
-          const stderr = await result.stderr();
-
-          return {
-            stdout,
-            stderr,
-            exitCode: result.exitCode,
-          };
         },
 
         copyIn: async (

--- a/src/sandboxes/vercel.ts
+++ b/src/sandboxes/vercel.ts
@@ -18,10 +18,7 @@ import {
   type IsolatedSandboxProvider,
 } from "../SandboxProvider.js";
 import { BoundedTail, MAX_TAIL_CHARS } from "../boundedTail.js";
-import {
-  createStdinFilePath,
-  redirectCommandStdinFromFile,
-} from "./stdin-file.js";
+import { redirectCommandStdinFromFile, withStdinFile } from "./stdin-file.js";
 
 /** Worktree directory inside the Vercel sandbox's default working directory. */
 const VERCEL_WORKTREE_DIR = "workspace";
@@ -213,95 +210,91 @@ export const vercel = (options?: VercelOptions): IsolatedSandboxProvider =>
           },
         ): Promise<ExecResult> => {
           const stdin = opts?.stdin;
-          const stdinPath =
-            stdin !== undefined ? createStdinFilePath() : undefined;
 
-          try {
-            if (stdinPath !== undefined && stdin !== undefined) {
-              await sandbox.writeFiles([
-                { path: stdinPath, content: Buffer.from(stdin) },
-              ]);
-            }
+          return withStdinFile(
+            stdin,
+            {
+              upload: (path, content) =>
+                sandbox.writeFiles([{ path, content }]),
+              remove: async (path) => {
+                await sandbox.runCommand({
+                  cmd: "rm",
+                  args: ["-f", "--", path],
+                });
+              },
+            },
+            async (stdinPath) => {
+              const commandToRun = stdinPath
+                ? redirectCommandStdinFromFile(command, stdinPath)
+                : command;
 
-            const commandToRun = stdinPath
-              ? redirectCommandStdinFromFile(command, stdinPath)
-              : command;
+              if (opts?.onLine) {
+                const onLine = opts.onLine;
+                const stdoutTail = new BoundedTail(maxOutputTailChars, "\n");
+                const stderrTail = new BoundedTail(maxOutputTailChars, "");
+                let partial = "";
 
-            if (opts?.onLine) {
-              const onLine = opts.onLine;
-              const stdoutTail = new BoundedTail(maxOutputTailChars, "\n");
-              const stderrTail = new BoundedTail(maxOutputTailChars, "");
-              let partial = "";
+                const stdoutWritable = new Writable({
+                  write(chunk, _encoding, callback) {
+                    const text = partial + chunk.toString();
+                    const lines = text.split("\n");
+                    partial = lines.pop() ?? "";
+                    for (const line of lines) {
+                      stdoutTail.push(line);
+                      onLine(line);
+                    }
+                    callback();
+                  },
+                  final(callback) {
+                    if (partial) {
+                      stdoutTail.push(partial);
+                      onLine(partial);
+                      partial = "";
+                    }
+                    callback();
+                  },
+                });
 
-              const stdoutWritable = new Writable({
-                write(chunk, _encoding, callback) {
-                  const text = partial + chunk.toString();
-                  const lines = text.split("\n");
-                  partial = lines.pop() ?? "";
-                  for (const line of lines) {
-                    stdoutTail.push(line);
-                    onLine(line);
-                  }
-                  callback();
-                },
-                final(callback) {
-                  if (partial) {
-                    stdoutTail.push(partial);
-                    onLine(partial);
-                    partial = "";
-                  }
-                  callback();
-                },
-              });
+                const stderrWritable = new Writable({
+                  write(chunk, _encoding, callback) {
+                    stderrTail.push(chunk.toString());
+                    callback();
+                  },
+                });
 
-              const stderrWritable = new Writable({
-                write(chunk, _encoding, callback) {
-                  stderrTail.push(chunk.toString());
-                  callback();
-                },
-              });
+                const result = await sandbox.runCommand({
+                  cmd: "sh",
+                  args: ["-c", commandToRun],
+                  cwd: opts?.cwd ?? worktreePath,
+                  stdout: stdoutWritable,
+                  stderr: stderrWritable,
+                  ...(opts?.sudo ? { sudo: true } : {}),
+                });
+
+                return {
+                  stdout: stdoutTail.toString(),
+                  stderr: stderrTail.toString(),
+                  exitCode: result.exitCode,
+                };
+              }
 
               const result = await sandbox.runCommand({
                 cmd: "sh",
                 args: ["-c", commandToRun],
                 cwd: opts?.cwd ?? worktreePath,
-                stdout: stdoutWritable,
-                stderr: stderrWritable,
                 ...(opts?.sudo ? { sudo: true } : {}),
               });
 
+              const stdout = await result.stdout();
+              const stderr = await result.stderr();
+
               return {
-                stdout: stdoutTail.toString(),
-                stderr: stderrTail.toString(),
+                stdout,
+                stderr,
                 exitCode: result.exitCode,
               };
-            }
-
-            const result = await sandbox.runCommand({
-              cmd: "sh",
-              args: ["-c", commandToRun],
-              cwd: opts?.cwd ?? worktreePath,
-              ...(opts?.sudo ? { sudo: true } : {}),
-            });
-
-            const stdout = await result.stdout();
-            const stderr = await result.stderr();
-
-            return {
-              stdout,
-              stderr,
-              exitCode: result.exitCode,
-            };
-          } finally {
-            if (stdinPath !== undefined) {
-              await sandbox
-                .runCommand({
-                  cmd: "rm",
-                  args: ["-f", "--", stdinPath],
-                })
-                .catch(() => {});
-            }
-          }
+            },
+          );
         },
 
         copyIn: async (

--- a/src/sandboxes/vercel.ts
+++ b/src/sandboxes/vercel.ts
@@ -9,7 +9,7 @@
 import { execSync } from "node:child_process";
 import { readFile, unlink, writeFile, mkdir, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, posix } from "node:path";
 import { Writable } from "node:stream";
 import {
   createIsolatedSandboxProvider,
@@ -23,8 +23,8 @@ import {
   redirectCommandStdinFromFile,
 } from "./stdin-file.js";
 
-/** Worktree path inside the Vercel sandbox. */
-const VERCEL_REPO_PATH = "/vercel/sandbox/workspace";
+/** Worktree directory inside the Vercel sandbox's default working directory. */
+const VERCEL_WORKTREE_DIR = "workspace";
 
 /**
  * Options for creating a Vercel sandbox provider.
@@ -172,11 +172,36 @@ export const vercel = (options?: VercelOptions): IsolatedSandboxProvider =>
         createParams as Parameters<typeof Sandbox.create>[0],
       );
 
-      // Ensure worktree directory exists
-      await sandbox.mkDir(VERCEL_REPO_PATH);
+      let worktreePath: string;
+      try {
+        // Vercel SDK 2.x starts in /vercel/sandbox, while 3.x starts in
+        // /vercel. Discover the default rather than depending on image layout.
+        const pwdResult = await sandbox.runCommand({ cmd: "pwd" });
+        const defaultCwd = (await pwdResult.stdout()).trim();
+        if (pwdResult.exitCode !== 0 || !posix.isAbsolute(defaultCwd)) {
+          const stderr = await pwdResult.stderr();
+          throw new Error(
+            `Could not determine Vercel sandbox working directory: ${stderr || defaultCwd}`,
+          );
+        }
+
+        worktreePath = posix.join(defaultCwd, VERCEL_WORKTREE_DIR);
+        const mkdirResult = await sandbox.runCommand({
+          cmd: "mkdir",
+          args: ["-p", worktreePath],
+        });
+        if (mkdirResult.exitCode !== 0) {
+          throw new Error(
+            `Could not create Vercel sandbox worktree directory: ${await mkdirResult.stderr()}`,
+          );
+        }
+      } catch (error) {
+        await sandbox.stop().catch(() => {});
+        throw error;
+      }
 
       const handle: IsolatedSandboxHandle = {
-        worktreePath: VERCEL_REPO_PATH,
+        worktreePath,
 
         exec: async (
           command: string,
@@ -239,7 +264,7 @@ export const vercel = (options?: VercelOptions): IsolatedSandboxProvider =>
               const result = await sandbox.runCommand({
                 cmd: "sh",
                 args: ["-c", commandToRun],
-                cwd: opts?.cwd ?? VERCEL_REPO_PATH,
+                cwd: opts?.cwd ?? worktreePath,
                 stdout: stdoutWritable,
                 stderr: stderrWritable,
                 ...(opts?.sudo ? { sudo: true } : {}),
@@ -255,7 +280,7 @@ export const vercel = (options?: VercelOptions): IsolatedSandboxProvider =>
             const result = await sandbox.runCommand({
               cmd: "sh",
               args: ["-c", commandToRun],
-              cwd: opts?.cwd ?? VERCEL_REPO_PATH,
+              cwd: opts?.cwd ?? worktreePath,
               ...(opts?.sudo ? { sudo: true } : {}),
             });
 

--- a/src/test-fixtures/vercel-sandbox.ts
+++ b/src/test-fixtures/vercel-sandbox.ts
@@ -1,0 +1,15 @@
+type SandboxCreate = (options?: Record<string, unknown>) => Promise<unknown>;
+
+let createSandbox: SandboxCreate = async () => {
+  throw new Error("Vercel sandbox test fixture was not configured");
+};
+
+export const setVercelSandboxCreate = (create: SandboxCreate): void => {
+  createSandbox = create;
+};
+
+export class Sandbox {
+  static create(options?: Record<string, unknown>): Promise<unknown> {
+    return createSandbox(options);
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@vercel/sandbox": fileURLToPath(
+        new URL("./src/test-fixtures/vercel-sandbox.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     include: ["src/**/*.test.ts"],
     setupFiles: ["src/testSetup.ts"],


### PR DESCRIPTION
Fixes #936.

## Summary

- forward ExecOptions.stdin in the Vercel and Daytona isolated sandbox providers
- preserve large and empty payloads using sandbox files and shell redirection
- clean up temporary stdin files after success, command failure, or streaming execution
- discover the Vercel sandbox working directory so SDK 2.x and 3.x filesystem layouts both work
- support @vercel/sandbox >=2.0.0 <4 and document the compatibility decision in ADR 0021

## Real-provider verification

The temporary smoke harness passed against:

- @vercel/sandbox 2.0.0
- @vercel/sandbox 2.9.2
- @vercel/sandbox 3.2.1
- @daytona/sdk 0.164.0

Each provider test covered a 200 KB exact stdin payload, streamed output, empty stdin, concurrent executions, non-zero exits, and temporary-file cleanup.

Early Vercel SDK 1.x releases were excluded after 1.0.2 and 1.1.0 lost streamed output. Version 1.10.2 passed, but there is no documented reliable boundary within that major.

## Repository verification

- npm run typecheck
- npm run build
- npm test — 1,453 passed, 2 skipped
